### PR TITLE
add android stream screenshot grpc

### DIFF
--- a/packages/serve-emu/CLAUDE.md
+++ b/packages/serve-emu/CLAUDE.md
@@ -1,4 +1,7 @@
 - Prefer kebab-case for all TS/JS files.
+- Two video/input backends behind one session interface (`src/session.ts`), selected per session with `SERVE_EMU_BACKEND=scrcpy|grpc` (default `scrcpy`) or `AppOptions.backend`:
+  - `scrcpy`: in-guest capture + MediaCodec encode, streamed over adb. Emulators and physical devices.
+  - `grpc`: emulators only — host-side capture via the emulator's built-in gRPC endpoint (`src/emulator-grpc.ts`, discovered through the `pid_<pid>.ini` files Android Studio uses; hand-rolled protobuf over node:http2, no deps) plus host-side ffmpeg H.264 encode (`src/h264-encoder.ts`). Zero guest CPU cost; input injection is ~0.3ms vs ~5ms. Requires `ffmpeg` on PATH (or `SERVE_EMU_FFMPEG`); physical devices and any grpc start failure fall back to scrcpy with a console warning.
 - Streaming runs through the vendored scrcpy server (`vendor/scrcpy-server-v<VERSION>`). The version is pinned in `scripts/fetch-scrcpy.ts`; the wire protocol drifts between scrcpy majors, so bumping the version means re-validating `src/scrcpy.ts` against the new server.
 - Server protocol summary: open two sockets through `adb forward tcp:<port> localabstract:scrcpy_<scid>`; both prefix a 1-byte dummy. Video socket then yields 64-byte device name, 12-byte codec meta (codec_id, width, height BE), then frames of `[8B PTS BE (high bit = config), 4B size BE, N B Annex-B NALUs]`. Control socket consumes binary messages described in `src/input.ts`.
 - Default device target: the only booted device. If multiple, require `-s <serial>`.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -11,13 +11,14 @@ bunx serve-emu
 # → Preview at http://localhost:3300
 ```
 
-`serve-emu` spawns the scrcpy server on the device, opens an adb forward tunnel, pipes H.264 frames over a WebSocket, and decodes them in the browser with WebCodecs. Input events flow back over the same socket to scrcpy's control channel.
+`serve-emu` streams H.264 frames over a WebSocket and decodes them in the browser with WebCodecs. It uses scrcpy by default, or `--stream-mode grpc-screenshot` for host-side Android Emulator screenshot capture and input injection.
 
 ## Status
 
 v1. Working:
 
 - Live H.264 video stream from device → WebCodecs canvas
+- Runtime stream-source switching between scrcpy and gRPC screenshot from the browser UI
 - Taps, swipes, hardware buttons (Back / Home / Recents / Power)
 - Text injection, keyevents
 - Multi-client (multiple browser tabs share one stream)
@@ -40,6 +41,7 @@ Planned:
 - `adb` on PATH (Android platform-tools)
 - A booted device/emulator (`adb devices` shows it), or an AVD name passed with `--avd`
 - Chrome / Edge / Safari 16.4+ (for WebCodecs)
+- `ffmpeg` with the `libx264` encoder on PATH when using `--stream-mode grpc-screenshot`
 
 ## Quick start
 
@@ -55,7 +57,7 @@ The `setup` step is also run lazily on first start, so you can skip it.
 ## CLI
 
 ```
-serve-emu [-p <port>] [-s <serial>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
+serve-emu [-p <port>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
 serve-emu --avd <name> [--restart-avd]
 serve-emu --avd-list
 serve-emu --running-avds
@@ -65,9 +67,10 @@ serve-emu --running-avds
 |---|---|---|
 | `-p, --port` | `3300` | HTTP port for the preview server |
 | `-s, --serial` | auto | adb device serial (only required when multiple devices are attached) |
+| `--stream-mode` | `scrcpy` | screen/input source: `scrcpy` (all devices) or `grpc-screenshot` (Android emulators only; requires `ffmpeg` with `libx264`) |
 | `--max-fps` | `30` | cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
-| `--max-size` | `1024` | downscale longest edge to N pixels; `0` = native (encoders on many emulators reject above ~2560, so the default trims) |
+| `--max-size` | `1280` | downscale longest edge to N pixels; `0` = native (encoders on many emulators reject above ~2560, so the default trims) |
 | `--key-frame-interval` | `1` | ask the encoder for regular keyframes so clients can recover without resetting video capture; `0` disables this codec option |
 | `--avd` | none | launch this Android Virtual Device before streaming |
 | `--restart-avd` | false | stop a running matching AVD before launching it |
@@ -77,6 +80,18 @@ serve-emu --running-avds
 | `--emulator-port` | auto | emulator console port for `--avd`; must be an even port from 5554 through 5682 |
 
 ## HTTP API
+
+Read or change the selected device's stream source without restarting serve-emu:
+
+```sh
+curl 'http://localhost:3300/api/stream-mode?device=emulator-5554'
+
+curl -X PUT 'http://localhost:3300/api/stream-mode?device=emulator-5554' \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot"}'
+```
+
+The supported modes are `scrcpy` and `grpc-screenshot`. gRPC screenshot is emulator-only; if a requested replacement cannot start, serve-emu leaves the current stream running.
 
 Set an Android Emulator GPS fix:
 

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -9,13 +9,14 @@ bunx serve-emu
 # → Preview at http://localhost:3300
 ```
 
-`serve-emu` spawns the scrcpy server on the device, opens an adb forward tunnel, pipes H.264 frames over a WebSocket, and decodes them in the browser with WebCodecs. Input events flow back over the same socket to scrcpy's control channel.
+`serve-emu` streams H.264 frames over a WebSocket and decodes them in the browser with WebCodecs. It uses scrcpy by default, or `--stream-mode grpc-screenshot` for host-side Android Emulator screenshot capture and input injection.
 
 ## Status
 
 v1. Working:
 
 - Live H.264 video stream from device → WebCodecs canvas
+- Runtime stream-source switching between scrcpy and gRPC screenshot from the browser UI
 - Taps, swipes, hardware buttons (Back / Home / Recents / Power)
 - Text injection, keyevents
 - Multi-client (multiple browser tabs share one stream)
@@ -39,6 +40,7 @@ Planned:
 - `adb` on PATH (Android platform-tools)
 - A booted device/emulator (`adb devices` shows it), or an AVD name passed with `--avd`
 - Chrome / Edge / Safari 16.4+ (for WebCodecs)
+- `ffmpeg` with the `libx264` encoder on PATH when using `--stream-mode grpc-screenshot`
 
 ## Quick start
 
@@ -54,7 +56,7 @@ The `setup` step is also run lazily on first start, so you can skip it.
 ## CLI
 
 ```
-serve-emu [-p <port>] [-s <serial>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
+serve-emu [-p <port>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
 serve-emu --avd <name> [--restart-avd]
 serve-emu --avd-list
 serve-emu --running-avds
@@ -64,9 +66,10 @@ serve-emu --running-avds
 |---|---|---|
 | `-p, --port` | `3300` | HTTP port for the preview server |
 | `-s, --serial` | auto | adb device serial (only required when multiple devices are attached) |
+| `--stream-mode` | `scrcpy` | screen/input source: `scrcpy` (all devices) or `grpc-screenshot` (Android emulators only; requires `ffmpeg` with `libx264`) |
 | `--max-fps` | `30` | cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
-| `--max-size` | `1024` | downscale longest edge to N pixels; `0` = native (encoders on many emulators reject above ~2560, so the default trims) |
+| `--max-size` | `1280` | downscale longest edge to N pixels; `0` = native (encoders on many emulators reject above ~2560, so the default trims) |
 | `--key-frame-interval` | `1` | ask the encoder for regular keyframes so clients can recover without resetting video capture; `0` disables this codec option |
 | `--avd` | none | launch this Android Virtual Device before streaming |
 | `--restart-avd` | false | stop a running matching AVD before launching it |
@@ -76,6 +79,18 @@ serve-emu --running-avds
 | `--emulator-port` | auto | emulator console port for `--avd`; must be an even port from 5554 through 5682 |
 
 ## HTTP API
+
+Read or change the selected device's stream source without restarting serve-emu:
+
+```sh
+curl 'http://localhost:3300/api/stream-mode?device=emulator-5554'
+
+curl -X PUT 'http://localhost:3300/api/stream-mode?device=emulator-5554' \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot"}'
+```
+
+The supported modes are `scrcpy` and `grpc-screenshot`. gRPC screenshot is emulator-only; if a requested replacement cannot start, serve-emu leaves the current stream running.
 
 Set an Android Emulator GPS fix:
 

--- a/packages/serve-emu/packages/serve-emu/package.json
+++ b/packages/serve-emu/packages/serve-emu/package.json
@@ -61,6 +61,7 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "typecheck:ui": "tsc -p src/ui --noEmit",
+    "test": "bun test",
     "prepublishOnly": "bun run build"
   },
   "files": [

--- a/packages/serve-emu/packages/serve-emu/src/cli.ts
+++ b/packages/serve-emu/packages/serve-emu/src/cli.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "node:util";
 import { listAvds, listRunningAvds, startEmulator } from "./emulator.ts";
 import { startServer } from "./server.ts";
+import { backendForStreamMode, EMU_STREAM_MODES } from "./session.ts";
 
 const argv = Bun.argv.slice(2);
 const { values } = parseArgs({
@@ -16,6 +17,7 @@ const { values } = parseArgs({
     // bake in black letterbox columns the way 1024 (→460.8, rounded to 464) did.
     "max-size": { type: "string", default: "1280" },
     "key-frame-interval": { type: "string", default: "1" },
+    "stream-mode": { type: "string" },
     avd: { type: "string" },
     "avd-list": { type: "boolean" },
     "running-avds": { type: "boolean" },
@@ -36,10 +38,10 @@ function numberOption(name: string, fallback: number): number {
 }
 
 if (values.help) {
-  console.log(`serve-emu — host an Android device over scrcpy + WebSocket
+  console.log(`serve-emu — host an Android device stream in the browser
 
 Usage:
-  serve-emu [-p <port>] [-s <serial>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
+  serve-emu [-p <port>] [-s <serial>] [--stream-mode <mode>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec]
   serve-emu --avd <name> [--restart-avd]
   serve-emu --avd-list
   serve-emu --running-avds
@@ -55,6 +57,9 @@ Options:
       --key-frame-interval <sec>
                          Ask the encoder for regular keyframes; 0 disables this
                          codec option (default: 1)
+      --stream-mode <mode>
+                         Screen/input source: ${EMU_STREAM_MODES.join(" or ")}
+                         (default: scrcpy)
       --avd <name>       Launch this Android Virtual Device before streaming
       --restart-avd      Stop a running matching AVD before launching it
       --avd-list         Print available Android Virtual Device names
@@ -87,6 +92,17 @@ async function main() {
     throw new Error("Use either --avd to launch an emulator or --serial to attach to an existing device, not both.");
   }
 
+  // Validate the requested source before --restart-avd can mutate emulator
+  // state. With no flag, leave the backend unset so SERVE_EMU_BACKEND remains
+  // a supported programmatic/CLI default.
+  const streamMode = values["stream-mode"];
+  const backend = streamMode === undefined ? undefined : backendForStreamMode(streamMode);
+  if (streamMode !== undefined && !backend) {
+    throw new Error(
+      `--stream-mode must be one of: ${EMU_STREAM_MODES.join(", ")}. Received "${streamMode}".`,
+    );
+  }
+
   let emulatorLaunch: Awaited<ReturnType<typeof startEmulator>> | null = null;
   // Without --avd or -s, leave the serial undefined: the router picks the first
   // available device, so multiple booted devices no longer error.
@@ -103,7 +119,6 @@ async function main() {
   const bitRate = numberOption("bit-rate", 8_000_000);
   const maxSize = numberOption("max-size", 1280);
   const keyFrameInterval = numberOption("key-frame-interval", 1);
-
   const started = await startServer({
     serial,
     port,
@@ -111,6 +126,8 @@ async function main() {
     bitRate,
     maxSize,
     keyFrameInterval,
+    backend,
+    strictBackend: streamMode !== undefined,
   }).catch((err) => {
     emulatorLaunch?.stop();
     throw err;

--- a/packages/serve-emu/packages/serve-emu/src/emulator-grpc.test.ts
+++ b/packages/serve-emu/packages/serve-emu/src/emulator-grpc.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { parseEmulatorGrpcPort } from "./emulator-grpc.ts";
+
+describe("emulator gRPC console output", () => {
+  test("parses an already-active endpoint response", () => {
+    expect(parseEmulatorGrpcPort('OK: { "port": "8554" }')).toBe(8554);
+  });
+
+  test("parses the endpoint-started response", () => {
+    expect(parseEmulatorGrpcPort("OK: gRPC endpoint available at port 43127")).toBe(43127);
+  });
+
+  test("rejects missing or invalid ports", () => {
+    expect(parseEmulatorGrpcPort("OK")).toBeNull();
+    expect(parseEmulatorGrpcPort("port 70000")).toBeNull();
+  });
+});

--- a/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
+++ b/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
@@ -1,0 +1,446 @@
+import http2 from "node:http2";
+import { readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Minimal client for the Android Emulator's built-in gRPC control endpoint
+ * (android.emulation.control.EmulatorController). The emulator process serves
+ * the guest framebuffer and injects input host-side, so unlike scrcpy none of
+ * it costs the guest any CPU.
+ *
+ * gRPC is protobuf messages over HTTP/2 with a 5-byte length prefix, and we
+ * only need four RPCs with a handful of scalar fields, so the wire format is
+ * hand-rolled on top of node:http2 to keep the package dependency-free. The
+ * schema ships with the SDK: $ANDROID_HOME/emulator/lib/emulator_controller.proto.
+ */
+
+export type GrpcEndpoint = {
+  port: number;
+  token: string | null;
+  avdName: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Endpoint discovery
+// ---------------------------------------------------------------------------
+
+function discoveryDirs(): string[] {
+  const home = homedir();
+  const dirs = [join(home, "Library", "Caches", "TemporaryItems", "avd", "running")];
+  if (process.env.XDG_RUNTIME_DIR) dirs.push(join(process.env.XDG_RUNTIME_DIR, "avd", "running"));
+  if (process.env.LOCALAPPDATA) dirs.push(join(process.env.LOCALAPPDATA, "Temp", "avd", "running"));
+  dirs.push(join(home, ".android", "avd", "running"));
+  return dirs;
+}
+
+/**
+ * Find the gRPC control endpoint of a running emulator by its adb serial.
+ * Every modern emulator writes a discovery file (`pid_<pid>.ini`, same files
+ * Android Studio uses) containing its gRPC port and, when auth is on (the
+ * default), a bearer token. Returns null when no discovery file matches —
+ * e.g. a physical device, or an emulator running with gRPC disabled.
+ */
+export function findEmulatorGrpcEndpoint(serial: string): GrpcEndpoint | null {
+  const match = serial.match(/^emulator-(\d+)$/);
+  if (!match) return null;
+  for (const dir of discoveryDirs()) {
+    let files: string[];
+    try {
+      files = readdirSync(dir).filter((f) => /^pid_\d+\.ini$/.test(f));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      let text: string;
+      try {
+        text = readFileSync(join(dir, file), "utf8");
+      } catch {
+        continue;
+      }
+      const kv = new Map<string, string>();
+      for (const line of text.split("\n")) {
+        const eq = line.indexOf("=");
+        if (eq > 0) kv.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+      }
+      if (kv.get("port.serial") !== match[1]) continue;
+      const port = Number(kv.get("grpc.port"));
+      if (!Number.isInteger(port) || port <= 0) continue;
+      return { port, token: kv.get("grpc.token") || null, avdName: kv.get("avd.name") || null };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf wire format (only what the four RPCs need)
+// ---------------------------------------------------------------------------
+
+function writeVarint(out: number[], value: number | bigint): void {
+  let v = BigInt(value);
+  while (v > 0x7fn) {
+    out.push(Number(v & 0x7fn) | 0x80);
+    v >>= 7n;
+  }
+  out.push(Number(v));
+}
+
+// proto3 scalar defaults are omitted on the wire.
+function varintField(out: number[], fieldNo: number, value: number): void {
+  if (!value) return;
+  writeVarint(out, (fieldNo << 3) | 0);
+  writeVarint(out, value);
+}
+
+function lenField(out: number[], fieldNo: number, bytes: number[] | Buffer): void {
+  if (!bytes.length) return;
+  writeVarint(out, (fieldNo << 3) | 2);
+  writeVarint(out, bytes.length);
+  for (const b of bytes) out.push(b);
+}
+
+function stringField(out: number[], fieldNo: number, value: string): void {
+  if (!value) return;
+  lenField(out, fieldNo, Buffer.from(value, "utf8"));
+}
+
+type ProtoField =
+  | { fieldNo: number; wire: 0; varint: bigint }
+  | { fieldNo: number; wire: 1; fixed64: bigint }
+  | { fieldNo: number; wire: 2; bytes: Buffer }
+  | { fieldNo: number; wire: 5; fixed32: number };
+
+function readVarint(buf: Buffer, offset: number): [bigint, number] {
+  let shift = 0n;
+  let value = 0n;
+  for (;;) {
+    const byte = buf[offset++];
+    if (byte === undefined) throw new Error("truncated varint");
+    value |= BigInt(byte & 0x7f) << shift;
+    if (!(byte & 0x80)) return [value, offset];
+    shift += 7n;
+  }
+}
+
+function* protoFields(buf: Buffer): Generator<ProtoField> {
+  let offset = 0;
+  while (offset < buf.length) {
+    let tag: bigint;
+    [tag, offset] = readVarint(buf, offset);
+    const fieldNo = Number(tag >> 3n);
+    const wire = Number(tag & 7n);
+    if (wire === 0) {
+      let value: bigint;
+      [value, offset] = readVarint(buf, offset);
+      yield { fieldNo, wire, varint: value };
+    } else if (wire === 2) {
+      let len: bigint;
+      [len, offset] = readVarint(buf, offset);
+      const end = offset + Number(len);
+      yield { fieldNo, wire, bytes: buf.subarray(offset, end) };
+      offset = end;
+    } else if (wire === 5) {
+      yield { fieldNo, wire, fixed32: buf.readUInt32LE(offset) };
+      offset += 4;
+    } else if (wire === 1) {
+      yield { fieldNo, wire, fixed64: buf.readBigUInt64LE(offset) };
+      offset += 8;
+    } else {
+      throw new Error(`unsupported protobuf wire type ${wire}`);
+    }
+  }
+}
+
+// ImageFormat.ImgFormat
+export const IMG_FORMAT_PNG = 0;
+export const IMG_FORMAT_RGBA8888 = 1;
+export const IMG_FORMAT_RGB888 = 2;
+
+export type ImageFormatRequest = {
+  format: number;
+  /** Fit box: the emulator scales the frame to fit width×height, preserving aspect. 0 = native. */
+  width?: number;
+  height?: number;
+};
+
+// ImageFormat { ImgFormat format=1; Rotation rotation=2; uint32 width=3; uint32 height=4; uint32 display=5 }
+function encodeImageFormat(req: ImageFormatRequest): Buffer {
+  const out: number[] = [];
+  varintField(out, 1, req.format);
+  varintField(out, 3, req.width ?? 0);
+  varintField(out, 4, req.height ?? 0);
+  return Buffer.from(out);
+}
+
+export type EmuImage = {
+  width: number;
+  height: number;
+  format: number;
+  /** Rotation.SkinRotation: 0 portrait, 1 landscape, 2 reverse portrait, 3 reverse landscape. */
+  rotation: number;
+  /** Raw payload: PNG file or top-down packed pixels, per the requested format. */
+  image: Buffer;
+  seq: number;
+  timestampUs: bigint;
+};
+
+// Image { ImageFormat format=1; bytes image=4; uint32 seq=5; uint64 timestampUs=6 }
+function decodeImage(buf: Buffer): EmuImage {
+  const image: EmuImage = {
+    width: 0,
+    height: 0,
+    format: 0,
+    rotation: 0,
+    image: Buffer.alloc(0),
+    seq: 0,
+    timestampUs: 0n,
+  };
+  for (const field of protoFields(buf)) {
+    if (field.fieldNo === 1 && field.wire === 2) {
+      for (const sub of protoFields(field.bytes)) {
+        if (sub.fieldNo === 1 && sub.wire === 0) image.format = Number(sub.varint);
+        else if (sub.fieldNo === 3 && sub.wire === 0) image.width = Number(sub.varint);
+        else if (sub.fieldNo === 4 && sub.wire === 0) image.height = Number(sub.varint);
+        else if (sub.fieldNo === 2 && sub.wire === 2) {
+          for (const rot of protoFields(sub.bytes)) {
+            if (rot.fieldNo === 1 && rot.wire === 0) image.rotation = Number(rot.varint);
+          }
+        }
+      }
+    } else if (field.fieldNo === 4 && field.wire === 2) image.image = field.bytes;
+    else if (field.fieldNo === 5 && field.wire === 0) image.seq = Number(field.varint);
+    else if (field.fieldNo === 6 && field.wire === 0) image.timestampUs = field.varint;
+  }
+  return image;
+}
+
+export type TouchPoint = {
+  /** Native display pixels (not stream pixels), origin top-left. */
+  x: number;
+  y: number;
+  /** Tracks one finger across down/move/up; reused after release. */
+  identifier: number;
+  /** Nonzero while touching; 0 releases the identifier. */
+  pressure: number;
+};
+
+// TouchEvent { repeated Touch touches=1; int32 display=2 }
+// Touch { int32 x=1; int32 y=2; int32 identifier=3; int32 pressure=4 }
+function encodeTouchEvent(touches: TouchPoint[]): Buffer {
+  const out: number[] = [];
+  for (const t of touches) {
+    const touch: number[] = [];
+    varintField(touch, 1, Math.max(0, Math.round(t.x)));
+    varintField(touch, 2, Math.max(0, Math.round(t.y)));
+    varintField(touch, 3, t.identifier);
+    varintField(touch, 4, t.pressure);
+    lenField(out, 1, touch);
+  }
+  return Buffer.from(out);
+}
+
+export type KeyboardEventRequest = {
+  /**
+   * W3C KeyboardEvent.key value, sent as a keypress (down+up). The emulator
+   * understands the Android-specific values "GoBack", "GoHome", "AppSwitch"
+   * and "Power" in addition to regular keys ("Enter", "a", ...).
+   */
+  key?: string;
+  /** UTF-8 text typed as a sequence of keypresses; overrides `key`. */
+  text?: string;
+};
+
+// KeyboardEvent { KeyCodeType codeType=1; KeyEventType eventType=2; int32 keyCode=3; string key=4; string text=5 }
+const KEY_EVENT_TYPE_KEYPRESS = 2;
+
+function encodeKeyboardEvent(req: KeyboardEventRequest): Buffer {
+  const out: number[] = [];
+  if (!req.text) varintField(out, 2, KEY_EVENT_TYPE_KEYPRESS);
+  stringField(out, 4, req.key ?? "");
+  stringField(out, 5, req.text ?? "");
+  return Buffer.from(out);
+}
+
+// ---------------------------------------------------------------------------
+// gRPC over HTTP/2
+// ---------------------------------------------------------------------------
+
+const CONTROLLER_PREFIX = "/android.emulation.control.EmulatorController/";
+const UNARY_TIMEOUT_MS = 5_000;
+
+function grpcFrame(message: Buffer): Buffer {
+  const out = Buffer.allocUnsafe(5 + message.length);
+  out.writeUInt8(0, 0); // uncompressed
+  out.writeUInt32BE(message.length, 1);
+  message.copy(out, 5);
+  return out;
+}
+
+type RequestOpts = {
+  onMessage?: (message: Buffer) => void;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export class EmulatorGrpcClient {
+  private http2Session: http2.ClientHttp2Session;
+  private closed = false;
+  private sessionErrorCb: ((err: Error) => void) | null = null;
+
+  constructor(private endpoint: GrpcEndpoint) {
+    this.http2Session = http2.connect(`http://127.0.0.1:${endpoint.port}`);
+    this.http2Session.on("error", (err: Error) => {
+      if (!this.closed) this.sessionErrorCb?.(err);
+    });
+  }
+
+  /** Connection-level errors (individual calls also reject on their own). */
+  onSessionError(cb: (err: Error) => void): void {
+    this.sessionErrorCb = cb;
+  }
+
+  private request(method: string, message: Buffer, opts: RequestOpts = {}): Promise<Buffer[]> {
+    return new Promise((resolve, reject) => {
+      if (this.closed) return reject(new Error("emulator grpc client is closed"));
+      const headers: http2.OutgoingHttpHeaders = {
+        ":method": "POST",
+        ":path": CONTROLLER_PREFIX + method,
+        "content-type": "application/grpc",
+        te: "trailers",
+      };
+      if (this.endpoint.token) headers.authorization = `Bearer ${this.endpoint.token}`;
+
+      const stream = this.http2Session.request(headers);
+      const messages: Buffer[] = [];
+      const chunks: Buffer[] = [];
+      let buffered = 0;
+      let frameEnd = -1;
+      let grpcStatus: string | null = null;
+      let grpcMessage = "";
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+        if (err) reject(err);
+        else resolve(messages);
+      };
+      const onAbort = () => {
+        try {
+          stream.close(http2.constants.NGHTTP2_CANCEL);
+        } catch {}
+        settle();
+      };
+
+      const takeStatus = (h: Record<string, unknown>) => {
+        if (h["grpc-status"] === undefined) return;
+        grpcStatus = String(h["grpc-status"]);
+        try {
+          grpcMessage = decodeURIComponent(String(h["grpc-message"] ?? ""));
+        } catch {
+          grpcMessage = String(h["grpc-message"] ?? "");
+        }
+      };
+
+      stream.on("response", (h) => takeStatus(h as Record<string, unknown>));
+      stream.on("trailers", (t) => takeStatus(t as Record<string, unknown>));
+      stream.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        buffered += chunk.length;
+        for (;;) {
+          if (frameEnd < 0) {
+            if (buffered < 5) break;
+            const head = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+            chunks.length = 0;
+            chunks.push(head);
+            if (head[0] !== 0) {
+              settle(new Error(`${method}: compressed grpc frames are not supported`));
+              try {
+                stream.close(http2.constants.NGHTTP2_CANCEL);
+              } catch {}
+              return;
+            }
+            frameEnd = 5 + head.readUInt32BE(1);
+          }
+          if (buffered < frameEnd) break;
+          const all = chunks.length === 1 ? chunks[0] : Buffer.concat(chunks);
+          const body = all.subarray(5, frameEnd);
+          const rest = all.subarray(frameEnd);
+          chunks.length = 0;
+          buffered = rest.length;
+          if (rest.length) chunks.push(rest);
+          frameEnd = -1;
+          if (opts.onMessage) opts.onMessage(body);
+          else messages.push(body);
+        }
+      });
+      stream.on("error", (err: Error) => {
+        if (opts.signal?.aborted) settle();
+        else settle(new Error(`${method}: ${err.message}`));
+      });
+      stream.on("close", () => {
+        if (opts.signal?.aborted || grpcStatus === "0") settle();
+        else if (grpcStatus !== null) settle(new Error(`${method}: grpc-status ${grpcStatus}${grpcMessage ? ` (${grpcMessage})` : ""}`));
+        else settle(new Error(`${method}: stream closed without grpc status`));
+      });
+
+      if (opts.timeoutMs) {
+        timer = setTimeout(() => {
+          settle(new Error(`${method}: timed out after ${opts.timeoutMs}ms`));
+          try {
+            stream.close(http2.constants.NGHTTP2_CANCEL);
+          } catch {}
+        }, opts.timeoutMs);
+      }
+      if (opts.signal) {
+        if (opts.signal.aborted) return onAbort();
+        opts.signal.addEventListener("abort", onAbort);
+      }
+
+      stream.end(grpcFrame(message));
+    });
+  }
+
+  /** One frame of the main display; with width/height 0 the native size is returned. */
+  async getScreenshot(format: ImageFormatRequest): Promise<EmuImage> {
+    const [message] = await this.request("getScreenshot", encodeImageFormat(format), {
+      timeoutMs: UNARY_TIMEOUT_MS,
+    });
+    if (!message) throw new Error("getScreenshot returned no image");
+    return decodeImage(message);
+  }
+
+  /**
+   * Push-stream of frames, delivered only when the display changes (the
+   * current frame is sent immediately on connect). Resolves when aborted.
+   */
+  streamScreenshot(
+    format: ImageFormatRequest,
+    onImage: (image: EmuImage) => void,
+    signal: AbortSignal,
+  ): Promise<void> {
+    return this.request("streamScreenshot", encodeImageFormat(format), {
+      signal,
+      onMessage: (message) => onImage(decodeImage(message)),
+    }).then(() => undefined);
+  }
+
+  async sendTouch(touches: TouchPoint[]): Promise<void> {
+    await this.request("sendTouch", encodeTouchEvent(touches), { timeoutMs: UNARY_TIMEOUT_MS });
+  }
+
+  async sendKey(event: KeyboardEventRequest): Promise<void> {
+    await this.request("sendKey", encodeKeyboardEvent(event), { timeoutMs: UNARY_TIMEOUT_MS });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.http2Session.destroy();
+    } catch {}
+  }
+}

--- a/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
+++ b/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
@@ -1,7 +1,10 @@
 import http2 from "node:http2";
-import { readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { createConnection, createServer } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 
 /**
  * Minimal client for the Android Emulator's built-in gRPC control endpoint
@@ -34,6 +37,18 @@ function discoveryDirs(): string[] {
   return dirs;
 }
 
+function discoveryProcessIsAlive(file: string): boolean {
+  const match = file.match(/^pid_(\d+)(?:_info)?\.ini$/);
+  if (!match) return false;
+  try {
+    process.kill(Number(match[1]), 0);
+    return true;
+  } catch (error) {
+    // EPERM still means that the process exists (relevant on shared hosts).
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
 /**
  * Find the gRPC control endpoint of a running emulator by its adb serial.
  * Every modern emulator writes a discovery file (`pid_<pid>.ini`, same files
@@ -44,14 +59,19 @@ function discoveryDirs(): string[] {
 export function findEmulatorGrpcEndpoint(serial: string): GrpcEndpoint | null {
   const match = serial.match(/^emulator-(\d+)$/);
   if (!match) return null;
+  const candidates: (GrpcEndpoint & { modifiedMs: number })[] = [];
   for (const dir of discoveryDirs()) {
     let files: string[];
     try {
-      files = readdirSync(dir).filter((f) => /^pid_\d+\.ini$/.test(f));
+      files = readdirSync(dir).filter((f) => /^pid_\d+(?:_info)?\.ini$/.test(f));
     } catch {
       continue;
     }
     for (const file of files) {
+      // Discovery files are not always removed after an emulator exits. A
+      // stale file can claim the same console serial as a newer emulator and
+      // otherwise send us to a dead (or unrelated) gRPC port.
+      if (!discoveryProcessIsAlive(file)) continue;
       let text: string;
       try {
         text = readFileSync(join(dir, file), "utf8");
@@ -66,10 +86,123 @@ export function findEmulatorGrpcEndpoint(serial: string): GrpcEndpoint | null {
       if (kv.get("port.serial") !== match[1]) continue;
       const port = Number(kv.get("grpc.port"));
       if (!Number.isInteger(port) || port <= 0) continue;
-      return { port, token: kv.get("grpc.token") || null, avdName: kv.get("avd.name") || null };
+      let modifiedMs = 0;
+      try {
+        modifiedMs = statSync(join(dir, file)).mtimeMs;
+      } catch {}
+      candidates.push({
+        port,
+        token: kv.get("grpc.token") || null,
+        avdName: kv.get("avd.name") || null,
+        modifiedMs,
+      });
     }
   }
-  return null;
+  candidates.sort((a, b) => b.modifiedMs - a.modifiedMs);
+  const endpoint = candidates[0];
+  return endpoint
+    ? { port: endpoint.port, token: endpoint.token, avdName: endpoint.avdName }
+    : null;
+}
+
+function portIsReachable(port: number, timeoutMs = 300): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    let settled = false;
+    const finish = (reachable: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve(reachable);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+function pickAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("could not allocate a local gRPC port"));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+function runningAvdName(serial: string): string | null {
+  const result = spawnSync("adb", ["-s", serial, "emu", "avd", "name"], {
+    encoding: "utf8",
+    timeout: 5_000,
+  });
+  if (result.status !== 0) return null;
+  return (
+    result.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line && line !== "OK" && !line.startsWith("KO:")) ?? null
+  );
+}
+
+export function parseEmulatorGrpcPort(output: string): number | null {
+  const value = Number(
+    output.match(/["']?port["']?\s*:\s*["']?(\d+)/i)?.[1] ??
+      output.match(/\bport\s+(\d+)/i)?.[1],
+  );
+  return Number.isInteger(value) && value > 0 && value <= 65_535 ? value : null;
+}
+
+/**
+ * Return a usable emulator gRPC endpoint. Android Studio launches publish one
+ * in a discovery file. Headless/CLI emulators commonly do not start gRPC at
+ * all, so enable a loopback endpoint through the emulator console and read
+ * its refreshed discovery/auth metadata when no live endpoint exists.
+ */
+export async function ensureEmulatorGrpcEndpoint(serial: string): Promise<GrpcEndpoint> {
+  const discovered = findEmulatorGrpcEndpoint(serial);
+  if (discovered && (await portIsReachable(discovered.port))) return discovered;
+
+  let lastError = discovered
+    ? `discovered gRPC port ${discovered.port} is not reachable`
+    : "no live emulator gRPC discovery file";
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const port = await pickAvailablePort();
+    const result = spawnSync("adb", ["-s", serial, "emu", "grpc", String(port)], {
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+    if (result.status !== 0 || output.includes("KO:")) {
+      lastError = output || result.error?.message || `adb exited with ${result.status}`;
+      continue;
+    }
+
+    const reportedPort = parseEmulatorGrpcPort(output);
+    for (let probe = 0; probe < 40; probe++) {
+      // Starting the endpoint creates/refreshes the authenticated discovery
+      // file. Prefer it so we carry the token, and honor the emulator when it
+      // reports an already-active port instead of the one we requested.
+      const activated = findEmulatorGrpcEndpoint(serial);
+      if (activated && (await portIsReachable(activated.port))) return activated;
+      const activePort = reportedPort ?? port;
+      if (probe === 39 && (await portIsReachable(activePort))) {
+        return { port: activePort, token: null, avdName: runningAvdName(serial) };
+      }
+      await sleep(50);
+    }
+    lastError = `emulator accepted the gRPC command, but no usable endpoint became reachable`;
+  }
+
+  throw new Error(`could not enable the emulator gRPC endpoint for ${serial}: ${lastError}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -178,7 +311,7 @@ export type EmuImage = {
   format: number;
   /** Rotation.SkinRotation: 0 portrait, 1 landscape, 2 reverse portrait, 3 reverse landscape. */
   rotation: number;
-  /** Raw payload: PNG file or top-down packed pixels, per the requested format. */
+  /** Raw payload: PNG file or packed pixels, per the requested format. */
   image: Buffer;
   seq: number;
   timestampUs: bigint;
@@ -248,6 +381,8 @@ export type KeyboardEventRequest = {
   key?: string;
   /** UTF-8 text typed as a sequence of keypresses; overrides `key`. */
   text?: string;
+  /** Linux evdev keycode, sent as a complete keypress. */
+  evdev?: number;
 };
 
 // KeyboardEvent { KeyCodeType codeType=1; KeyEventType eventType=2; int32 keyCode=3; string key=4; string text=5 }
@@ -255,6 +390,14 @@ const KEY_EVENT_TYPE_KEYPRESS = 2;
 
 function encodeKeyboardEvent(req: KeyboardEventRequest): Buffer {
   const out: number[] = [];
+  if (req.evdev !== undefined) {
+    // KeyCodeType.Evdev = 1; KeyEventType.keypress = 2. Let the emulator
+    // produce the correctly encoded down/up pair for this physical key.
+    varintField(out, 1, 1);
+    varintField(out, 2, KEY_EVENT_TYPE_KEYPRESS);
+    varintField(out, 3, req.evdev);
+    return Buffer.from(out);
+  }
   if (!req.text) varintField(out, 2, KEY_EVENT_TYPE_KEYPRESS);
   stringField(out, 4, req.key ?? "");
   stringField(out, 5, req.text ?? "");
@@ -434,6 +577,14 @@ export class EmulatorGrpcClient {
 
   async sendKey(event: KeyboardEventRequest): Promise<void> {
     await this.request("sendKey", encodeKeyboardEvent(event), { timeoutMs: UNARY_TIMEOUT_MS });
+  }
+
+  /** Send one evdev keypress through the emulator control endpoint. */
+  async sendEvdevKeyPress(keyCode: number): Promise<void> {
+    if (!Number.isInteger(keyCode) || keyCode <= 0) {
+      throw new Error(`invalid evdev keycode ${keyCode}`);
+    }
+    await this.sendKey({ evdev: keyCode });
   }
 
   close(): void {

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -1,0 +1,348 @@
+import { spawn } from "node:child_process";
+import {
+  EmulatorGrpcClient,
+  findEmulatorGrpcEndpoint,
+  IMG_FORMAT_PNG,
+  IMG_FORMAT_RGB888,
+  type EmuImage,
+} from "./emulator-grpc.ts";
+import { H264Encoder, assertFfmpegAvailable } from "./h264-encoder.ts";
+import { truncateTextUtf8, type Gesture } from "./input.ts";
+import type { StartOpts, VideoFrame } from "./scrcpy.ts";
+import type { EmuSession } from "./session.ts";
+
+/**
+ * Emulator streaming session over the emulator's built-in gRPC endpoint:
+ * raw frames are pulled host-side (streamScreenshot) and encoded to H.264 by
+ * a host ffmpeg, and input goes through host-side injection (sendTouch ~0.3ms
+ * round-trip vs ~5ms for scrcpy's control socket). The guest runs nothing —
+ * unlike scrcpy there is no in-guest capture or MediaCodec encode competing
+ * with the app under test for emulated CPU.
+ */
+
+// Video pacing. The emulator pushes frames only when the display changes (at
+// up to ~60fps); we coalesce to maxFps for scrcpy parity. Because x264 only
+// surfaces an access unit when the next one starts (see h264-encoder.ts), a
+// fresh frame is chased by one duplicate write after FLUSH_MS to bound
+// latency, and IDLE_REPEAT_MS keeps a trickle of tiny skip-frames flowing on
+// a static screen so the middleware's stall watchdog stays quiet.
+const FLUSH_MS = 40;
+const IDLE_REPEAT_MS = 500;
+const IDLE_TICK_MS = 250;
+const RESTART_MIN_INTERVAL_MS = 1_000;
+const FIRST_FRAME_TIMEOUT_MS = 10_000;
+const MAX_QUEUED_FRAMES = 256;
+const MAX_TEXT_BYTES = 300;
+const TOUCH_PRESSURE = 1;
+
+// Android keycodes (input.ts KEY / client "key" gestures) → W3C KeyboardEvent
+// key values the emulator's keyboard translator understands.
+const ANDROID_KEYCODE_TO_W3C: Record<number, string> = {
+  3: "GoHome",
+  4: "GoBack",
+  19: "ArrowUp",
+  20: "ArrowDown",
+  21: "ArrowLeft",
+  22: "ArrowRight",
+  24: "AudioVolumeUp",
+  25: "AudioVolumeDown",
+  26: "Power",
+  61: "Tab",
+  66: "Enter",
+  67: "Backspace",
+  92: "PageUp",
+  93: "PageDown",
+  111: "Escape",
+  112: "Delete",
+  122: "Home",
+  123: "End",
+  164: "AudioVolumeMute",
+  187: "AppSwitch",
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function adbKeyEvent(serial: string, keycode: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("adb", ["-s", serial, "shell", "input", "keyevent", String(keycode)]);
+    proc.once("error", reject);
+    proc.once("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`adb input keyevent ${keycode} exited with ${code}`)),
+    );
+  });
+}
+
+export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
+  const { serial } = opts;
+  const maxFps = opts.maxFps ?? 30;
+  const bitRate = opts.bitRate ?? 8_000_000;
+  const maxSize = opts.maxSize ?? 1280;
+  const keyFrameInterval = opts.keyFrameInterval ?? 1;
+  const paceMs = Math.max(1, Math.round(1000 / maxFps));
+
+  const endpoint = findEmulatorGrpcEndpoint(serial);
+  if (!endpoint) {
+    throw new Error(
+      `no gRPC endpoint found for ${serial} (no emulator discovery file matches — the emulator may be too old or running with gRPC disabled)`,
+    );
+  }
+  assertFfmpegAvailable();
+
+  const client = new EmulatorGrpcClient(endpoint);
+  let closed = false;
+  let fatalReason: string | null = null;
+  let fatalCb: ((reason: string) => void) | null = null;
+
+  // --- frame plumbing: encoder output → readFrame() consumer -------------
+  const frameQueue: VideoFrame[] = [];
+  const waiters: ((frame: VideoFrame | null) => void)[] = [];
+  const pushFrame = (frame: VideoFrame) => {
+    if (closed || fatalReason) return;
+    const waiter = waiters.shift();
+    if (waiter) return waiter(frame);
+    frameQueue.push(frame);
+    // Emergency valve for a stalled consumer; clients resync on next keyframe.
+    if (frameQueue.length > MAX_QUEUED_FRAMES) frameQueue.splice(0, frameQueue.length - MAX_QUEUED_FRAMES);
+  };
+  const wakeAll = () => {
+    while (waiters.length) waiters.shift()!(null);
+  };
+  const readFrame = (): Promise<VideoFrame | null> => {
+    const frame = frameQueue.shift();
+    if (frame) return Promise.resolve(frame);
+    if (closed || fatalReason) return Promise.resolve(null);
+    return new Promise((resolve) => waiters.push(resolve));
+  };
+
+  const emitFatal = (reason: string) => {
+    if (closed || fatalReason) return;
+    fatalReason = reason;
+    wakeAll();
+    fatalCb?.(reason);
+  };
+  client.onSessionError((err) => emitFatal(`emulator grpc connection error: ${err.message}`));
+
+  // --- video: streamScreenshot → paced ffmpeg writes ----------------------
+  let encoder: H264Encoder | null = null;
+  let latest: EmuImage | null = null;
+  let lastWriteAt = 0;
+  let lastEncoderStartAt = 0;
+  let writeTimer: ReturnType<typeof setTimeout> | null = null;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const nowUs = () => BigInt(Math.round(performance.now() * 1000));
+
+  const writeFrame = (repeat: boolean) => {
+    if (closed || !encoder || !latest) return;
+    encoder.write(latest.image, nowUs());
+    lastWriteAt = Date.now();
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (!repeat) {
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        writeFrame(true);
+      }, FLUSH_MS);
+    }
+  };
+
+  const scheduleWrite = () => {
+    if (writeTimer) return;
+    const wait = lastWriteAt + paceMs - Date.now();
+    if (wait <= 0) return writeFrame(false);
+    writeTimer = setTimeout(() => {
+      writeTimer = null;
+      writeFrame(false);
+    }, wait);
+  };
+
+  const startEncoder = () => {
+    if (closed || !latest) return;
+    encoder?.close();
+    lastEncoderStartAt = Date.now();
+    encoder = new H264Encoder({
+      width: latest.width,
+      height: latest.height,
+      fps: maxFps,
+      bitRate,
+      keyFrameInterval,
+      onFrame: pushFrame,
+      onExit: emitFatal,
+    });
+    writeFrame(false); // seeds SPS/PPS + IDR; the flush chase surfaces it
+  };
+
+  let resolveFirstFrame: ((image: EmuImage) => void) | null = null;
+  const onImage = (image: EmuImage) => {
+    if (closed) return;
+    latest = image;
+    if (resolveFirstFrame) {
+      const resolve = resolveFirstFrame;
+      resolveFirstFrame = null;
+      resolve(image);
+      return;
+    }
+    if (encoder && (image.width !== encoder.width || image.height !== encoder.height)) {
+      startEncoder(); // rotation or display resize: dims changed mid-stream
+      return;
+    }
+    scheduleWrite();
+  };
+
+  const abort = new AbortController();
+  const idleTicker = setInterval(() => {
+    if (closed || !encoder) return;
+    if (Date.now() - lastWriteAt >= IDLE_REPEAT_MS) writeFrame(true);
+  }, IDLE_TICK_MS);
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(idleTicker);
+    if (writeTimer) clearTimeout(writeTimer);
+    if (flushTimer) clearTimeout(flushTimer);
+    abort.abort();
+    encoder?.close();
+    client.close();
+    wakeAll();
+  };
+
+  try {
+    // Touch coordinates are native display pixels while the stream is scaled,
+    // so learn the native size up front (rotation-normalized to portrait).
+    const probe = await client.getScreenshot({ format: IMG_FORMAT_PNG });
+    const probeLandscape = probe.rotation === 1 || probe.rotation === 3;
+    const portraitNative = {
+      width: probeLandscape ? probe.height : probe.width,
+      height: probeLandscape ? probe.width : probe.height,
+    };
+
+    const firstFrame = new Promise<EmuImage>((resolve, reject) => {
+      resolveFirstFrame = resolve;
+      const timer = setTimeout(
+        () => reject(new Error("timed out waiting for the first emulator frame")),
+        FIRST_FRAME_TIMEOUT_MS,
+      );
+      timer.unref?.();
+    });
+    void client
+      .streamScreenshot(
+        { format: IMG_FORMAT_RGB888, width: maxSize, height: maxSize },
+        onImage,
+        abort.signal,
+      )
+      .then(
+        () => emitFatal("emulator screenshot stream ended"),
+        (err) => emitFatal(`emulator screenshot stream failed: ${err instanceof Error ? err.message : err}`),
+      );
+    const first = await firstFrame;
+    startEncoder();
+
+    const currentNative = () => {
+      const rotation = latest?.rotation ?? probe.rotation;
+      return rotation === 1 || rotation === 3
+        ? { width: portraitNative.height, height: portraitNative.width }
+        : portraitNative;
+    };
+    const touch = (unitX: number, unitY: number, pressure: number, identifier = 0) => {
+      const native = currentNative();
+      return client.sendTouch([
+        {
+          x: Math.min(native.width - 1, Math.round(unitX * native.width)),
+          y: Math.min(native.height - 1, Math.round(unitY * native.height)),
+          identifier,
+          pressure,
+        },
+      ]);
+    };
+
+    const sendGesture = async (gesture: Gesture): Promise<void> => {
+      if (closed) throw new Error("session closed");
+      switch (gesture.type) {
+        case "tap":
+          await touch(gesture.x, gesture.y, TOUCH_PRESSURE);
+          await sleep(20);
+          await touch(gesture.x, gesture.y, 0);
+          return;
+        case "swipe": {
+          const dur = Math.max(80, gesture.durationMs ?? 250);
+          const steps = Math.max(8, Math.round(dur / 16));
+          await touch(gesture.x1, gesture.y1, TOUCH_PRESSURE);
+          for (let i = 1; i < steps; i++) {
+            const t = i / steps;
+            await sleep(dur / steps);
+            await touch(
+              gesture.x1 + (gesture.x2 - gesture.x1) * t,
+              gesture.y1 + (gesture.y2 - gesture.y1) * t,
+              TOUCH_PRESSURE,
+            );
+          }
+          await sleep(dur / steps);
+          await touch(gesture.x2, gesture.y2, 0);
+          return;
+        }
+        case "touch":
+          await touch(
+            gesture.x,
+            gesture.y,
+            gesture.action === "up" ? 0 : TOUCH_PRESSURE,
+            gesture.pointerId ?? 0,
+          );
+          return;
+        case "key": {
+          const key = ANDROID_KEYCODE_TO_W3C[gesture.keycode];
+          if (key) return void (await client.sendKey({ key }));
+          // Unmapped Android keycodes take the slow adb path (~200ms); the
+          // common ones all resolve to W3C key values above.
+          await adbKeyEvent(serial, gesture.keycode);
+          return;
+        }
+        case "text":
+          await client.sendKey({ text: truncateTextUtf8(gesture.text, MAX_TEXT_BYTES) });
+          return;
+        case "back":
+          await client.sendKey({ key: "GoBack" });
+          return;
+        case "home":
+          await client.sendKey({ key: "GoHome" });
+          return;
+        case "recents":
+          await client.sendKey({ key: "AppSwitch" });
+          return;
+        case "power":
+          await client.sendKey({ key: "Power" });
+          return;
+      }
+    };
+
+    return {
+      transport: "grpc",
+      serial,
+      meta: {
+        deviceName: endpoint.avdName ?? serial,
+        codecId: "h264",
+        width: first.width,
+        height: first.height,
+      },
+      readFrame,
+      sendGesture,
+      // ffmpeg cannot force an IDR mid-stream over a pipe, so a keyframe
+      // request restarts the encoder — it opens on SPS/PPS + IDR. Rate-limited
+      // on top of the middleware's own reset cooldown.
+      resetVideo: () => {
+        if (closed || Date.now() - lastEncoderStartAt < RESTART_MIN_INTERVAL_MS) return;
+        startEncoder();
+      },
+      onFatal: (cb) => {
+        fatalCb = cb;
+        if (fatalReason) cb(fatalReason);
+      },
+      close,
+    };
+  } catch (err) {
+    close();
+    throw err;
+  }
+}

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import {
   EmulatorGrpcClient,
-  findEmulatorGrpcEndpoint,
+  ensureEmulatorGrpcEndpoint,
   IMG_FORMAT_PNG,
   IMG_FORMAT_RGB888,
   type EmuImage,
@@ -35,41 +35,102 @@ const MAX_QUEUED_FRAMES = 256;
 const MAX_TEXT_BYTES = 300;
 const TOUCH_PRESSURE = 1;
 
-// Android keycodes (input.ts KEY / client "key" gestures) → W3C KeyboardEvent
-// key values the emulator's keyboard translator understands.
-const ANDROID_KEYCODE_TO_W3C: Record<number, string> = {
-  3: "GoHome",
-  4: "GoBack",
-  19: "ArrowUp",
-  20: "ArrowDown",
-  21: "ArrowLeft",
-  22: "ArrowRight",
-  24: "AudioVolumeUp",
-  25: "AudioVolumeDown",
-  26: "Power",
-  61: "Tab",
-  66: "Enter",
-  67: "Backspace",
-  92: "PageUp",
-  93: "PageDown",
-  111: "Escape",
-  112: "Delete",
-  122: "Home",
-  123: "End",
-  164: "AudioVolumeMute",
-  187: "AppSwitch",
+// Android keycodes (input.ts KEY / client "key" gestures) → Linux evdev
+// codes for non-printable physical keys. Printable keys use the emulator's
+// W3C character path below so keyboard layout/modifier handling stays native.
+const ANDROID_KEYCODE_TO_EVDEV: Record<number, number> = {
+  19: 103, // KEY_UP
+  20: 108, // KEY_DOWN
+  21: 105, // KEY_LEFT
+  22: 106, // KEY_RIGHT
+  24: 115, // KEY_VOLUMEUP
+  25: 114, // KEY_VOLUMEDOWN
+  61: 15, // KEY_TAB
+  66: 28, // KEY_ENTER
+  67: 14, // KEY_BACKSPACE
+  92: 104, // KEY_PAGEUP
+  93: 109, // KEY_PAGEDOWN
+  111: 1, // KEY_ESC
+  112: 111, // KEY_DELETE
+  122: 102, // KEY_HOME → Android MOVE_HOME in Generic.kl
+  123: 107, // KEY_END → Android MOVE_END in Generic.kl
+  164: 113, // KEY_MUTE
+};
+
+const ANDROID_PRINTABLE_KEYCODE_TO_W3C: Record<number, string> = {
+  55: ",",
+  56: ".",
+  62: " ",
+  68: "`",
+  69: "-",
+  70: "=",
+  71: "[",
+  72: "]",
+  73: "\\",
+  74: ";",
+  75: "'",
+  76: "/",
+  77: "@",
+  81: "+",
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function adbKeyEvent(serial: string, keycode: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn("adb", ["-s", serial, "shell", "input", "keyevent", String(keycode)]);
-    proc.once("error", reject);
-    proc.once("exit", (code) =>
-      code === 0 ? resolve() : reject(new Error(`adb input keyevent ${keycode} exited with ${code}`)),
-    );
+function readNavigationMode(serial: string): 0 | 1 | 2 | null {
+  const result = spawnSync(
+    "adb",
+    ["-s", serial, "shell", "settings", "get", "secure", "navigation_mode"],
+    { encoding: "utf8", timeout: 5_000 },
+  );
+  const mode = Number(result.stdout.trim());
+  return result.status === 0 && (mode === 0 || mode === 1 || mode === 2) ? mode : null;
+}
+
+function runPowerCommand(serial: string, action: "sleep" | "wakeup"): void {
+  const result = spawnSync("adb", ["-s", serial, "shell", "cmd", "power", action], {
+    encoding: "utf8",
+    timeout: 5_000,
   });
+  if (result.status !== 0) {
+    throw new Error(
+      `could not ${action} ${serial}: ${result.stderr.trim() || result.stdout.trim() || result.error?.message || `adb exited with ${result.status}`}`,
+    );
+  }
+}
+
+function isDeviceAwake(serial: string): boolean {
+  const result = spawnSync("adb", ["-s", serial, "shell", "dumpsys", "power"], {
+    encoding: "utf8",
+    timeout: 5_000,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `could not read power state for ${serial}: ${result.stderr.trim() || result.error?.message || `adb exited with ${result.status}`}`,
+    );
+  }
+  return /mWakefulness=Awake\b/.test(result.stdout);
+}
+
+function toggleDevicePower(serial: string): void {
+  runPowerCommand(serial, isDeviceAwake(serial) ? "sleep" : "wakeup");
+}
+
+function androidKeycodeToW3c(keycode: number): string | null {
+  const named = ANDROID_PRINTABLE_KEYCODE_TO_W3C[keycode];
+  if (named) return named;
+  // Android KEYCODE_0..9 and KEYCODE_A..Z are contiguous.
+  if (keycode >= 7 && keycode <= 16) return String(keycode - 7);
+  if (keycode >= 29 && keycode <= 54) return String.fromCharCode(97 + keycode - 29);
+  return null;
+}
+
+function isUsableRgbFrame(image: EmuImage): boolean {
+  return (
+    image.format === IMG_FORMAT_RGB888 &&
+    image.width > 0 &&
+    image.height > 0 &&
+    image.image.length === image.width * image.height * 3
+  );
 }
 
 export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
@@ -80,15 +141,11 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
   const keyFrameInterval = opts.keyFrameInterval ?? 1;
   const paceMs = Math.max(1, Math.round(1000 / maxFps));
 
-  const endpoint = findEmulatorGrpcEndpoint(serial);
-  if (!endpoint) {
-    throw new Error(
-      `no gRPC endpoint found for ${serial} (no emulator discovery file matches — the emulator may be too old or running with gRPC disabled)`,
-    );
-  }
   assertFfmpegAvailable();
+  const endpoint = await ensureEmulatorGrpcEndpoint(serial);
 
   const client = new EmulatorGrpcClient(endpoint);
+  const navigationMode = readNavigationMode(serial);
   let closed = false;
   let fatalReason: string | null = null;
   let fatalCb: ((reason: string) => void) | null = null;
@@ -134,13 +191,13 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
 
   const writeFrame = (repeat: boolean) => {
     if (closed || !encoder || !latest) return;
-    encoder.write(latest.image, nowUs());
+    const accepted = encoder.write(latest.image, nowUs());
     lastWriteAt = Date.now();
     if (flushTimer) {
       clearTimeout(flushTimer);
       flushTimer = null;
     }
-    if (!repeat) {
+    if (!repeat && accepted) {
       flushTimer = setTimeout(() => {
         flushTimer = null;
         writeFrame(true);
@@ -176,7 +233,10 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
 
   let resolveFirstFrame: ((image: EmuImage) => void) | null = null;
   const onImage = (image: EmuImage) => {
-    if (closed) return;
+    // The emulator explicitly emits empty frames while a display is inactive.
+    // Feeding one (or a partial raw payload) into ffmpeg would permanently
+    // desynchronize the rawvideo byte stream.
+    if (closed || !isUsableRgbFrame(image)) return;
     latest = image;
     if (resolveFirstFrame) {
       const resolve = resolveFirstFrame;
@@ -212,7 +272,24 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
   try {
     // Touch coordinates are native display pixels while the stream is scaled,
     // so learn the native size up front (rotation-normalized to portrait).
-    const probe = await client.getScreenshot({ format: IMG_FORMAT_PNG });
+    if (!isDeviceAwake(serial)) {
+      runPowerCommand(serial, "wakeup");
+      await sleep(100);
+    }
+    let probe = await client.getScreenshot({ format: IMG_FORMAT_PNG });
+    if (probe.width <= 0 || probe.height <= 0) {
+      // A sleeping display produces explicit 0×0 images. Wake through the
+      // power service (not `adb shell input`) so startup can learn dimensions
+      // and expose a usable stream on keyboard-less AVDs.
+      runPowerCommand(serial, "wakeup");
+      for (let attempt = 0; attempt < 20 && (probe.width <= 0 || probe.height <= 0); attempt++) {
+        await sleep(100);
+        probe = await client.getScreenshot({ format: IMG_FORMAT_PNG });
+      }
+      if (probe.width <= 0 || probe.height <= 0) {
+        throw new Error("emulator display stayed inactive after requesting wakeup");
+      }
+    }
     const probeLandscape = probe.rotation === 1 || probe.rotation === 3;
     const portraitNative = {
       width: probeLandscape ? probe.height : probe.width,
@@ -257,6 +334,51 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
         },
       ]);
     };
+    const swipeTouch = async (
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      durationMs: number,
+      holdMs = 0,
+    ) => {
+      const dur = Math.max(80, durationMs);
+      const steps = Math.max(8, Math.round(dur / 16));
+      await touch(x1, y1, TOUCH_PRESSURE);
+      for (let i = 1; i < steps; i++) {
+        const t = i / steps;
+        await sleep(dur / steps);
+        await touch(x1 + (x2 - x1) * t, y1 + (y2 - y1) * t, TOUCH_PRESSURE);
+      }
+      await sleep(dur / steps + holdMs);
+      await touch(x2, y2, 0);
+    };
+    const tapTouch = async (x: number, y: number) => {
+      await touch(x, y, TOUCH_PRESSURE);
+      await sleep(20);
+      await touch(x, y, 0);
+    };
+
+    // Navigate through the on-screen system UI so controls also work on AVDs
+    // with hw.keyboard=false. Modes: 0 = 3-button, 1 = 2-button, 2 = gestural.
+    const goBack = () =>
+      navigationMode === 2
+        ? swipeTouch(0.002, 0.5, 0.28, 0.5, 180)
+        : navigationMode === 0 || navigationMode === 1
+          ? tapTouch(0.17, 0.985)
+          : client.sendKey({ key: "GoBack" });
+    const goHome = () =>
+      navigationMode === 2
+        ? swipeTouch(0.5, 0.995, 0.5, 0.65, 250)
+        : navigationMode === 0 || navigationMode === 1
+          ? tapTouch(0.5, 0.985)
+          : client.sendKey({ key: "GoHome" });
+    const openRecents = () =>
+      navigationMode === 0
+        ? tapTouch(0.83, 0.985)
+        : navigationMode === 1 || navigationMode === 2
+          ? swipeTouch(0.5, 0.995, 0.5, 0.55, 280, 500)
+          : client.sendKey({ key: "AppSwitch" });
 
     const sendGesture = async (gesture: Gesture): Promise<void> => {
       if (closed) throw new Error("session closed");
@@ -267,20 +389,13 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
           await touch(gesture.x, gesture.y, 0);
           return;
         case "swipe": {
-          const dur = Math.max(80, gesture.durationMs ?? 250);
-          const steps = Math.max(8, Math.round(dur / 16));
-          await touch(gesture.x1, gesture.y1, TOUCH_PRESSURE);
-          for (let i = 1; i < steps; i++) {
-            const t = i / steps;
-            await sleep(dur / steps);
-            await touch(
-              gesture.x1 + (gesture.x2 - gesture.x1) * t,
-              gesture.y1 + (gesture.y2 - gesture.y1) * t,
-              TOUCH_PRESSURE,
-            );
-          }
-          await sleep(dur / steps);
-          await touch(gesture.x2, gesture.y2, 0);
+          await swipeTouch(
+            gesture.x1,
+            gesture.y1,
+            gesture.x2,
+            gesture.y2,
+            gesture.durationMs ?? 250,
+          );
           return;
         }
         case "touch":
@@ -292,27 +407,36 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
           );
           return;
         case "key": {
-          const key = ANDROID_KEYCODE_TO_W3C[gesture.keycode];
-          if (key) return void (await client.sendKey({ key }));
-          // Unmapped Android keycodes take the slow adb path (~200ms); the
-          // common ones all resolve to W3C key values above.
-          await adbKeyEvent(serial, gesture.keycode);
+          if (gesture.keycode === 3) return goHome();
+          if (gesture.keycode === 4) return goBack();
+          if (gesture.keycode === 26) return void toggleDevicePower(serial);
+          if (gesture.keycode === 187) return openRecents();
+          const evdev = ANDROID_KEYCODE_TO_EVDEV[gesture.keycode];
+          if (evdev) {
+            await client.sendEvdevKeyPress(evdev);
+            return;
+          }
+          const key = androidKeycodeToW3c(gesture.keycode);
+          if (!key) {
+            throw new Error(`Android keycode ${gesture.keycode} is unsupported by the gRPC backend`);
+          }
+          await client.sendKey({ key });
           return;
         }
         case "text":
           await client.sendKey({ text: truncateTextUtf8(gesture.text, MAX_TEXT_BYTES) });
           return;
         case "back":
-          await client.sendKey({ key: "GoBack" });
+          await goBack();
           return;
         case "home":
-          await client.sendKey({ key: "GoHome" });
+          await goHome();
           return;
         case "recents":
-          await client.sendKey({ key: "AppSwitch" });
+          await openRecents();
           return;
         case "power":
-          await client.sendKey({ key: "Power" });
+          toggleDevicePower(serial);
           return;
       }
     };
@@ -323,8 +447,8 @@ export async function startGrpcSession(opts: StartOpts): Promise<EmuSession> {
       meta: {
         deviceName: endpoint.avdName ?? serial,
         codecId: "h264",
-        width: first.width,
-        height: first.height,
+        width: first.width - (first.width % 2),
+        height: first.height - (first.height % 2),
       },
       readFrame,
       sendGesture,

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -1,0 +1,225 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import type { VideoFrame } from "./scrcpy.ts";
+
+/**
+ * Host-side H.264 encoder for the grpc backend: raw RGB frames in via stdin,
+ * scrcpy-compatible VideoFrames out (standalone SPS/PPS "config" packets plus
+ * Annex-B access units), so the middleware fan-out and the WebCodecs client
+ * are byte-compatible with the scrcpy path.
+ *
+ * ffmpeg/libx264 runs with zerolatency (no lookahead, no B-frames), which
+ * keeps input frame N ↔ output access unit N strictly 1:1 and in order — that
+ * pairing is what lets us attach PTS values from a simple queue. `aud=1`
+ * inserts Access Unit Delimiter NALs so the byte stream can be split into
+ * access units without parsing slice headers.
+ */
+
+export type H264EncoderOpts = {
+  width: number;
+  height: number;
+  fps: number;
+  bitRate: number;
+  /** Seconds between forced keyframes; 0 leaves it to the encoder (matches scrcpy). */
+  keyFrameInterval: number;
+  onFrame: (frame: VideoFrame) => void;
+  /** Fired only for unexpected exits (not close()). */
+  onExit: (reason: string) => void;
+};
+
+const NAL_IDR = 5;
+const NAL_SPS = 7;
+const NAL_PPS = 8;
+const NAL_AUD = 9;
+const START_CODE = Buffer.from([0, 0, 0, 1]);
+
+type Nal = { pos: number; dataPos: number; type: number };
+
+export function resolveFfmpeg(): string {
+  return process.env.SERVE_EMU_FFMPEG || "ffmpeg";
+}
+
+export function assertFfmpegAvailable(): void {
+  const r = spawnSync(resolveFfmpeg(), ["-version"], { encoding: "utf8" });
+  if (r.error || r.status !== 0) {
+    throw new Error(
+      `ffmpeg not found (tried "${resolveFfmpeg()}"); the grpc backend encodes H.264 on the host — install ffmpeg or point SERVE_EMU_FFMPEG at a binary`,
+    );
+  }
+}
+
+export class H264Encoder {
+  readonly width: number;
+  readonly height: number;
+  private readonly opts: H264EncoderOpts;
+  private proc: ChildProcess;
+  private closed = false;
+  private pending: Buffer = Buffer.alloc(0);
+  private scanFrom = 0;
+  private nals: Nal[] = [];
+  private ptsQueue: bigint[] = [];
+  private lastPts = 0n;
+  private lastConfig: Buffer | null = null;
+
+  constructor(opts: H264EncoderOpts) {
+    this.opts = opts;
+    this.width = opts.width;
+    this.height = opts.height;
+    const keyint =
+      opts.keyFrameInterval > 0 ? Math.max(1, Math.round(opts.fps * opts.keyFrameInterval)) : 250;
+    const x264Params = [
+      `keyint=${keyint}`,
+      `min-keyint=${keyint}`,
+      "scenecut=0",
+      "repeat-headers=1",
+      "aud=1",
+    ].join(":");
+
+    this.proc = spawn(
+      resolveFfmpeg(),
+      [
+        "-hide_banner",
+        "-loglevel", "error",
+        "-f", "rawvideo",
+        "-pix_fmt", "rgb24",
+        "-video_size", `${opts.width}x${opts.height}`,
+        "-framerate", String(opts.fps),
+        "-i", "pipe:0",
+        "-an",
+        // yuv420p needs even dimensions; the crop is a no-op when already even.
+        "-vf", "crop=trunc(iw/2)*2:trunc(ih/2)*2",
+        "-pix_fmt", "yuv420p",
+        "-c:v", "libx264",
+        "-preset", "ultrafast",
+        "-tune", "zerolatency",
+        "-profile:v", "baseline",
+        "-b:v", String(opts.bitRate),
+        "-maxrate", String(opts.bitRate),
+        "-bufsize", String(opts.bitRate),
+        "-x264-params", x264Params,
+        "-f", "h264",
+        "-flush_packets", "1",
+        "pipe:1",
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    this.proc.stdout!.on("data", (chunk: Buffer) => this.append(chunk));
+    this.proc.stderr!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8").trim();
+      if (text) console.warn(`serve-emu ffmpeg: ${text}`);
+    });
+    this.proc.stdin!.on("error", () => {}); // EPIPE during teardown
+    this.proc.once("error", (err) => {
+      if (!this.closed) this.opts.onExit(`ffmpeg failed to start: ${err.message}`);
+    });
+    this.proc.once("exit", (code, signal) => {
+      if (!this.closed) {
+        this.opts.onExit(`ffmpeg exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
+      }
+    });
+  }
+
+  /** Feed one rgb24 frame (must be width×height×3 bytes). */
+  write(rgb: Buffer, ptsUs: bigint): void {
+    if (this.closed || !this.proc.stdin?.writable) return;
+    this.ptsQueue.push(ptsUs);
+    this.proc.stdin.write(rgb);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.proc.stdin?.destroy();
+    } catch {}
+    try {
+      this.proc.kill("SIGKILL");
+    } catch {}
+  }
+
+  private append(chunk: Buffer): void {
+    if (this.closed) return;
+    this.pending = this.pending.length ? Buffer.concat([this.pending, chunk]) : chunk;
+    this.scanNals();
+    this.emitCompleteAccessUnits();
+  }
+
+  // Record the start/type of every NAL unit in `pending`. Resumes a few bytes
+  // before the previous scan end so start codes split across chunks are found.
+  private scanNals(): void {
+    const buf = this.pending;
+    const lastFound = this.nals.length ? this.nals[this.nals.length - 1].pos : -1;
+    let i = Math.max(0, this.scanFrom - 4);
+    while (i + 3 < buf.length) {
+      if (buf[i] !== 0 || buf[i + 1] !== 0) {
+        i++;
+        continue;
+      }
+      let dataPos = -1;
+      if (buf[i + 2] === 1) dataPos = i + 3;
+      else if (buf[i + 2] === 0 && buf[i + 3] === 1) dataPos = i + 4;
+      if (dataPos === -1) {
+        i++;
+        continue;
+      }
+      if (dataPos >= buf.length) break; // NAL type byte not received yet
+      if (i > lastFound) this.nals.push({ pos: i, dataPos, type: buf[dataPos] & 0x1f });
+      i = dataPos + 1;
+    }
+    this.scanFrom = Math.max(0, buf.length - 4);
+  }
+
+  // An access unit spans from one AUD (exclusive) to the next AUD; the final
+  // AU stays pending until the next one begins, so callers chase "real" frames
+  // with a repeat write to flush them (see grpc-session.ts).
+  private emitCompleteAccessUnits(): void {
+    let lastAud = -1;
+    for (let n = 0; n < this.nals.length; n++) {
+      if (this.nals[n].type !== NAL_AUD) continue;
+      if (lastAud >= 0) this.emitAccessUnit(this.nals.slice(lastAud + 1, n), this.nals[n].pos);
+      lastAud = n;
+    }
+    if (lastAud < 0) return;
+    const base = this.nals[lastAud].pos;
+    this.nals = this.nals.slice(lastAud);
+    if (base > 0) {
+      this.pending = this.pending.subarray(base);
+      for (const nal of this.nals) {
+        nal.pos -= base;
+        nal.dataPos -= base;
+      }
+      this.scanFrom = Math.max(0, this.scanFrom - base);
+    }
+  }
+
+  private emitAccessUnit(units: Nal[], endPos: number): void {
+    if (!units.length) return;
+    let isKey = false;
+    const config: Buffer[] = [];
+    const frame: Buffer[] = [];
+    for (let i = 0; i < units.length; i++) {
+      const nal = units[i];
+      const end = i + 1 < units.length ? units[i + 1].pos : endPos;
+      const payload = this.pending.subarray(nal.dataPos, end);
+      if (nal.type === NAL_SPS || nal.type === NAL_PPS) {
+        config.push(START_CODE, payload);
+      } else {
+        if (nal.type === NAL_IDR) isKey = true;
+        frame.push(START_CODE, payload);
+      }
+    }
+    // Standalone SPS/PPS packet, like scrcpy's config packets; repeat-headers=1
+    // re-emits them before every IDR but we forward only actual changes.
+    if (config.length) {
+      const configBuf = Buffer.concat(config);
+      if (!this.lastConfig || !this.lastConfig.equals(configBuf)) {
+        this.lastConfig = configBuf;
+        this.opts.onFrame({ data: configBuf, pts: this.lastPts, isConfig: true, isKey: false });
+      }
+    }
+    if (!frame.length) return;
+    const pts = this.ptsQueue.shift() ?? this.lastPts + 33_333n;
+    this.lastPts = pts;
+    this.opts.onFrame({ data: Buffer.concat(frame), pts, isConfig: false, isKey });
+  }
+}

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -39,10 +39,15 @@ export function resolveFfmpeg(): string {
 }
 
 export function assertFfmpegAvailable(): void {
-  const r = spawnSync(resolveFfmpeg(), ["-version"], { encoding: "utf8" });
+  const r = spawnSync(resolveFfmpeg(), ["-hide_banner", "-encoders"], { encoding: "utf8" });
   if (r.error || r.status !== 0) {
     throw new Error(
       `ffmpeg not found (tried "${resolveFfmpeg()}"); the grpc backend encodes H.264 on the host — install ffmpeg or point SERVE_EMU_FFMPEG at a binary`,
+    );
+  }
+  if (!/\blibx264\b/.test(r.stdout)) {
+    throw new Error(
+      `ffmpeg at "${resolveFfmpeg()}" does not include the libx264 encoder required by the grpc backend`,
     );
   }
 }
@@ -119,11 +124,12 @@ export class H264Encoder {
     });
   }
 
-  /** Feed one rgb24 frame (must be width×height×3 bytes). */
-  write(rgb: Buffer, ptsUs: bigint): void {
-    if (this.closed || !this.proc.stdin?.writable) return;
+  /** Feed one rgb24 frame; false means it was dropped for encoder backpressure. */
+  write(rgb: Buffer, ptsUs: bigint): boolean {
+    if (this.closed || !this.proc.stdin?.writable || this.proc.stdin.writableNeedDrain) return false;
     this.ptsQueue.push(ptsUs);
     this.proc.stdin.write(rgb);
+    return true;
   }
 
   close(): void {

--- a/packages/serve-emu/packages/serve-emu/src/input.ts
+++ b/packages/serve-emu/packages/serve-emu/src/input.ts
@@ -86,16 +86,21 @@ function keycode(value: unknown): number {
   return n;
 }
 
-function textBytes(text: string): Buffer {
+/** Truncate to whole UTF-8 characters within a byte budget. */
+export function truncateTextUtf8(text: string, maxBytes: number): string {
   const out: string[] = [];
   let total = 0;
   for (const char of text) {
     const bytes = Buffer.byteLength(char, "utf8");
-    if (total + bytes > MAX_TEXT_BYTES) break;
+    if (total + bytes > maxBytes) break;
     out.push(char);
     total += bytes;
   }
-  return Buffer.from(out.join(""), "utf8");
+  return out.join("");
+}
+
+function textBytes(text: string): Buffer {
+  return Buffer.from(truncateTextUtf8(text, MAX_TEXT_BYTES), "utf8");
 }
 
 export function parseGesture(value: unknown): Gesture {

--- a/packages/serve-emu/packages/serve-emu/src/middleware.test.ts
+++ b/packages/serve-emu/packages/serve-emu/src/middleware.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test";
+import type { Device } from "./adb.ts";
+import {
+  createRouter,
+  type AppOptions,
+  type EmuApp,
+  type RouterDependencies,
+} from "./middleware.ts";
+import type { EmuBackend, EmuSession } from "./session.ts";
+
+type FakeAppRecord = {
+  app: EmuApp;
+  crash: () => void;
+  stopCount: () => number;
+};
+
+function fakeApp(serial: string, backend: EmuBackend, events: string[]): FakeAppRecord {
+  let streaming = true;
+  let stops = 0;
+  const session: EmuSession = {
+    transport: backend,
+    serial,
+    meta: {
+      deviceName: backend === "grpc" ? "fake-emulator" : "fake-android",
+      codecId: "h264",
+      width: 576,
+      height: 1280,
+    },
+    readFrame: async () => null,
+    sendGesture: async () => {},
+    resetVideo: () => {},
+    onFatal: () => {},
+    close: () => {},
+  };
+  const app = {
+    session,
+    isStreaming: () => streaming,
+    health: () => ({ status: streaming ? "streaming" : "stopped" }),
+    handleRequest: async () => Response.json({ ok: true }),
+    attachWebSocket: () => {},
+    stop: () => {
+      events.push(`stop:${backend}`);
+      stops++;
+      streaming = false;
+    },
+  } as unknown as EmuApp;
+  return {
+    app,
+    crash: () => {
+      streaming = false;
+    },
+    stopCount: () => stops,
+  };
+}
+
+function testRouter(serial = "emulator-5554", defaultBackend: EmuBackend = "grpc") {
+  const devices: Device[] = [{ serial, state: "device" }];
+  const calls: AppOptions[] = [];
+  const created: FakeAppRecord[] = [];
+  const events: string[] = [];
+  let failingBackend: EmuBackend | null = null;
+  let beforeCreate: ((opts: AppOptions) => Promise<void>) | null = null;
+  const dependencies: RouterDependencies = {
+    listAllDevices: () => devices,
+    listDevices: () => devices,
+    createApp: async (opts) => {
+      calls.push({ ...opts });
+      const backend = opts.backend ?? "scrcpy";
+      events.push(`create:${backend}`);
+      if (backend === failingBackend) throw new Error(`${backend} unavailable`);
+      if (beforeCreate) await beforeCreate(opts);
+      const record = fakeApp(opts.serial, backend, events);
+      created.push(record);
+      return record.app;
+    },
+  };
+  return {
+    router: createRouter({ serial, backend: defaultBackend }, dependencies),
+    calls,
+    created,
+    events,
+    failOn: (backend: EmuBackend | null) => {
+      failingBackend = backend;
+    },
+    beforeEachCreate: (hook: ((opts: AppOptions) => Promise<void>) | null) => {
+      beforeCreate = hook;
+    },
+  };
+}
+
+const streamModeRequest = (serial: string, init?: RequestInit) =>
+  new Request(`http://serve-emu.test/api/stream-mode?device=${serial}`, init);
+
+describe("runtime stream mode selection", () => {
+  test("reports the active transport and treats the current mode as a no-op", async () => {
+    const { router, calls, created } = testRouter();
+
+    const initial = await router.handleRequest(streamModeRequest("emulator-5554"));
+    expect(initial.status).toBe(200);
+    expect(await initial.json()).toMatchObject({
+      ok: true,
+      mode: "grpc-screenshot",
+      transport: "grpc",
+      availableModes: ["scrcpy", "grpc-screenshot"],
+    });
+
+    const same = await router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "grpc-screenshot" }),
+      }),
+    );
+    expect(same.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(created[0]?.stopCount()).toBe(0);
+  });
+
+  test("stages the requested backend before stopping and replacing the old app", async () => {
+    const { router, calls, created, events } = testRouter();
+    await router.ensure("emulator-5554");
+
+    const response = await router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "scrcpy" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ mode: "scrcpy", transport: "scrcpy" });
+    expect(events).toEqual(["create:grpc", "create:scrcpy", "stop:grpc"]);
+    expect(calls[1]).toMatchObject({ backend: "scrcpy", strictBackend: true });
+    expect(created[0]?.stopCount()).toBe(1);
+    expect((await router.ensure("emulator-5554")).app).toBe(created[1]?.app);
+  });
+
+  test("keeps the existing stream when a replacement cannot start", async () => {
+    const { router, created, failOn } = testRouter();
+    const original = (await router.ensure("emulator-5554")).app;
+    failOn("scrcpy");
+
+    const response = await router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "scrcpy" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ ok: false, error: "scrcpy unavailable" });
+    expect(created[0]?.stopCount()).toBe(0);
+    expect((await router.ensure("emulator-5554")).app).toBe(original);
+  });
+
+  test("persists a successful selection when a dead app is recreated", async () => {
+    const { router, calls, created } = testRouter();
+    await router.ensure("emulator-5554");
+    await router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "scrcpy" }),
+      }),
+    );
+
+    created[1]?.crash();
+    await router.ensure("emulator-5554");
+    expect(calls[2]).toMatchObject({ backend: "scrcpy", strictBackend: true });
+  });
+
+  test("serializes conflicting requests in arrival order", async () => {
+    const { router, beforeEachCreate } = testRouter("emulator-5554", "scrcpy");
+    await router.ensure("emulator-5554");
+
+    let releaseFirstGrpc!: () => void;
+    let firstGrpcStarted!: () => void;
+    const firstGrpcGate = new Promise<void>((resolve) => {
+      releaseFirstGrpc = resolve;
+    });
+    const sawFirstGrpc = new Promise<void>((resolve) => {
+      firstGrpcStarted = resolve;
+    });
+    let delayGrpc = true;
+    beforeEachCreate(async (opts) => {
+      if (opts.backend !== "grpc" || !delayGrpc) return;
+      delayGrpc = false;
+      firstGrpcStarted();
+      await firstGrpcGate;
+    });
+
+    const first = router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "grpc-screenshot" }),
+      }),
+    );
+    await sawFirstGrpc;
+    const second = router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "scrcpy" }),
+      }),
+    );
+    const third = router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "grpc-screenshot" }),
+      }),
+    );
+    releaseFirstGrpc();
+
+    const responses = await Promise.all([first, second, third]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200, 200]);
+    expect((await router.ensure("emulator-5554")).app.session.transport).toBe("grpc");
+  });
+
+  test("stops a staged replacement that resolves after router shutdown", async () => {
+    const { router, beforeEachCreate, created } = testRouter();
+    await router.ensure("emulator-5554");
+
+    let releaseReplacement!: () => void;
+    let replacementStarted!: () => void;
+    const replacementGate = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
+    });
+    const sawReplacement = new Promise<void>((resolve) => {
+      replacementStarted = resolve;
+    });
+    beforeEachCreate(async (opts) => {
+      if (opts.backend !== "scrcpy") return;
+      replacementStarted();
+      await replacementGate;
+    });
+
+    const switching = router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "scrcpy" }),
+      }),
+    );
+    await sawReplacement;
+    router.stopAll();
+    releaseReplacement();
+
+    expect((await switching).status).toBe(503);
+    expect(created.map((record) => record.stopCount())).toEqual([1, 1]);
+    expect(router.getActiveApp("emulator-5554")).toBeUndefined();
+  });
+
+  test("rejects invalid modes and emulator-only gRPC on physical devices", async () => {
+    const emulator = testRouter();
+    await emulator.router.ensure("emulator-5554");
+    const invalid = await emulator.router.handleRequest(
+      streamModeRequest("emulator-5554", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "grpc" }),
+      }),
+    );
+    expect(invalid.status).toBe(400);
+    expect(emulator.calls).toHaveLength(1);
+
+    const physical = testRouter("physical-device", "scrcpy");
+    const initial = await physical.router.handleRequest(streamModeRequest("physical-device"));
+    expect(await initial.json()).toMatchObject({ availableModes: ["scrcpy"] });
+    const unsupported = await physical.router.handleRequest(
+      streamModeRequest("physical-device", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "grpc-screenshot" }),
+      }),
+    );
+    expect(unsupported.status).toBe(400);
+    expect(physical.calls).toHaveLength(1);
+    expect(physical.created[0]?.stopCount()).toBe(0);
+  });
+});

--- a/packages/serve-emu/packages/serve-emu/src/middleware.ts
+++ b/packages/serve-emu/packages/serve-emu/src/middleware.ts
@@ -14,8 +14,8 @@ import {
 } from "./app-management.ts";
 import { getForegroundApp } from "./app-info.ts";
 import { getNightMode, isNightMode, setNightMode } from "./ui-mode.ts";
-import { startScrcpy, type ScrcpySession } from "./scrcpy.ts";
-import { dispatch, parseGesture, resetVideoPacket, type Gesture, type Screen } from "./input.ts";
+import { startSession, type EmuBackend, type EmuSession } from "./session.ts";
+import { parseGesture, type Gesture } from "./input.ts";
 import { parseGeoFix, setEmulatorLocationAsync, type GeoFix } from "./location.ts";
 import { parseRoutePlaybackRequest, RoutePlayback } from "./route-playback.ts";
 import { SessionRecorder } from "./session-recorder.ts";
@@ -25,6 +25,7 @@ export { fromBunSocket, fromWsSocket } from "./stream-socket.ts";
 export type { StreamSocket, WsWebSocketLike } from "./stream-socket.ts";
 export { pickDevice } from "./adb.ts";
 export type { ScrcpySession } from "./scrcpy.ts";
+export type { EmuBackend, EmuSession } from "./session.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 // `src/middleware.ts` and `dist/middleware.mjs` both resolve to `<pkg>/dist/ui`.
@@ -36,6 +37,12 @@ export type AppOptions = {
   bitRate?: number;
   maxSize?: number;
   keyFrameInterval?: number;
+  /**
+   * Video/input backend: "scrcpy" (default, works everywhere) or "grpc"
+   * (emulator-only host-side capture; falls back to scrcpy when unavailable).
+   * Defaults to the SERVE_EMU_BACKEND environment variable.
+   */
+  backend?: EmuBackend;
 };
 
 type SessionStatus = "streaming" | "stopped" | "error";
@@ -119,16 +126,16 @@ function serveStaticFile(pathname: string): Response | null {
  * Expo DevTools plugin both mount these onto their own transport.
  */
 export async function createApp(opts: AppOptions) {
-  const session: ScrcpySession = await startScrcpy({
+  const session: EmuSession = await startSession({
     serial: opts.serial,
     maxFps: opts.maxFps,
     bitRate: opts.bitRate,
     maxSize: opts.maxSize,
     keyFrameInterval: opts.keyFrameInterval,
+    backend: opts.backend,
   });
 
   const clients = new Set<Client>();
-  const screen: Screen = { width: session.meta.width, height: session.meta.height };
   const startedMs = Date.now();
   const startedAt = new Date(startedMs).toISOString();
   let status: SessionStatus = "streaming";
@@ -162,6 +169,7 @@ export async function createApp(opts: AppOptions) {
     status,
     serial: opts.serial,
     device: session.meta.deviceName,
+    transport: session.transport,
     codec: session.meta.codecId,
     size: { width: session.meta.width, height: session.meta.height },
     clients: clients.size,
@@ -267,7 +275,7 @@ export async function createApp(opts: AppOptions) {
 
   const dispatchGesture = async (gesture: Gesture, source: string, record = true) => {
     if (status !== "streaming") throw new Error(`session is ${status}`);
-    await dispatch(session.controlSocket, gesture, screen);
+    await session.sendGesture(gesture);
     if (record) sessionRecorder.recordGesture(gesture, source);
   };
 
@@ -468,7 +476,7 @@ export async function createApp(opts: AppOptions) {
     lastVideoResetAt = new Date(now).toISOString();
     lastVideoResetReason = reason;
     try {
-      session.controlSocket.write(resetVideoPacket());
+      session.resetVideo();
     } catch {}
   };
 
@@ -522,7 +530,7 @@ export async function createApp(opts: AppOptions) {
       while (!stopRequested) {
         const f = await session.readFrame();
         if (!f) {
-          if (!stopRequested) markTerminal("error", "scrcpy video stream ended");
+          if (!stopRequested) markTerminal("error", "video stream ended");
           break;
         }
         if (f.isConfig) {
@@ -562,14 +570,9 @@ export async function createApp(opts: AppOptions) {
     }
   }, 1000);
 
-  session.proc.once("exit", (code, signal) => {
+  session.onFatal((reason) => {
     if (!stopRequested && status === "streaming") {
-      markTerminal("error", `scrcpy exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
-    }
-  });
-  session.controlSocket.once("error", (err) => {
-    if (!stopRequested && status === "streaming") {
-      markTerminal("error", `scrcpy control socket error: ${err.message}`);
+      markTerminal("error", reason);
     }
   });
 
@@ -580,6 +583,7 @@ export async function createApp(opts: AppOptions) {
       return Response.json({
         serial: opts.serial,
         device: session.meta.deviceName,
+        transport: session.transport,
         codec: session.meta.codecId,
         size: { width: session.meta.width, height: session.meta.height },
         status,

--- a/packages/serve-emu/packages/serve-emu/src/middleware.ts
+++ b/packages/serve-emu/packages/serve-emu/src/middleware.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { listAllDevices, listDevices, screencapPng } from "./adb.ts";
 import { getAccessibilitySnapshot } from "./accessibility.ts";
@@ -14,7 +14,14 @@ import {
 } from "./app-management.ts";
 import { getForegroundApp } from "./app-info.ts";
 import { getNightMode, isNightMode, setNightMode } from "./ui-mode.ts";
-import { startSession, type EmuBackend, type EmuSession } from "./session.ts";
+import {
+  backendForStreamMode,
+  EMU_STREAM_MODES,
+  startSession,
+  streamModeForBackend,
+  type EmuBackend,
+  type EmuSession,
+} from "./session.ts";
 import { parseGesture, type Gesture } from "./input.ts";
 import { parseGeoFix, setEmulatorLocationAsync, type GeoFix } from "./location.ts";
 import { parseRoutePlaybackRequest, RoutePlayback } from "./route-playback.ts";
@@ -43,6 +50,8 @@ export type AppOptions = {
    * Defaults to the SERVE_EMU_BACKEND environment variable.
    */
   backend?: EmuBackend;
+  /** Fail instead of falling back when the requested backend cannot start. */
+  strictBackend?: boolean;
 };
 
 type SessionStatus = "streaming" | "stopped" | "error";
@@ -74,6 +83,12 @@ const MAX_LOGCAT_QUERY_BYTES = 200;
 const SPAWN_RETRY_COOLDOWN_MS = 5_000;
 
 const errMsg = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+const readJsonBody = async (req: Request, maxBytes = MAX_JSON_BODY_BYTES): Promise<unknown> => {
+  const contentLength = Number(req.headers.get("content-length") ?? "0");
+  if (contentLength > maxBytes) throw new Error("request body too large");
+  return req.json();
+};
 
 const STATIC_CONTENT_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -133,9 +148,11 @@ export async function createApp(opts: AppOptions) {
     maxSize: opts.maxSize,
     keyFrameInterval: opts.keyFrameInterval,
     backend: opts.backend,
+    strictBackend: opts.strictBackend,
   });
 
   const clients = new Set<Client>();
+  const logcatProcesses = new Set<ChildProcess>();
   const startedMs = Date.now();
   const startedAt = new Date(startedMs).toISOString();
   let status: SessionStatus = "streaming";
@@ -208,15 +225,26 @@ export async function createApp(opts: AppOptions) {
     clients.clear();
   };
 
+  const closeLogcatStreams = () => {
+    for (const proc of logcatProcesses) {
+      try {
+        proc.kill("SIGTERM");
+      } catch {}
+    }
+    logcatProcesses.clear();
+  };
+
   const markTerminal = (nextStatus: Exclude<SessionStatus, "streaming">, reason: string) => {
     if (status !== "streaming") return;
     status = nextStatus;
     lastError = reason;
     stoppedAt = new Date().toISOString();
     if (watchdog) clearInterval(watchdog);
+    sessionRecorder.stopReplay();
     routePlayback.close();
     session.close();
     closeClients(nextStatus === "error" ? 1011 : 1000, reason);
+    closeLogcatStreams();
   };
 
   const sendJson = (socket: StreamSocket, value: unknown) => {
@@ -261,12 +289,6 @@ export async function createApp(opts: AppOptions) {
     !Array.isArray(value) &&
     (value as Record<string, unknown>).type === "reset-video";
 
-  const readJsonBody = async (req: Request, maxBytes = MAX_JSON_BODY_BYTES): Promise<unknown> => {
-    const contentLength = Number(req.headers.get("content-length") ?? "0");
-    if (contentLength > maxBytes) throw new Error("request body too large");
-    return req.json();
-  };
-
   const shouldRecord = (value: unknown) =>
     typeof value !== "object" ||
     value === null ||
@@ -280,6 +302,7 @@ export async function createApp(opts: AppOptions) {
   };
 
   const applyLocation = async (fix: GeoFix, source: string, record = true) => {
+    if (status !== "streaming") throw new Error(`session is ${status}`);
     routePlayback.stop();
     await setEmulatorLocationAsync(opts.serial, fix);
     lastLocation = { ...fix, appliedAt: new Date().toISOString() };
@@ -301,6 +324,7 @@ export async function createApp(opts: AppOptions) {
     const packageName = (url.searchParams.get("package") ?? "").trim().slice(0, MAX_LOGCAT_QUERY_BYTES);
     const search = (url.searchParams.get("search") ?? "").trim().slice(0, MAX_LOGCAT_QUERY_BYTES).toLowerCase();
     const proc = spawn("adb", ["-s", opts.serial, "logcat", "-v", "threadtime"]);
+    logcatProcesses.add(proc);
     const encoder = new TextEncoder();
     let pidSet = packageName ? resolvePackagePids(packageName) : new Set<string>();
     let pidTimer: ReturnType<typeof setInterval> | null = null;
@@ -348,6 +372,7 @@ export async function createApp(opts: AppOptions) {
           if (text) send("error", { line: text, at: new Date().toISOString() });
         });
         proc.once("exit", (code, signal) => {
+          logcatProcesses.delete(proc);
           send("close", { code, signal });
           try {
             controller.close();
@@ -355,6 +380,7 @@ export async function createApp(opts: AppOptions) {
           if (pidTimer) clearInterval(pidTimer);
         });
         proc.once("error", (err) => {
+          logcatProcesses.delete(proc);
           send("error", { line: err.message, at: new Date().toISOString() });
           try {
             controller.close();
@@ -364,6 +390,7 @@ export async function createApp(opts: AppOptions) {
       },
       cancel() {
         if (pidTimer) clearInterval(pidTimer);
+        logcatProcesses.delete(proc);
         try {
           proc.kill("SIGTERM");
         } catch {}
@@ -931,8 +958,10 @@ export async function createApp(opts: AppOptions) {
     }
     closeClients(1001, "server stopping");
     if (watchdog) clearInterval(watchdog);
+    sessionRecorder.stopReplay();
     routePlayback.close();
     session.close();
+    closeLogcatStreams();
   };
 
   return {
@@ -949,6 +978,19 @@ export type EmuApp = Awaited<ReturnType<typeof createApp>>;
 
 export type RouterDefaults = Partial<AppOptions>;
 
+/** Injectable process/device seams used by focused router lifecycle tests. */
+export type RouterDependencies = {
+  createApp: (opts: AppOptions) => Promise<EmuApp>;
+  listAllDevices: typeof listAllDevices;
+  listDevices: typeof listDevices;
+};
+
+const defaultRouterDependencies: RouterDependencies = {
+  createApp,
+  listAllDevices,
+  listDevices,
+};
+
 /**
  * Multi-device router. Owns a lazily-populated `Map<serial, EmuApp>` and routes
  * each request to the app for its `?device=<serial>` query (falling back to the
@@ -957,17 +999,23 @@ export type RouterDefaults = Partial<AppOptions>;
  * and the Expo DevTools plugin mount this onto their own transport, so the
  * device-routing logic lives here once rather than in each transport.
  */
-export function createRouter(defaults: RouterDefaults = {}) {
+export function createRouter(
+  defaults: RouterDefaults = {},
+  dependencies: RouterDependencies = defaultRouterDependencies,
+) {
   const apps = new Map<string, EmuApp>();
   const pending = new Map<string, Promise<EmuApp>>();
   const failureAt = new Map<string, number>();
+  const backendOverrides = new Map<string, EmuBackend>();
+  const backendQueues = new Map<string, Promise<void>>();
+  let stopped = false;
 
   // Resolve the serial a request targets: an explicit (connected) `?device=`,
   // else the configured default if still attached, else the first online
   // device. Throws only when *no* device is attached — multiple devices is
   // never an error (we just take the first), so the UI always opens cleanly.
   const resolveSerial = (requested?: string | null): string => {
-    const online = listDevices();
+    const online = dependencies.listDevices();
     if (requested) {
       if (!online.some((d) => d.serial === requested)) {
         throw new Error(`device ${requested} is not connected`);
@@ -984,12 +1032,36 @@ export function createRouter(defaults: RouterDefaults = {}) {
     return first.serial;
   };
 
+  const createConfiguredApp = (
+    serial: string,
+    backend = backendOverrides.get(serial),
+  ): Promise<EmuApp> => {
+    const appOptions: AppOptions = { ...defaults, serial };
+    if (backend) {
+      appOptions.backend = backend;
+      // A user-selected mode must stay truthful rather than silently starting
+      // another transport when its requested backend is unavailable.
+      appOptions.strictBackend = true;
+    }
+    return dependencies.createApp(appOptions);
+  };
+
   // Get (or lazily start) the app for a serial. A dead session is torn down so
   // the next call re-initializes; repeated start failures are throttled.
   const getApp = (serial: string): Promise<EmuApp> => {
+    if (stopped) return Promise.reject(new Error("serve-emu router is stopped"));
     const existing = apps.get(serial);
     if (existing) {
       if (existing.isStreaming()) return Promise.resolve(existing);
+    }
+    const backendQueue = backendQueues.get(serial);
+    if (backendQueue) {
+      return backendQueue.then(() => {
+        const active = apps.get(serial);
+        return active?.isStreaming() ? active : getApp(serial);
+      });
+    }
+    if (existing) {
       try {
         existing.stop();
       } catch {}
@@ -1003,7 +1075,13 @@ export function createRouter(defaults: RouterDefaults = {}) {
       );
     }
     const promise = (async () => {
-      const created = await createApp({ ...defaults, serial });
+      const created = await createConfiguredApp(serial);
+      if (stopped) {
+        try {
+          created.stop();
+        } catch {}
+        throw new Error("serve-emu router stopped while the device session was starting");
+      }
       apps.set(serial, created);
       return created;
     })();
@@ -1016,6 +1094,64 @@ export function createRouter(defaults: RouterDefaults = {}) {
       },
     );
     return promise;
+  };
+
+  // Start the replacement before disturbing the live app. Once ready, swap it
+  // into the router atomically and close the previous app; its WebSockets close
+  // and the browser's normal reconnect path attaches to the new backend. A
+  // failed replacement leaves the existing stream untouched.
+  const performBackendSwitch = async (serial: string, backend: EmuBackend): Promise<EmuApp> => {
+    if (stopped) throw new Error("serve-emu router is stopped");
+    const inFlight = pending.get(serial);
+    if (inFlight) {
+      try {
+        await inFlight;
+      } catch {}
+    }
+    if (stopped) throw new Error("serve-emu router is stopped");
+
+    const current = apps.get(serial);
+    if (current?.isStreaming() && current.session.transport === backend) {
+      backendOverrides.set(serial, backend);
+      return current;
+    }
+
+    const replacement = await createConfiguredApp(serial, backend);
+    if (stopped) {
+      try {
+        replacement.stop();
+      } catch {}
+      throw new Error("serve-emu router stopped while the backend was switching");
+    }
+    const previous = apps.get(serial);
+    backendOverrides.set(serial, backend);
+    failureAt.delete(serial);
+    apps.set(serial, replacement);
+    if (previous && previous !== replacement) {
+      try {
+        previous.stop();
+      } catch {}
+    }
+    return replacement;
+  };
+
+  // Every request joins the same per-device FIFO, including repeated targets.
+  // This makes the last completed request the final state instead of letting a
+  // later request coalesce with an older operation across an intervening mode.
+  const switchBackend = (serial: string, backend: EmuBackend): Promise<EmuApp> => {
+    if (stopped) return Promise.reject(new Error("serve-emu router is stopped"));
+    const previous = backendQueues.get(serial) ?? Promise.resolve();
+    const operation = previous.then(() => performBackendSwitch(serial, backend));
+    const tail = operation.then(
+      () => {},
+      () => {},
+    );
+    backendQueues.set(serial, tail);
+    const clearQueue = () => {
+      if (backendQueues.get(serial) === tail) backendQueues.delete(serial);
+    };
+    tail.then(clearQueue);
+    return operation;
   };
 
   // Resolve + start in one step.
@@ -1034,12 +1170,21 @@ export function createRouter(defaults: RouterDefaults = {}) {
     return Response.json({
       ok: true,
       defaultSerial,
-      devices: listAllDevices().map((device) => ({
+      devices: dependencies.listAllDevices().map((device) => ({
         ...device,
         streaming: apps.get(device.serial)?.isStreaming() ?? false,
       })),
     });
   };
+
+  const streamModeResponse = (serial: string, app: EmuApp): Response =>
+    Response.json({
+      ok: true,
+      serial,
+      mode: streamModeForBackend(app.session.transport),
+      transport: app.session.transport,
+      availableModes: /^emulator-\d+$/.test(serial) ? EMU_STREAM_MODES : ["scrcpy"],
+    });
 
   const handleRequest = async (req: Request): Promise<Response> => {
     const url = new URL(req.url);
@@ -1051,6 +1196,57 @@ export function createRouter(defaults: RouterDefaults = {}) {
         return devicesResponse();
       } catch (err) {
         return Response.json({ ok: false, error: errMsg(err) }, { status: 400 });
+      }
+    }
+
+    // Backend selection replaces the device app itself, so this endpoint lives
+    // at the router layer instead of inside the currently-active app.
+    if (url.pathname === "/api/stream-mode") {
+      if (req.method !== "GET" && req.method !== "PUT") {
+        return new Response("method not allowed", {
+          status: 405,
+          headers: { Allow: "GET, PUT" },
+        });
+      }
+
+      let serial: string;
+      try {
+        serial = resolveSerial(url.searchParams.get("device"));
+      } catch (err) {
+        return Response.json({ ok: false, error: errMsg(err) }, { status: 503 });
+      }
+
+      if (req.method === "GET") {
+        try {
+          return streamModeResponse(serial, await getApp(serial));
+        } catch (err) {
+          return Response.json({ ok: false, error: errMsg(err) }, { status: 503 });
+        }
+      }
+
+      let backend: EmuBackend;
+      try {
+        const payload = await readJsonBody(req);
+        const mode =
+          typeof payload === "object" && payload !== null && !Array.isArray(payload)
+            ? (payload as Record<string, unknown>).mode
+            : undefined;
+        const parsed = backendForStreamMode(mode);
+        if (!parsed) {
+          throw new Error(`mode must be one of: ${EMU_STREAM_MODES.join(", ")}`);
+        }
+        if (parsed === "grpc" && !/^emulator-\d+$/.test(serial)) {
+          throw new Error("grpc-screenshot is only available for Android Emulator devices");
+        }
+        backend = parsed;
+      } catch (err) {
+        return Response.json({ ok: false, error: errMsg(err) }, { status: 400 });
+      }
+
+      try {
+        return streamModeResponse(serial, await switchBackend(serial, backend));
+      } catch (err) {
+        return Response.json({ ok: false, error: errMsg(err) }, { status: 503 });
       }
     }
 
@@ -1092,15 +1288,27 @@ export function createRouter(defaults: RouterDefaults = {}) {
   };
 
   const stopAll = () => {
+    stopped = true;
     for (const app of apps.values()) {
       try {
         app.stop();
       } catch {}
     }
     apps.clear();
+    backendOverrides.clear();
   };
 
-  return { resolveSerial, getApp, ensure, handleRequest, attachWebSocket, stopAll };
+  const getActiveApp = (serial: string): EmuApp | undefined => apps.get(serial);
+
+  return {
+    resolveSerial,
+    getApp,
+    getActiveApp,
+    ensure,
+    handleRequest,
+    attachWebSocket,
+    stopAll,
+  };
 }
 
 export type EmuRouter = ReturnType<typeof createRouter>;

--- a/packages/serve-emu/packages/serve-emu/src/server.ts
+++ b/packages/serve-emu/packages/serve-emu/src/server.ts
@@ -24,7 +24,7 @@ export async function startServer(opts: ServerOpts) {
   // log has something to print, and a no-device situation fails fast at boot.
   const { serial, app } = await router.ensure(defaults.serial);
   console.log(
-    `scrcpy ready: ${app.session.meta.deviceName} • ${app.session.meta.codecId} • ${app.session.meta.width}×${app.session.meta.height}`,
+    `${app.session.transport} ready: ${app.session.meta.deviceName} • ${app.session.meta.codecId} • ${app.session.meta.width}×${app.session.meta.height}`,
   );
 
   const server = Bun.serve<WsData>({

--- a/packages/serve-emu/packages/serve-emu/src/server.ts
+++ b/packages/serve-emu/packages/serve-emu/src/server.ts
@@ -77,7 +77,15 @@ export async function startServer(opts: ServerOpts) {
     server.stop(true);
   };
 
-  return { server, router, serial, session: app.session, stop };
+  return {
+    server,
+    router,
+    serial,
+    get session() {
+      return router.getActiveApp(serial)?.session ?? app.session;
+    },
+    stop,
+  };
 }
 
 export type StartedServer = Awaited<ReturnType<typeof startServer>>;

--- a/packages/serve-emu/packages/serve-emu/src/session-recorder.test.ts
+++ b/packages/serve-emu/packages/serve-emu/src/session-recorder.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { SessionRecorder } from "./session-recorder.ts";
+
+describe("session replay cancellation", () => {
+  test("does not dispatch an event after cancellation during its delay", async () => {
+    const recorder = new SessionRecorder();
+    recorder.recordLocation({ latitude: 1, longitude: 1 }, "test");
+    await Bun.sleep(150);
+    recorder.recordLocation({ latitude: 2, longitude: 2 }, "test");
+
+    const applied: number[] = [];
+    let firstApplied!: () => void;
+    const sawFirst = new Promise<void>((resolve) => {
+      firstApplied = resolve;
+    });
+    const replay = recorder.replay({
+      dispatchGesture: async () => {},
+      setLocation: (fix) => {
+        applied.push(fix.latitude);
+        if (applied.length === 1) firstApplied();
+      },
+    });
+
+    await sawFirst;
+    await Bun.sleep(5);
+    const stoppedAt = performance.now();
+    recorder.stopReplay();
+    await replay;
+    expect(applied).toEqual([1]);
+    expect(performance.now() - stoppedAt).toBeLessThan(75);
+  });
+});

--- a/packages/serve-emu/packages/serve-emu/src/session-recorder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/session-recorder.ts
@@ -35,10 +35,6 @@ type ReplayHandlers = {
 
 const MAX_EVENTS = 2_000;
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export class SessionRecorder {
   #events: RecordedEvent[] = [];
   #nextId = 1;
@@ -49,6 +45,7 @@ export class SessionRecorder {
   #replayStartedAt: string | null = null;
   #replayCompletedAt: string | null = null;
   #lastError: string | null = null;
+  #cancelDelay: (() => void) | null = null;
 
   get isReplaying(): boolean {
     return this.#replaying;
@@ -72,6 +69,7 @@ export class SessionRecorder {
 
   stopReplay(): SessionSnapshot {
     this.#stopReplay = true;
+    this.#cancelDelay?.();
     return this.snapshot();
   }
 
@@ -103,7 +101,8 @@ export class SessionRecorder {
     try {
       for (const event of events) {
         if (this.#stopReplay) break;
-        await sleep(Math.max(0, event.delayMs / multiplier));
+        await this.#waitForDelay(Math.max(0, event.delayMs / multiplier));
+        if (this.#stopReplay) break;
         if (event.kind === "gesture") {
           await handlers.dispatchGesture(event.gesture);
         } else {
@@ -115,11 +114,27 @@ export class SessionRecorder {
       this.#lastError = err instanceof Error ? err.message : String(err);
       throw err;
     } finally {
+      this.#cancelDelay = null;
       this.#replaying = false;
       this.#stopReplay = false;
     }
 
     return this.snapshot();
+  }
+
+  #waitForDelay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this.#cancelDelay === finish) this.#cancelDelay = null;
+        resolve();
+      };
+      const timer = setTimeout(finish, ms);
+      this.#cancelDelay = finish;
+    });
   }
 
   #record(

--- a/packages/serve-emu/packages/serve-emu/src/session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/src/session.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  backendForStreamMode,
+  EMU_STREAM_MODES,
+  resolveBackend,
+  startSession,
+  streamModeForBackend,
+} from "./session.ts";
+
+const originalBackend = process.env.SERVE_EMU_BACKEND;
+
+afterEach(() => {
+  if (originalBackend === undefined) delete process.env.SERVE_EMU_BACKEND;
+  else process.env.SERVE_EMU_BACKEND = originalBackend;
+});
+
+describe("stream mode selection", () => {
+  test("publishes the supported CLI values", () => {
+    expect(EMU_STREAM_MODES).toEqual(["scrcpy", "grpc-screenshot"]);
+  });
+
+  test("maps public stream modes to session backends", () => {
+    expect(backendForStreamMode("scrcpy")).toBe("scrcpy");
+    expect(backendForStreamMode("grpc-screenshot")).toBe("grpc");
+    expect(backendForStreamMode("grpc")).toBeUndefined();
+    expect(backendForStreamMode(undefined)).toBeUndefined();
+    expect(streamModeForBackend("scrcpy")).toBe("scrcpy");
+    expect(streamModeForBackend("grpc")).toBe("grpc-screenshot");
+  });
+
+  test("keeps the environment variable compatible with both gRPC spellings", () => {
+    process.env.SERVE_EMU_BACKEND = "grpc";
+    expect(resolveBackend()).toBe("grpc");
+    process.env.SERVE_EMU_BACKEND = "grpc-screenshot";
+    expect(resolveBackend()).toBe("grpc");
+  });
+
+  test("does not silently fall back for a strict gRPC selection", async () => {
+    await expect(
+      startSession({ serial: "physical-device", backend: "grpc", strictBackend: true }),
+    ).rejects.toThrow("grpc-screenshot requires an Android Emulator serial");
+  });
+});

--- a/packages/serve-emu/packages/serve-emu/src/session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/session.ts
@@ -1,0 +1,91 @@
+import { startGrpcSession } from "./grpc-session.ts";
+import { dispatch, resetVideoPacket, type Gesture, type Screen } from "./input.ts";
+import { startScrcpy, type ScrcpyMeta, type StartOpts, type VideoFrame } from "./scrcpy.ts";
+
+/**
+ * Backend selection:
+ * - "scrcpy" (default): in-guest capture + MediaCodec encode, streamed over
+ *   adb. Works for emulators and physical devices.
+ * - "grpc": host-side capture through the emulator's built-in gRPC endpoint
+ *   plus host-side ffmpeg encode — zero guest overhead, so stream fps and
+ *   input latency no longer depend on emulated CPU. Emulators only; physical
+ *   devices always use scrcpy, and a grpc failure falls back to scrcpy.
+ *
+ * Selected per session via AppOptions.backend, defaulting to the
+ * SERVE_EMU_BACKEND environment variable.
+ */
+export type EmuBackend = "scrcpy" | "grpc";
+
+export type SessionOpts = StartOpts & { backend?: string };
+
+/**
+ * Transport-agnostic device streaming session. Both backends produce H.264
+ * Annex-B access units (standalone SPS/PPS packets flagged isConfig) and
+ * consume normalized 0..1 gestures, so the middleware and the browser client
+ * are identical for both.
+ */
+export type EmuSession = {
+  transport: EmuBackend;
+  serial: string;
+  meta: ScrcpyMeta;
+  readFrame: () => Promise<VideoFrame | null>;
+  sendGesture: (gesture: Gesture) => Promise<void>;
+  /** Ask the source for a fresh keyframe (new client joined, backpressure, stall). */
+  resetVideo: () => void;
+  /** Register a callback for unrecoverable session failure. */
+  onFatal: (cb: (reason: string) => void) => void;
+  close: () => void;
+};
+
+export function resolveBackend(explicit?: string): EmuBackend {
+  const value = explicit ?? process.env.SERVE_EMU_BACKEND ?? "scrcpy";
+  if (value === "scrcpy" || value === "grpc") return value;
+  console.warn(`serve-emu: unknown backend "${value}" (expected "scrcpy" or "grpc"); using scrcpy`);
+  return "scrcpy";
+}
+
+export async function startSession(opts: SessionOpts): Promise<EmuSession> {
+  if (resolveBackend(opts.backend) === "grpc") {
+    if (/^emulator-\d+$/.test(opts.serial)) {
+      try {
+        const session = await startGrpcSession(opts);
+        console.log(`serve-emu: ${opts.serial} streaming via grpc backend (host-side capture)`);
+        return session;
+      } catch (err) {
+        console.warn(
+          `serve-emu: grpc backend failed for ${opts.serial} (${err instanceof Error ? err.message : err}); falling back to scrcpy`,
+        );
+      }
+    }
+    // Physical devices have no host-side framebuffer; scrcpy is the only option.
+  }
+  return startScrcpySession(opts);
+}
+
+async function startScrcpySession(opts: StartOpts): Promise<EmuSession> {
+  const session = await startScrcpy(opts);
+  const screen: Screen = { width: session.meta.width, height: session.meta.height };
+  const fatalCbs: ((reason: string) => void)[] = [];
+  session.proc.once("exit", (code, signal) => {
+    for (const cb of fatalCbs) cb(`scrcpy exited with code ${code ?? "null"} signal ${signal ?? "null"}`);
+  });
+  session.controlSocket.once("error", (err) => {
+    for (const cb of fatalCbs) cb(`scrcpy control socket error: ${err.message}`);
+  });
+  return {
+    transport: "scrcpy",
+    serial: opts.serial,
+    meta: session.meta,
+    readFrame: session.readFrame,
+    sendGesture: (gesture) => dispatch(session.controlSocket, gesture, screen),
+    resetVideo: () => {
+      try {
+        session.controlSocket.write(resetVideoPacket());
+      } catch {}
+    },
+    onFatal: (cb) => {
+      fatalCbs.push(cb);
+    },
+    close: session.close,
+  };
+}

--- a/packages/serve-emu/packages/serve-emu/src/session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/session.ts
@@ -15,8 +15,11 @@ import { startScrcpy, type ScrcpyMeta, type StartOpts, type VideoFrame } from ".
  * SERVE_EMU_BACKEND environment variable.
  */
 export type EmuBackend = "scrcpy" | "grpc";
+export type EmuStreamMode = "scrcpy" | "grpc-screenshot";
 
-export type SessionOpts = StartOpts & { backend?: string };
+export const EMU_STREAM_MODES = ["scrcpy", "grpc-screenshot"] as const satisfies readonly EmuStreamMode[];
+
+export type SessionOpts = StartOpts & { backend?: string; strictBackend?: boolean };
 
 /**
  * Transport-agnostic device streaming session. Both backends produce H.264
@@ -40,8 +43,23 @@ export type EmuSession = {
 export function resolveBackend(explicit?: string): EmuBackend {
   const value = explicit ?? process.env.SERVE_EMU_BACKEND ?? "scrcpy";
   if (value === "scrcpy" || value === "grpc") return value;
-  console.warn(`serve-emu: unknown backend "${value}" (expected "scrcpy" or "grpc"); using scrcpy`);
+  if (value === "grpc-screenshot") return "grpc";
+  console.warn(
+    `serve-emu: unknown backend "${value}" (expected "scrcpy" or "grpc-screenshot"); using scrcpy`,
+  );
   return "scrcpy";
+}
+
+/** Parse the public CLI spelling into the internal session adapter name. */
+export function backendForStreamMode(value: unknown): EmuBackend | undefined {
+  if (value === "scrcpy") return "scrcpy";
+  if (value === "grpc-screenshot") return "grpc";
+  return undefined;
+}
+
+/** Convert an active session adapter name back to the public UI/CLI spelling. */
+export function streamModeForBackend(backend: EmuBackend): EmuStreamMode {
+  return backend === "grpc" ? "grpc-screenshot" : "scrcpy";
 }
 
 export async function startSession(opts: SessionOpts): Promise<EmuSession> {
@@ -52,10 +70,14 @@ export async function startSession(opts: SessionOpts): Promise<EmuSession> {
         console.log(`serve-emu: ${opts.serial} streaming via grpc backend (host-side capture)`);
         return session;
       } catch (err) {
+        if (opts.strictBackend) throw err;
         console.warn(
           `serve-emu: grpc backend failed for ${opts.serial} (${err instanceof Error ? err.message : err}); falling back to scrcpy`,
         );
       }
+    }
+    if (opts.strictBackend) {
+      throw new Error(`grpc-screenshot requires an Android Emulator serial; received ${opts.serial}`);
     }
     // Physical devices have no host-side framebuffer; scrcpy is the only option.
   }

--- a/packages/serve-emu/packages/serve-emu/src/ui/app.tsx
+++ b/packages/serve-emu/packages/serve-emu/src/ui/app.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from "./components/status-bar";
 import { AppManagementPanel } from "./components/app-management-panel";
 import { AccessibilityPanel, type AccessibilityNode } from "./components/accessibility-panel";
 import { DevicePanel } from "./components/device-panel";
+import { StreamModePanel } from "./components/stream-mode-panel";
 import { AppearancePanel } from "./components/appearance-panel";
 import { ScreenshotPanel } from "./components/screenshot-panel";
 import { DeviceStream } from "./components/device-stream";
@@ -61,6 +62,7 @@ export function App() {
         </div>
         <aside className="side-panel">
           <DevicePanel />
+          <StreamModePanel />
           <AppearancePanel />
           <ScreenshotPanel />
           <AccessibilityPanel

--- a/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
+++ b/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useApi } from "../lib/device";
+
+type StreamMode = "scrcpy" | "grpc-screenshot";
+
+type StreamModeResponse = {
+  ok?: boolean;
+  mode?: StreamMode;
+  availableModes?: StreamMode[];
+  error?: string;
+};
+
+const OPTIONS: { label: string; description: string; mode: StreamMode }[] = [
+  { label: "Scrcpy", description: "On-device", mode: "scrcpy" },
+  { label: "gRPC screenshot", description: "Host-side", mode: "grpc-screenshot" },
+];
+
+const isStreamMode = (value: unknown): value is StreamMode =>
+  value === "scrcpy" || value === "grpc-screenshot";
+
+export function StreamModePanel() {
+  const api = useApi();
+  const requestId = useRef(0);
+  const [mode, setMode] = useState<StreamMode | null>(null);
+  const [availableModes, setAvailableModes] = useState<StreamMode[]>([]);
+  const [loadedSerial, setLoadedSerial] = useState<string | null>(null);
+  const [status, setStatus] = useState("Loading…");
+  const [busy, setBusy] = useState(false);
+
+  const applyResponse = useCallback((data: StreamModeResponse, serial: string) => {
+    setMode(isStreamMode(data.mode) ? data.mode : null);
+    setAvailableModes(
+      Array.isArray(data.availableModes) ? data.availableModes.filter(isStreamMode) : [],
+    );
+    setLoadedSerial(serial);
+  }, []);
+
+  const load = useCallback(async () => {
+    const id = ++requestId.current;
+    setBusy(false);
+    setMode(null);
+    setAvailableModes([]);
+    setLoadedSerial(null);
+    if (!api.serial) {
+      setStatus("Waiting for device");
+      return;
+    }
+
+    setStatus("Loading…");
+    try {
+      const res = await api.fetch("/api/stream-mode", { cache: "no-store" });
+      const data = (await res.json()) as StreamModeResponse;
+      if (!res.ok || !data.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      if (id !== requestId.current) return;
+      applyResponse(data, api.serial);
+      setStatus("Ready");
+    } catch (err) {
+      if (id !== requestId.current) return;
+      setMode(null);
+      setAvailableModes([]);
+      setLoadedSerial(null);
+      setStatus(err instanceof Error ? err.message : String(err));
+    }
+  }, [api, applyResponse]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      requestId.current++;
+    };
+  }, [load]);
+
+  const apply = useCallback(
+    async (next: StreamMode) => {
+      if (busy || next === mode || !api.serial || loadedSerial !== api.serial) return;
+      const id = ++requestId.current;
+      setBusy(true);
+      setStatus("Switching…");
+      try {
+        const res = await api.fetch("/api/stream-mode", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: next }),
+        });
+        const data = (await res.json()) as StreamModeResponse;
+        if (!res.ok || !data.ok) throw new Error(data.error || `HTTP ${res.status}`);
+        if (id !== requestId.current) return;
+        applyResponse(data, api.serial);
+        setStatus("Ready");
+      } catch (err) {
+        if (id !== requestId.current) return;
+        setStatus(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (id === requestId.current) setBusy(false);
+      }
+    },
+    [api, applyResponse, busy, loadedSerial, mode],
+  );
+
+  const selectionReady = Boolean(api.serial && loadedSerial === api.serial);
+  const grpcAvailable = availableModes.includes("grpc-screenshot");
+  const help = !api.serial
+    ? "Select a device to choose its stream source."
+    : !selectionReady
+      ? status === "Loading…"
+        ? "Checking the available stream sources…"
+        : "Stream source details are unavailable."
+      : !grpcAvailable
+        ? "gRPC screenshot requires an Android Emulator device."
+        : mode === "grpc-screenshot"
+          ? "Frames and input travel through the emulator host gRPC endpoint."
+          : "Frames and input travel through the scrcpy server on the device.";
+
+  return (
+    <section className="tool-panel stream-mode-panel">
+      <div className="panel-heading">
+        <h2>Stream source</h2>
+        <div className="location-status" aria-live="polite">
+          {status}
+        </div>
+      </div>
+      <fieldset className="stream-mode-fieldset" aria-describedby="stream-mode-help">
+        <legend className="visually-hidden">Stream source</legend>
+        <div className="stream-mode-options">
+          {OPTIONS.map((option) => {
+            const disabled =
+              busy ||
+              !api.serial ||
+              !selectionReady ||
+              !availableModes.includes(option.mode);
+            return (
+              <label className="stream-mode-option" key={option.mode}>
+                <input
+                  type="radio"
+                  name="stream-mode"
+                  value={option.mode}
+                  checked={mode === option.mode}
+                  disabled={disabled}
+                  onChange={() => void apply(option.mode)}
+                />
+                <span>
+                  <strong>{option.label}</strong>
+                  <small>{option.description}</small>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+      <p className="stream-mode-help" id="stream-mode-help">
+        {help}
+      </p>
+    </section>
+  );
+}

--- a/packages/serve-emu/packages/serve-emu/src/ui/styles.css
+++ b/packages/serve-emu/packages/serve-emu/src/ui/styles.css
@@ -2,6 +2,17 @@
   color-scheme: dark;
   font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
 }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
 body {
   margin: 0;
   min-height: 100vh;
@@ -539,6 +550,83 @@ input[type="checkbox"] {
 .appearance-option:disabled {
   cursor: default;
   opacity: 0.5;
+}
+.stream-mode-fieldset {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.stream-mode-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.stream-mode-option {
+  position: relative;
+  min-width: 0;
+}
+.stream-mode-option input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+  opacity: 0;
+}
+.stream-mode-option span {
+  box-sizing: border-box;
+  min-height: 48px;
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  padding: 7px 10px;
+  border: 1px solid #2a2a32;
+  border-radius: 8px;
+  background: #1c1c22;
+  color: #e5e5ea;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.stream-mode-option strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.stream-mode-option small {
+  color: #8a8a93;
+  font-size: 10px;
+}
+.stream-mode-option input:checked + span {
+  border-color: #3f7d5c;
+  background: #132219;
+}
+.stream-mode-option input:focus-visible + span {
+  outline: 2px solid #5cc8ff;
+  outline-offset: 2px;
+}
+.stream-mode-option input:disabled + span {
+  cursor: default;
+  opacity: 0.5;
+}
+.stream-mode-help {
+  min-height: 2.7em;
+  margin: 0;
+  color: #8a8a93;
+  font-size: 11px;
+  line-height: 1.35;
+}
+@media (hover: hover) and (pointer: fine) {
+  .stream-mode-option:hover input:not(:disabled):not(:checked) + span {
+    border-color: #3a3a44;
+    background: #25252d;
+  }
 }
 @media (max-width: 920px) {
   body {


### PR DESCRIPTION
- even without hardware acceleration (a.k.a `--gpu host`) reaches ~30fps
- which is much better compared to ~10fps with scrcpy and no acceleration
- this is important for android emulators running in background window, which became unusable when launched with `--gpu auto` (even tho while in foreground they reach ~60fps)

https://claude.ai/code/session_01QmMrNyPxQXwjd7ccniJU4a