### PR TITLE
feat: Add H.264 and WebRTC iOS simulators

### DIFF
--- a/.changeset/simulator-stream-modes.md
+++ b/.changeset/simulator-stream-modes.md
@@ -1,0 +1,6 @@
+---
+"@expo/hub-client": minor
+"expo-device-hub": minor
+---
+
+Add selectable MJPEG, H.264, and WebRTC simulator streaming with secure-context fallbacks.

--- a/.changeset/simulator-stream-modes.md
+++ b/.changeset/simulator-stream-modes.md
@@ -1,6 +1,5 @@
 ---
-"@expo/hub-client": minor
 "expo-device-hub": minor
 ---
 
-Add selectable MJPEG, H.264, and WebRTC simulator streaming with secure-context fallbacks.
+Add H.264, and WebRTC iOS simulator streaming.

--- a/packages/@expo/hub-client/src/DeviceScreen.tsx
+++ b/packages/@expo/hub-client/src/DeviceScreen.tsx
@@ -22,8 +22,8 @@ const FINGER_CURSOR =
 /**
  * Shared renderer for a live {@link DeviceClient}, used in place of the static
  * `<img>` inside {@link PhoneFrame}. It paints whatever element the active
- * implementation asks for (`<canvas>` for serve-emu H.264, `<img>` for serve-sim
- * MJPEG) and forwards normalized pointer input.
+ * implementation asks for (`<canvas>` for H.264, `<img>` for MJPEG, or
+ * `<video>` for WebRTC) and forwards normalized pointer input.
  *
  * Input is measured in *display* space (the hook remaps to the device's raw
  * frame for the current orientation). Single-finger drags go through
@@ -302,6 +302,8 @@ export function DeviceScreen({ client, borderRadius, squircle }: DeviceScreenPro
     <div style={surfaceStyle}>
       {videoKind === 'canvas' ? (
         <canvas ref={attachVideo} style={mediaStyle} />
+      ) : videoKind === 'video' ? (
+        <video ref={attachVideo} autoPlay muted playsInline style={mediaStyle} />
       ) : (
         <img ref={attachVideo} alt="Device screen" draggable={false} style={mediaStyle} />
       )}

--- a/packages/@expo/hub-client/src/__tests__/avcc-fallback.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/avcc-fallback.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { avccFallbackReducer, initialAvccFallback } from '../avcc-fallback';
+
+describe('AVCC fallback', () => {
+  test('falls back when no decoded frame arrives', () => {
+    expect(avccFallbackReducer(initialAvccFallback, 'timeout').fellBack).toBe(true);
+  });
+
+  test('keeps a stream that decoded before the timeout', () => {
+    const streamed = avccFallbackReducer(initialAvccFallback, 'decoded-frame');
+    expect(avccFallbackReducer(streamed, 'timeout').fellBack).toBe(false);
+  });
+
+  test('a fatal decoder error falls back even after streaming', () => {
+    const streamed = avccFallbackReducer(initialAvccFallback, 'decoded-frame');
+    expect(avccFallbackReducer(streamed, 'error').fellBack).toBe(true);
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/avcc.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/avcc.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  AVCC_TAG_DELTA,
+  AVCC_TAG_DESCRIPTION,
+  AVCC_TAG_KEYFRAME,
+  AVCC_TAG_SEED,
+  AvccDemuxer,
+  avcCodecString,
+} from '../avcc';
+
+function envelope(tag: number, payload: number[]): Uint8Array {
+  const length = payload.length + 1;
+  const result = new Uint8Array(4 + length);
+  new DataView(result.buffer).setUint32(0, length, false);
+  result[4] = tag;
+  result.set(payload, 5);
+  return result;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((length, part) => length + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+describe('AvccDemuxer', () => {
+  test('parses complete envelopes in order', () => {
+    const chunks = new AvccDemuxer().push(
+      concat(
+        envelope(AVCC_TAG_DESCRIPTION, [1, 100, 0, 40]),
+        envelope(AVCC_TAG_KEYFRAME, [9]),
+        envelope(AVCC_TAG_DELTA, [8, 7]),
+        envelope(AVCC_TAG_SEED, [0xff, 0xd8, 0xff, 0xd9]),
+      ),
+    );
+    expect(chunks.map((chunk) => chunk.type)).toEqual(['description', 'keyframe', 'delta', 'seed']);
+  });
+
+  test('buffers envelopes split across reads', () => {
+    const demuxer = new AvccDemuxer();
+    const frame = envelope(AVCC_TAG_KEYFRAME, [1, 2, 3, 4]);
+    expect(demuxer.push(frame.slice(0, 6))).toHaveLength(0);
+    expect(Array.from(demuxer.push(frame.slice(6))[0]!.payload)).toEqual([1, 2, 3, 4]);
+  });
+
+  test('reset drops a partial envelope', () => {
+    const demuxer = new AvccDemuxer();
+    demuxer.push(envelope(AVCC_TAG_DELTA, [1, 2]).slice(0, 4));
+    demuxer.reset();
+    expect(demuxer.push(envelope(AVCC_TAG_KEYFRAME, [9]))[0]!.type).toBe('keyframe');
+  });
+});
+
+describe('avcCodecString', () => {
+  test('derives profile, constraints, and level from avcC', () => {
+    expect(avcCodecString(new Uint8Array([1, 0x64, 0, 0x28, 0xff]))).toBe('avc1.640028');
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-fallback.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-fallback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  nextWebRtcFallbackCodec,
+  webRtcFailureDisposition,
+  webRtcFallbackDecision,
+} from '../webrtc-fallback';
+
+describe('WebRTC fallback', () => {
+  test('tries VP8 and VP9 after H.264', () => {
+    expect(nextWebRtcFallbackCodec('h264', 'h264')).toBe('vp8');
+    expect(nextWebRtcFallbackCodec('h264', 'vp8')).toBe('vp9');
+    expect(nextWebRtcFallbackCodec('h264', 'vp9')).toBe(null);
+  });
+
+  test('switches to HTTP after codecs are exhausted or signaling is permanent', () => {
+    expect(webRtcFallbackDecision('h264', 'h264', { kind: 'permanent' })).toEqual({
+      type: 'switch-to-http',
+    });
+    expect(webRtcFallbackDecision('h264', 'vp9', { kind: 'codec', codec: 'vp9' })).toEqual({
+      type: 'switch-to-http',
+    });
+  });
+
+  test('only treats a connected first-frame timeout as a codec failure', () => {
+    expect(webRtcFailureDisposition('first-frame-timeout', 'connected')).toBe('codec');
+    expect(webRtcFailureDisposition('first-frame-timeout', 'connecting')).toBe('transport');
+    expect(webRtcFailureDisposition('connection-failed', 'failed')).toBe('transport');
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-negotiation.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-negotiation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  closeWebRtcSession,
+  postWebRtcOffer,
+  WebRtcSignalingBusyError,
+  WebRtcSignalingTimeoutError,
+} from '../webrtc-negotiation';
+
+describe('WebRTC offer negotiation', () => {
+  test('uses a fresh deadline after a busy response', async () => {
+    const signals: AbortSignal[] = [];
+    let requests = 0;
+    const response = await postWebRtcOffer({
+      url: 'https://example.test/webrtc/offer',
+      body: '{}',
+      requestTimeoutMs: 100,
+      busyRetryIntervalMs: 0,
+      busyRetryCount: 1,
+      fetchImpl: async (_url, init) => {
+        signals.push(init?.signal as AbortSignal);
+        requests++;
+        return new Response(null, { status: requests === 1 ? 409 : 200 });
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  test('reports exhausted offer contention', async () => {
+    await expect(
+      postWebRtcOffer({
+        url: 'https://example.test/webrtc/offer',
+        body: '{}',
+        requestTimeoutMs: 100,
+        busyRetryIntervalMs: 0,
+        busyRetryCount: 1,
+        fetchImpl: async () => new Response(null, { status: 409 }),
+      }),
+    ).rejects.toBeInstanceOf(WebRtcSignalingBusyError);
+  });
+
+  test('reports an individual signaling timeout', async () => {
+    await expect(
+      postWebRtcOffer({
+        url: 'https://example.test/webrtc/offer',
+        body: '{}',
+        requestTimeoutMs: 5,
+        busyRetryIntervalMs: 0,
+        busyRetryCount: 0,
+        fetchImpl: async (_url, init) => {
+          await new Promise<void>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+              once: true,
+            });
+          });
+          return new Response(null, { status: 200 });
+        },
+      }),
+    ).rejects.toBeInstanceOf(WebRtcSignalingTimeoutError);
+  });
+
+  test('uses a beacon to release a session during pagehide', async () => {
+    let fetched = false;
+    const beaconBodies: Blob[] = [];
+    await closeWebRtcSession({
+      url: 'https://example.test/webrtc/close',
+      sessionId: 'session-1',
+      keepalive: true,
+      sendBeacon: (_url, body) => {
+        beaconBodies.push(body as Blob);
+        return true;
+      },
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response(null, { status: 204 });
+      },
+    });
+    expect(fetched).toBe(false);
+    expect(await beaconBodies[0]!.text()).toBe(JSON.stringify({ sessionId: 'session-1' }));
+  });
+});

--- a/packages/@expo/hub-client/src/avcc-fallback.ts
+++ b/packages/@expo/hub-client/src/avcc-fallback.ts
@@ -1,0 +1,30 @@
+export interface AvccFallbackState {
+  streamed: boolean;
+  fellBack: boolean;
+}
+
+export type AvccFallbackEvent = 'decoded-frame' | 'timeout' | 'error' | 'reset';
+
+export const initialAvccFallback: AvccFallbackState = {
+  streamed: false,
+  fellBack: false,
+};
+
+/** Matches serve-sim's one-way H.264-to-MJPEG recovery policy. */
+export function avccFallbackReducer(
+  state: AvccFallbackState,
+  event: AvccFallbackEvent,
+): AvccFallbackState {
+  switch (event) {
+    case 'decoded-frame':
+      return state.streamed ? state : { ...state, streamed: true };
+    case 'timeout':
+      return state.streamed || state.fellBack ? state : { ...state, fellBack: true };
+    case 'error':
+      return state.fellBack ? state : { ...state, fellBack: true };
+    case 'reset':
+      return initialAvccFallback;
+  }
+}
+
+export const AVCC_FRAME_TIMEOUT_MS = 4_000;

--- a/packages/@expo/hub-client/src/avcc.ts
+++ b/packages/@expo/hub-client/src/avcc.ts
@@ -1,0 +1,102 @@
+/**
+ * Wire parser for serve-sim's `/stream.avcc` H.264 stream.
+ *
+ * Each envelope is a 4-byte big-endian length (covering the tag byte and
+ * payload), followed by the tag and payload. This mirrors serve-sim's browser
+ * client so Hub can consume the same stream without depending on its UI bundle.
+ */
+
+export const AVCC_TAG_DESCRIPTION = 0x01;
+export const AVCC_TAG_KEYFRAME = 0x02;
+export const AVCC_TAG_DELTA = 0x03;
+export const AVCC_TAG_SEED = 0x04;
+
+export type AvccChunkType = 'description' | 'keyframe' | 'delta' | 'seed';
+
+export interface AvccChunk {
+  type: AvccChunkType;
+  payload: Uint8Array;
+}
+
+const TAG_TO_TYPE: Record<number, AvccChunkType | undefined> = {
+  [AVCC_TAG_DESCRIPTION]: 'description',
+  [AVCC_TAG_KEYFRAME]: 'keyframe',
+  [AVCC_TAG_DELTA]: 'delta',
+  [AVCC_TAG_SEED]: 'seed',
+};
+
+/** Incrementally turns a fragmented byte stream into complete AVCC envelopes. */
+export class AvccDemuxer {
+  private buffer = new Uint8Array(64 * 1024);
+  private length = 0;
+  private start = 0;
+
+  private append(bytes: Uint8Array): void {
+    if (this.length + bytes.length > this.buffer.length) {
+      if (this.start > 0) {
+        this.buffer.copyWithin(0, this.start, this.length);
+        this.length -= this.start;
+        this.start = 0;
+      }
+      if (this.length + bytes.length > this.buffer.length) {
+        let capacity = this.buffer.length;
+        while (capacity < this.length + bytes.length) capacity *= 2;
+        const grown = new Uint8Array(capacity);
+        grown.set(this.buffer.subarray(0, this.length));
+        this.buffer = grown;
+      }
+    }
+    this.buffer.set(bytes, this.length);
+    this.length += bytes.length;
+  }
+
+  push(bytes: Uint8Array): AvccChunk[] {
+    if (bytes.length > 0) this.append(bytes);
+
+    const chunks: AvccChunk[] = [];
+    const buffer = this.buffer;
+    while (this.length - this.start >= 4) {
+      const offset = this.start;
+      const length =
+        ((buffer[offset]! << 24) |
+          (buffer[offset + 1]! << 16) |
+          (buffer[offset + 2]! << 8) |
+          buffer[offset + 3]!) >>>
+        0;
+      if (this.length - offset - 4 < length) break;
+      if (length < 1) {
+        this.start += 4;
+        continue;
+      }
+      const type = TAG_TO_TYPE[buffer[offset + 4]!];
+      if (type) {
+        // Copy the payload because the accumulation buffer is reused in place.
+        chunks.push({ type, payload: buffer.slice(offset + 5, offset + 4 + length) });
+      }
+      this.start += 4 + length;
+    }
+
+    if (this.start > 0) {
+      if (this.start < this.length) this.buffer.copyWithin(0, this.start, this.length);
+      this.length -= this.start;
+      this.start = 0;
+    }
+    return chunks;
+  }
+
+  reset(): void {
+    this.length = 0;
+    this.start = 0;
+  }
+}
+
+/** Build an `avc1.PPCCLL` WebCodecs string from an avcC description. */
+export function avcCodecString(description: Uint8Array): string {
+  if (description.length < 4) return 'avc1.42E01E';
+  const hex = (byte: number) => byte.toString(16).padStart(2, '0');
+  return `avc1.${hex(description[1]!)}${hex(description[2]!)}${hex(description[3]!)}`;
+}
+
+export function isAvccSupported(): boolean {
+  return typeof globalThis !== 'undefined' && typeof globalThis.VideoDecoder !== 'undefined';
+}

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -22,7 +22,7 @@ import { type CSSProperties } from 'react';
 export type DevicePlatform = 'ios' | 'android';
 
 /** Viewer-selected transport for serve-sim video. */
-export type DeviceStreamMode = 'mjpeg' | 'h264';
+export type DeviceStreamMode = 'mjpeg' | 'h264' | 'webrtc';
 
 /**
  * Lifecycle of a single connection:
@@ -157,7 +157,7 @@ export interface DeviceConnectionOptions {
 }
 
 /** Which element the implementation paints into. */
-export type VideoSurfaceKind = 'canvas' | 'img';
+export type VideoSurfaceKind = 'canvas' | 'img' | 'video';
 
 /**
  * The live state + controls for one device connection. Returned by the hook and
@@ -199,10 +199,11 @@ export interface DeviceClient {
   /** Element kind {@link DeviceScreen} should render for this client. */
   videoKind: VideoSurfaceKind;
   /**
-   * Ref callback for the paint target. The hook owns the element: for `canvas`
-   * it decodes frames into it; for `img` it points its `src` at the stream.
+   * Ref callback for the paint target. The hook owns the element: `canvas`
+   * receives decoded H.264 frames, `img` points at MJPEG, and `video` receives
+   * a WebRTC MediaStream.
    */
-  attachVideo: (el: HTMLCanvasElement | HTMLImageElement | null) => void;
+  attachVideo: (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => void;
 
   /** Forward a normalized touch/drag to the device. */
   sendTouch: (sample: TouchSample) => void;

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -21,6 +21,9 @@ import { type CSSProperties } from 'react';
 
 export type DevicePlatform = 'ios' | 'android';
 
+/** Viewer-selected transport for serve-sim video. */
+export type DeviceStreamMode = 'mjpeg' | 'h264';
+
 /**
  * Lifecycle of a single connection:
  *   idle       — nothing to connect to (no base URL / disabled)
@@ -145,6 +148,12 @@ export interface DeviceConnectionOptions {
    * helper via `/api?device=<udid>`; when omitted the first available is used.
    */
   device?: string | null;
+  /**
+   * Stream transport selected by the consumer. There is intentionally no
+   * client-level default; products embedding Hub own their default choice.
+   * serve-emu currently ignores this because its wire protocol is always H.264.
+   */
+  streamMode: DeviceStreamMode;
 }
 
 /** Which element the implementation paints into. */

--- a/packages/@expo/hub-client/src/useActiveDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useActiveDeviceClient.ts
@@ -1,5 +1,9 @@
 import { endpointFor } from './connections';
-import { type DeviceClient, type DevicePlatform } from './types';
+import {
+  type DeviceClient,
+  type DeviceConnectionOptions,
+  type DevicePlatform,
+} from './types';
 import { useAndroidDeviceClient } from './useAndroidDevice';
 import { useIosDeviceClient } from './useIosDevice';
 import { NOOP_DEVICE_CLIENT } from './useNoopDeviceClient';
@@ -8,6 +12,8 @@ export interface ActiveDeviceTarget {
   platform: DevicePlatform;
   /** Which running device (udid/serial) to stream. */
   device?: string | null;
+  /** Explicit consumer-owned stream selection. */
+  streamMode: DeviceConnectionOptions['streamMode'];
 }
 
 /**
@@ -26,11 +32,13 @@ export function useActiveDeviceClient(
     enabled: iosActive,
     baseUrl: iosActive ? endpointFor('ios', hubBase) : null,
     device: iosActive ? target?.device ?? null : null,
+    streamMode: target?.streamMode as DeviceConnectionOptions['streamMode'],
   });
   const android = useAndroidDeviceClient({
     enabled: androidActive,
     baseUrl: androidActive ? endpointFor('android', hubBase) : null,
     device: androidActive ? target?.device ?? null : null,
+    streamMode: target?.streamMode as DeviceConnectionOptions['streamMode'],
   });
 
   if (iosActive) return ios;

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -112,9 +112,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   // unique even though lines are kept (the stream effect may re-run).
   const logSeqRef = useRef(0);
 
-  const attachVideo = useCallback((el: HTMLCanvasElement | HTMLImageElement | null) => {
-    canvasRef.current = (el as HTMLCanvasElement) ?? null;
-  }, []);
+  const attachVideo = useCallback(
+    (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
+      canvasRef.current = (el as HTMLCanvasElement) ?? null;
+    },
+    [],
+  );
 
   const attachLogs = useCallback(() => setLogsEnabled(true), []);
   const detachLogs = useCallback(() => setLogsEnabled(false), []);

--- a/packages/@expo/hub-client/src/useAvccStream.ts
+++ b/packages/@expo/hub-client/src/useAvccStream.ts
@@ -1,0 +1,201 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+import { AvccDemuxer, avcCodecString, isAvccSupported, type AvccChunkType } from './avcc';
+
+export interface UseAvccStreamOptions {
+  /** Base serve-sim helper URL, without `/stream.avcc`. */
+  url: string;
+  enabled: boolean;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  onFirstFrame?: () => void;
+  onFrame?: () => void;
+  onDecodedFrame?: () => void;
+  onResize?: (width: number, height: number) => void;
+  onError?: (message: string) => void;
+  onDecoderError?: () => void;
+}
+
+const RETRY_DELAY_MS = 1_000;
+const FRAME_DURATION_US = 16_667;
+
+/** Decode serve-sim's H.264 AVCC feed into a canvas via WebCodecs. */
+export function useAvccStream({
+  url,
+  enabled,
+  canvasRef,
+  onFirstFrame,
+  onFrame,
+  onDecodedFrame,
+  onResize,
+  onError,
+  onDecoderError,
+}: UseAvccStreamOptions): void {
+  const callbacks = useRef({
+    onFirstFrame,
+    onFrame,
+    onDecodedFrame,
+    onResize,
+    onError,
+    onDecoderError,
+  });
+  callbacks.current = {
+    onFirstFrame,
+    onFrame,
+    onDecodedFrame,
+    onResize,
+    onError,
+    onDecoderError,
+  };
+
+  useEffect(() => {
+    if (!enabled || !url || !isAvccSupported()) return;
+
+    const controller = new AbortController();
+    const demuxer = new AvccDemuxer();
+    let stopped = false;
+    let painted = false;
+    let decodedFramePainted = false;
+    let timestamp = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let decoder: VideoDecoder | null = null;
+
+    const isLive = () => !stopped && !controller.signal.aborted;
+
+    const reportDecodeFailure = (message: string) => {
+      if (callbacks.current.onDecoderError) callbacks.current.onDecoderError();
+      else callbacks.current.onError?.(message);
+    };
+
+    const paint = (source: CanvasImageSource, width: number, height: number, decoded: boolean) => {
+      if (!isLive()) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+        callbacks.current.onResize?.(width, height);
+      }
+      const context = canvas.getContext('2d');
+      if (!context) return;
+      context.drawImage(source, 0, 0, width, height);
+      callbacks.current.onFrame?.();
+      if (decoded && !decodedFramePainted) {
+        decodedFramePainted = true;
+        callbacks.current.onDecodedFrame?.();
+      }
+      if (!painted) {
+        painted = true;
+        callbacks.current.onFirstFrame?.();
+      }
+    };
+
+    const makeDecoder = () =>
+      new VideoDecoder({
+        output: (frame) => {
+          try {
+            if (isLive()) paint(frame, frame.displayWidth, frame.displayHeight, true);
+          } finally {
+            frame.close();
+          }
+        },
+        error: (decoderError) => reportDecodeFailure(`decoder: ${decoderError.message}`),
+      });
+
+    const paintSeed = async (jpeg: Uint8Array) => {
+      const bitmap = await createImageBitmap(new Blob([jpeg as BlobPart], { type: 'image/jpeg' }));
+      try {
+        if (isLive()) paint(bitmap, bitmap.width, bitmap.height, false);
+      } finally {
+        bitmap.close();
+      }
+    };
+
+    const configureDecoder = (description: Uint8Array) => {
+      if (!decoder || decoder.state === 'closed') decoder = makeDecoder();
+      try {
+        decoder.configure({
+          codec: avcCodecString(description),
+          description,
+          optimizeFor: 'latency',
+          hardwareAcceleration: 'prefer-hardware',
+        } as VideoDecoderConfig & { optimizeFor: 'latency' });
+      } catch (caught) {
+        reportDecodeFailure(`config: ${(caught as Error).message}`);
+      }
+    };
+
+    const decodeFrame = (type: 'keyframe' | 'delta', data: Uint8Array) => {
+      if (decoder?.state !== 'configured') return;
+      try {
+        decoder.decode(
+          new EncodedVideoChunk({
+            type: type === 'keyframe' ? 'key' : 'delta',
+            timestamp,
+            data,
+          }),
+        );
+        timestamp += FRAME_DURATION_US;
+      } catch {
+        // Drop an undecodable frame and wait for the next decoder output.
+      }
+    };
+
+    const handleChunk = (type: AvccChunkType, payload: Uint8Array) => {
+      switch (type) {
+        case 'seed':
+          void paintSeed(payload).catch(() => {});
+          break;
+        case 'description':
+          configureDecoder(payload);
+          break;
+        case 'keyframe':
+        case 'delta':
+          decodeFrame(type, payload);
+          break;
+      }
+    };
+
+    const scheduleRetry = () => {
+      if (!isLive() || retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        void read();
+      }, RETRY_DELAY_MS);
+    };
+
+    const read = async () => {
+      demuxer.reset();
+      try {
+        const response = await fetch(`${url}/stream.avcc`, { signal: controller.signal });
+        if (!response.ok) throw new Error(`H.264 stream failed (${response.status})`);
+        const reader = response.body?.getReader();
+        if (!reader) return;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+          for (const chunk of demuxer.push(value)) handleChunk(chunk.type, chunk.payload);
+        }
+      } catch {
+        // Network errors are retried; the parent timeout handles old helpers.
+      } finally {
+        if (isLive()) scheduleRetry();
+      }
+    };
+
+    void read();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      controller.abort();
+      demuxer.reset();
+      if (decoder && decoder.state !== 'closed') {
+        try {
+          decoder.close();
+        } catch {}
+      }
+      decoder = null;
+    };
+  }, [url, enabled, canvasRef]);
+}

--- a/packages/@expo/hub-client/src/useAvccStream.ts
+++ b/packages/@expo/hub-client/src/useAvccStream.ts
@@ -116,9 +116,9 @@ export function useAvccStream({
         decoder.configure({
           codec: avcCodecString(description),
           description,
-          optimizeFor: 'latency',
+          optimizeForLatency: true,
           hardwareAcceleration: 'prefer-hardware',
-        } as VideoDecoderConfig & { optimizeFor: 'latency' });
+        });
       } catch (caught) {
         reportDecodeFailure(`config: ${(caught as Error).message}`);
       }

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -53,6 +53,11 @@ import {
 } from './types';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
 import { useAvccStream } from './useAvccStream';
+import { useWebRtcStream } from './useWebRtcStream';
+import {
+  type WebRtcCodec,
+  webRtcFallbackDecision,
+} from './webrtc-fallback';
 
 const MAX_LOGS = 200;
 const RECONNECT_MS = 1500;
@@ -306,9 +311,14 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   const logSeqRef = useRef(0);
   const imgRef = useRef<HTMLImageElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamUrlRef = useRef<string | null>(null);
   const [avccFallback, dispatchAvccFallback] = useReducer(avccFallbackReducer, initialAvccFallback);
-  const useAvcc = streamMode === 'h264' && isAvccSupported() && !avccFallback.fellBack;
+  const [webRtcCodec, setWebRtcCodec] = useState<WebRtcCodec>('h264');
+  const [webRtcHttpFallback, setWebRtcHttpFallback] = useState(false);
+  const useWebRtc = streamMode === 'webrtc' && !webRtcHttpFallback;
+  const wantsAvcc = streamMode === 'h264' || webRtcHttpFallback;
+  const useAvcc = wantsAvcc && isAvccSupported() && !avccFallback.fellBack;
   // True while the in-flight single-finger drag began in the home-indicator band.
   const edgeGestureRef = useRef(false);
   // Latest screen config, read by the (stable) input callbacks for orientation.
@@ -327,17 +337,23 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   }, []);
 
   const attachVideo = useCallback(
-    (el: HTMLCanvasElement | HTMLImageElement | null) => {
-      if (useAvcc) {
+    (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
+      if (useWebRtc) {
+        videoRef.current = (el as HTMLVideoElement) ?? null;
+        canvasRef.current = null;
+        imgRef.current = null;
+      } else if (useAvcc) {
         canvasRef.current = (el as HTMLCanvasElement) ?? null;
+        videoRef.current = null;
         imgRef.current = null;
       } else {
         imgRef.current = (el as HTMLImageElement) ?? null;
         canvasRef.current = null;
+        videoRef.current = null;
         if (el) applyStreamSrc();
       }
     },
-    [applyStreamSrc, useAvcc],
+    [applyStreamSrc, useAvcc, useWebRtc],
   );
 
   const sendTouch = useCallback((sample: TouchSample) => {
@@ -544,18 +560,6 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     };
   }, [active, baseUrl, targetDevice]);
 
-  // ── H.264 AVCC (WebCodecs) with serve-sim's MJPEG fallback policy. ──
-  useEffect(() => {
-    dispatchAvccFallback('reset');
-    setFps(0);
-  }, [streamMode, config?.url]);
-
-  useEffect(() => {
-    if (!useAvcc || !config?.url) return;
-    const timer = setTimeout(() => dispatchAvccFallback('timeout'), AVCC_FRAME_TIMEOUT_MS);
-    return () => clearTimeout(timer);
-  }, [useAvcc, config?.url]);
-
   const fpsCounterRef = useRef({ frames: 0, startedAt: 0 });
   const onAvccFrame = useCallback(() => {
     const now = performance.now();
@@ -568,6 +572,102 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     counter.startedAt = now;
     setFps((previous) => (previous === next ? previous : next));
   }, []);
+
+  // ── WebRTC with serve-sim's codec and HTTP fallback policy. ──
+  const {
+    stream: webRtcStream,
+    failure: webRtcFailure,
+    error: webRtcError,
+    markFrameDecoded: markWebRtcFrameDecoded,
+  } = useWebRtcStream({
+    offerUrl: config ? `${config.url}/webrtc/offer` : '',
+    closeUrl: config ? `${config.url}/webrtc/close` : '',
+    enabled: active && useWebRtc && !!config,
+    codec: webRtcCodec,
+  });
+  const handledWebRtcFailureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!useWebRtc || !webRtcFailure) return;
+    if (handledWebRtcFailureRef.current === webRtcFailure.sessionId) return;
+    handledWebRtcFailureRef.current = webRtcFailure.sessionId;
+    const decision = webRtcFallbackDecision('h264', webRtcCodec, webRtcFailure);
+    if (!decision) return;
+    if (decision.type === 'switch-to-http') setWebRtcHttpFallback(true);
+    else setWebRtcCodec(decision.codec);
+  }, [useWebRtc, webRtcFailure, webRtcCodec]);
+
+  useEffect(() => {
+    if (!useWebRtc) return;
+    if (webRtcError) {
+      setStatus('error');
+      setError(webRtcError);
+    } else if (!webRtcStream) {
+      setStatus('connecting');
+      setError(null);
+    }
+  }, [useWebRtc, webRtcError, webRtcStream]);
+
+  useEffect(() => {
+    if (!useWebRtc) return;
+    const video = videoRef.current;
+    if (!video) return;
+    let stopped = false;
+    let firstFrame = true;
+    let frameCallback = 0;
+
+    const markFrame = () => {
+      if (stopped) return;
+      if (video.videoWidth > 0 && video.videoHeight > 0 && !hasWsConfigRef.current) {
+        setScreen({ width: video.videoWidth, height: video.videoHeight });
+      }
+      onAvccFrame();
+      if (firstFrame) {
+        firstFrame = false;
+        markWebRtcFrameDecoded();
+        setStatus('streaming');
+        setError(null);
+      }
+    };
+    const onVideoFrame = () => {
+      markFrame();
+      frameCallback = video.requestVideoFrameCallback(onVideoFrame);
+    };
+    const onTimeUpdate = () => markFrame();
+
+    video.srcObject = webRtcStream;
+    if (webRtcStream) {
+      const supportsVideoFrameCallback = typeof video.requestVideoFrameCallback === 'function';
+      if (supportsVideoFrameCallback) frameCallback = video.requestVideoFrameCallback(onVideoFrame);
+      else video.addEventListener('timeupdate', onTimeUpdate);
+      video.addEventListener('loadeddata', markFrame, { once: true });
+      void video.play().catch(() => {});
+    }
+
+    return () => {
+      stopped = true;
+      video.removeEventListener('loadeddata', markFrame);
+      video.removeEventListener('timeupdate', onTimeUpdate);
+      if (frameCallback && typeof video.cancelVideoFrameCallback === 'function') {
+        video.cancelVideoFrameCallback(frameCallback);
+      }
+      video.srcObject = null;
+    };
+  }, [useWebRtc, webRtcStream, markWebRtcFrameDecoded, onAvccFrame]);
+
+  // ── H.264 AVCC (WebCodecs) with serve-sim's MJPEG fallback policy. ──
+  useEffect(() => {
+    dispatchAvccFallback('reset');
+    setWebRtcCodec('h264');
+    setWebRtcHttpFallback(false);
+    setFps(0);
+  }, [streamMode, config?.url]);
+
+  useEffect(() => {
+    if (!useAvcc || !config?.url) return;
+    const timer = setTimeout(() => dispatchAvccFallback('timeout'), AVCC_FRAME_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [useAvcc, config?.url]);
 
   useAvccStream({
     url: config?.url ?? '',
@@ -590,7 +690,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   });
 
   // ── MJPEG video (<img>) ──
-  const streamUrl = useAvcc ? null : (config?.streamUrl ?? null);
+  const streamUrl = useAvcc || useWebRtc ? null : (config?.streamUrl ?? null);
   useEffect(() => {
     if (!streamUrl) {
       streamUrlRef.current = null;
@@ -935,7 +1035,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     detachLogs,
     clearLogs,
     foregroundApp,
-    videoKind: useAvcc ? 'canvas' : 'img',
+    videoKind: useWebRtc ? 'video' : useAvcc ? 'canvas' : 'img',
     attachVideo,
     sendTouch,
     sendMultiTouch,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -22,8 +22,10 @@
  * helper because doing so drops the middleware/helper path from stream URLs.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 
+import { AVCC_FRAME_TIMEOUT_MS, avccFallbackReducer, initialAvccFallback } from './avcc-fallback';
+import { isAvccSupported } from './avcc';
 import {
   HID_EDGE_BOTTOM,
   homeIndicatorEdge,
@@ -50,6 +52,7 @@ import {
   type TouchSample,
 } from './types';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
+import { useAvccStream } from './useAvccStream';
 
 const MAX_LOGS = 200;
 const RECONNECT_MS = 1500;
@@ -244,6 +247,8 @@ function execWsCommand(
 
 /** Resolved connection: where to stream video/input, and how to reach logs/devices. */
 interface ResolvedConfig {
+  /** Base serve-sim helper URL used by `/stream.avcc`. */
+  url: string;
   streamUrl: string;
   wsUrl: string;
   device: string | null;
@@ -272,12 +277,13 @@ interface PreviewApi {
 }
 
 export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClient {
-  const { baseUrl, enabled = true, device: targetDevice = null } = options;
+  const { baseUrl, enabled = true, device: targetDevice = null, streamMode } = options;
   const active = enabled && !!baseUrl;
 
   const [status, setStatus] = useState<ConnectionStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [screen, setScreen] = useState<ScreenSize | null>(null);
+  const [fps, setFps] = useState(0);
   const [logs, setLogs] = useState<DeviceLog[]>([]);
   // Logs are opt-in: nothing streams until the user attaches.
   const [logsEnabled, setLogsEnabled] = useState(false);
@@ -299,7 +305,10 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   // unique even though lines are kept (the stream effect may re-run).
   const logSeqRef = useRef(0);
   const imgRef = useRef<HTMLImageElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const streamUrlRef = useRef<string | null>(null);
+  const [avccFallback, dispatchAvccFallback] = useReducer(avccFallbackReducer, initialAvccFallback);
+  const useAvcc = streamMode === 'h264' && isAvccSupported() && !avccFallback.fellBack;
   // True while the in-flight single-finger drag began in the home-indicator band.
   const edgeGestureRef = useRef(false);
   // Latest screen config, read by the (stable) input callbacks for orientation.
@@ -319,10 +328,16 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
 
   const attachVideo = useCallback(
     (el: HTMLCanvasElement | HTMLImageElement | null) => {
-      imgRef.current = (el as HTMLImageElement) ?? null;
-      if (el) applyStreamSrc();
+      if (useAvcc) {
+        canvasRef.current = (el as HTMLCanvasElement) ?? null;
+        imgRef.current = null;
+      } else {
+        imgRef.current = (el as HTMLImageElement) ?? null;
+        canvasRef.current = null;
+        if (el) applyStreamSrc();
+      }
     },
-    [applyStreamSrc],
+    [applyStreamSrc, useAvcc],
   );
 
   const sendTouch = useCallback((sample: TouchSample) => {
@@ -479,6 +494,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       const c = proxyPreviewConfigForBrowser(rawConfig, window.location);
       const basePath = c.basePath ?? '';
       return {
+        url: c.url!,
         streamUrl: c.streamUrl ?? `${c.url}/stream.mjpeg`,
         wsUrl: toQueryStyleHelperWsUrl(c.wsUrl ?? `${toWs(c.url!)}/ws`),
         device: c.device ?? null,
@@ -528,8 +544,53 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     };
   }, [active, baseUrl, targetDevice]);
 
+  // ── H.264 AVCC (WebCodecs) with serve-sim's MJPEG fallback policy. ──
+  useEffect(() => {
+    dispatchAvccFallback('reset');
+    setFps(0);
+  }, [streamMode, config?.url]);
+
+  useEffect(() => {
+    if (!useAvcc || !config?.url) return;
+    const timer = setTimeout(() => dispatchAvccFallback('timeout'), AVCC_FRAME_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [useAvcc, config?.url]);
+
+  const fpsCounterRef = useRef({ frames: 0, startedAt: 0 });
+  const onAvccFrame = useCallback(() => {
+    const now = performance.now();
+    const counter = fpsCounterRef.current;
+    if (counter.startedAt === 0) counter.startedAt = now;
+    counter.frames++;
+    if (now - counter.startedAt < 1_000) return;
+    const next = Math.round((counter.frames * 1_000) / (now - counter.startedAt));
+    counter.frames = 0;
+    counter.startedAt = now;
+    setFps((previous) => (previous === next ? previous : next));
+  }, []);
+
+  useAvccStream({
+    url: config?.url ?? '',
+    enabled: active && useAvcc && !!config,
+    canvasRef,
+    onFirstFrame: () => {
+      setStatus('streaming');
+      setError(null);
+    },
+    onFrame: onAvccFrame,
+    onDecodedFrame: () => dispatchAvccFallback('decoded-frame'),
+    onResize: (width, height) => {
+      if (!hasWsConfigRef.current) setScreen({ width, height });
+    },
+    onError: (message) => {
+      setStatus('error');
+      setError(message);
+    },
+    onDecoderError: () => dispatchAvccFallback('error'),
+  });
+
   // ── MJPEG video (<img>) ──
-  const streamUrl = config?.streamUrl ?? null;
+  const streamUrl = useAvcc ? null : (config?.streamUrl ?? null);
   useEffect(() => {
     if (!streamUrl) {
       streamUrlRef.current = null;
@@ -582,6 +643,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       const el = imgRef.current;
       if (el) el.removeAttribute('src');
       setScreen(null);
+      setFps(0);
     };
   }, [streamUrl, applyStreamSrc]);
 
@@ -865,7 +927,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     status,
     error,
     screen,
-    fps: 0,
+    fps,
     devices,
     logs,
     logsEnabled,
@@ -873,7 +935,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     detachLogs,
     clearLogs,
     foregroundApp,
-    videoKind: 'img',
+    videoKind: useAvcc ? 'canvas' : 'img',
     attachVideo,
     sendTouch,
     sendMultiTouch,

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  type WebRtcCodec,
+  type WebRtcStreamFailure,
+  webRtcFailureDisposition,
+} from './webrtc-fallback';
+import {
+  closeWebRtcSession,
+  postWebRtcOffer,
+  WebRtcSignalingBusyError,
+  WebRtcSignalingTimeoutError,
+} from './webrtc-negotiation';
+
+export type WebRtcIceServer = {
+  urls: string[];
+  username?: string;
+  credential?: string;
+};
+
+const DEFAULT_ICE_SERVERS: WebRtcIceServer[] = [
+  { urls: ['stun:stun.l.google.com:19302'] },
+  { urls: ['stun:stun1.l.google.com:19302'] },
+];
+const ICE_GATHERING_TIMEOUT_MS = 3_000;
+const SIGNALING_REQUEST_TIMEOUT_MS = 20_000;
+const FIRST_FRAME_TIMEOUT_MS = 4_000;
+const BUSY_RETRY_INTERVAL_MS = 500;
+const BUSY_RETRY_COUNT = 30;
+const TRANSPORT_RETRY_BASE_MS = 500;
+const TRANSPORT_RETRY_MAX_MS = 5_000;
+
+function createSessionId(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** Negotiate and maintain serve-sim's recv-only WebRTC stream. */
+export function useWebRtcStream({
+  offerUrl,
+  closeUrl,
+  enabled,
+  codec,
+  iceServers,
+}: {
+  offerUrl: string;
+  closeUrl: string;
+  enabled: boolean;
+  codec: WebRtcCodec;
+  iceServers?: WebRtcIceServer[];
+}) {
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [failure, setFailure] = useState<WebRtcStreamFailure | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [retryGeneration, setRetryGeneration] = useState(0);
+  const firstFrameTimeoutRef = useRef<number | undefined>(undefined);
+  const firstFrameDecodedRef = useRef(false);
+  const transportRetryAttemptRef = useRef(0);
+
+  const markFrameDecoded = useCallback(() => {
+    firstFrameDecodedRef.current = true;
+    transportRetryAttemptRef.current = 0;
+    if (firstFrameTimeoutRef.current !== undefined) {
+      window.clearTimeout(firstFrameTimeoutRef.current);
+      firstFrameTimeoutRef.current = undefined;
+    }
+    setFailure(null);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    transportRetryAttemptRef.current = 0;
+  }, [enabled, offerUrl, closeUrl, codec, iceServers]);
+
+  useEffect(() => {
+    if (!enabled || !offerUrl) return;
+    setFailure(null);
+    if (typeof RTCPeerConnection === 'undefined' || typeof RTCRtpReceiver === 'undefined') {
+      setStream(null);
+      setError('WebRTC is not supported by this browser.');
+      setFailure({ sessionId: createSessionId(), kind: 'permanent' });
+      return;
+    }
+
+    let stopped = false;
+    let peer: RTCPeerConnection | null = null;
+    let retryTimer: number | undefined;
+    let closePromise: Promise<void> | null = null;
+    let failing = false;
+    const lifecycleController = new AbortController();
+    const sessionId = createSessionId();
+    const servers = iceServers?.length ? iceServers : DEFAULT_ICE_SERVERS;
+    setStream(null);
+    setFailure(null);
+    setError(null);
+    firstFrameDecodedRef.current = false;
+    if (firstFrameTimeoutRef.current !== undefined) {
+      window.clearTimeout(firstFrameTimeoutRef.current);
+      firstFrameTimeoutRef.current = undefined;
+    }
+
+    const closeRemoteSession = (keepalive = false): Promise<void> => {
+      if (closePromise) return closePromise;
+      closePromise = closeWebRtcSession({ url: closeUrl, sessionId, keepalive });
+      return closePromise;
+    };
+    const releaseOnPageHide = () => void closeRemoteSession(true);
+    window.addEventListener('pagehide', releaseOnPageHide);
+    window.addEventListener('beforeunload', releaseOnPageHide);
+
+    const closePeer = () => {
+      setStream(null);
+      peer?.close();
+    };
+
+    const failPermanently = (message: string) => {
+      if (stopped || failing) return;
+      failing = true;
+      setError(message);
+      setFailure({ sessionId, kind: 'permanent' });
+      closePeer();
+      void closeRemoteSession();
+    };
+
+    const failCodec = () => {
+      if (stopped || failing) return;
+      failing = true;
+      closePeer();
+      void closeRemoteSession().finally(() => {
+        if (!stopped) setFailure({ sessionId, kind: 'codec', codec });
+      });
+    };
+
+    const retryTransport = (message: string) => {
+      if (stopped || failing) return;
+      failing = true;
+      setFailure(null);
+      const attempt = transportRetryAttemptRef.current++;
+      const delay = Math.min(
+        TRANSPORT_RETRY_BASE_MS * 2 ** Math.min(attempt, 4),
+        TRANSPORT_RETRY_MAX_MS,
+      );
+      setError(`${message} Retrying...`);
+      closePeer();
+      void closeRemoteSession().finally(() => {
+        if (stopped) return;
+        retryTimer = window.setTimeout(() => {
+          if (!stopped) setRetryGeneration((generation) => generation + 1);
+        }, delay);
+      });
+    };
+
+    const waitForIce = (connection: RTCPeerConnection) =>
+      new Promise<void>((resolve) => {
+        if (connection.iceGatheringState === 'complete') {
+          resolve();
+          return;
+        }
+        let timeout: number | undefined;
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          connection.removeEventListener('icegatheringstatechange', onState);
+          if (timeout !== undefined) window.clearTimeout(timeout);
+          resolve();
+        };
+        const onState = () => {
+          if (connection.iceGatheringState === 'complete') finish();
+        };
+        connection.addEventListener('icegatheringstatechange', onState);
+        timeout = window.setTimeout(finish, ICE_GATHERING_TIMEOUT_MS);
+      });
+
+    void (async () => {
+      try {
+        peer = new RTCPeerConnection({
+          iceServers: servers,
+          iceTransportPolicy: 'all',
+        });
+
+        const transceiver = peer.addTransceiver('video', { direction: 'recvonly' });
+        const capabilities = RTCRtpReceiver.getCapabilities('video');
+        const preferredMimeType =
+          codec === 'h264' ? 'video/H264' : codec === 'vp9' ? 'video/VP9' : 'video/VP8';
+        if (capabilities?.codecs.length && 'setCodecPreferences' in transceiver) {
+          const preferred = preferredMimeType.toLowerCase();
+          transceiver.setCodecPreferences([
+            ...capabilities.codecs.filter((candidate) => candidate.mimeType.toLowerCase() === preferred),
+            ...capabilities.codecs.filter((candidate) => candidate.mimeType.toLowerCase() !== preferred),
+          ]);
+        }
+
+        peer.ontrack = (event) => {
+          if (stopped) return;
+          firstFrameDecodedRef.current = false;
+          event.track.onended = () => retryTransport('WebRTC video track ended.');
+          setStream(event.streams[0] ?? new MediaStream([event.track]));
+          if (firstFrameTimeoutRef.current !== undefined) {
+            window.clearTimeout(firstFrameTimeoutRef.current);
+          }
+          firstFrameTimeoutRef.current = window.setTimeout(() => {
+            firstFrameTimeoutRef.current = undefined;
+            if (stopped || firstFrameDecodedRef.current) return;
+            const state = peer?.connectionState ?? 'closed';
+            if (webRtcFailureDisposition('first-frame-timeout', state) === 'codec') failCodec();
+            else retryTransport('WebRTC did not establish a video path.');
+          }, FIRST_FRAME_TIMEOUT_MS);
+        };
+        peer.onconnectionstatechange = () => {
+          if (stopped || !peer || peer.connectionState !== 'failed') return;
+          if (webRtcFailureDisposition('connection-failed', peer.connectionState) === 'transport') {
+            retryTransport('WebRTC connection failed.');
+          }
+        };
+
+        const offer = await peer.createOffer();
+        await peer.setLocalDescription(offer);
+        await waitForIce(peer);
+        const local = peer.localDescription;
+        if (!local) throw new Error('WebRTC offer was not created');
+        const response = await postWebRtcOffer({
+          url: offerUrl,
+          signal: lifecycleController.signal,
+          requestTimeoutMs: SIGNALING_REQUEST_TIMEOUT_MS,
+          busyRetryIntervalMs: BUSY_RETRY_INTERVAL_MS,
+          busyRetryCount: BUSY_RETRY_COUNT,
+          body: JSON.stringify({
+            type: local.type,
+            sdp: local.sdp,
+            sessionId,
+            codec,
+            iceServers: servers,
+          }),
+        });
+        if (!response.ok) {
+          await response.body?.cancel();
+          failPermanently(`WebRTC offer failed: HTTP ${response.status}`);
+          return;
+        }
+        const answer = (await response.json()) as RTCSessionDescriptionInit;
+        if (stopped) {
+          await closeRemoteSession(true);
+          return;
+        }
+        try {
+          await peer.setRemoteDescription(answer);
+        } catch {
+          failPermanently('WebRTC returned an invalid session description.');
+        }
+      } catch (caught) {
+        if (stopped || lifecycleController.signal.aborted) return;
+        if (caught instanceof WebRtcSignalingBusyError) {
+          failPermanently(caught.message);
+          return;
+        }
+        const message =
+          caught instanceof WebRtcSignalingTimeoutError
+            ? 'WebRTC signaling timed out.'
+            : 'WebRTC signaling failed.';
+        if (webRtcFailureDisposition('signaling-failed', peer?.connectionState ?? 'closed') === 'transport') {
+          retryTransport(message);
+        }
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      window.removeEventListener('pagehide', releaseOnPageHide);
+      window.removeEventListener('beforeunload', releaseOnPageHide);
+      lifecycleController.abort();
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+      if (firstFrameTimeoutRef.current !== undefined) {
+        window.clearTimeout(firstFrameTimeoutRef.current);
+        firstFrameTimeoutRef.current = undefined;
+      }
+      void closeRemoteSession(true);
+      setStream(null);
+      peer?.close();
+    };
+  }, [enabled, offerUrl, closeUrl, codec, iceServers, retryGeneration]);
+
+  return { stream, failure, error, markFrameDecoded };
+}

--- a/packages/@expo/hub-client/src/webrtc-fallback.ts
+++ b/packages/@expo/hub-client/src/webrtc-fallback.ts
@@ -1,0 +1,54 @@
+export type WebRtcCodec = 'h264' | 'vp8' | 'vp9';
+
+export type WebRtcFailureReason =
+  | { kind: 'permanent' }
+  | { kind: 'codec'; codec: WebRtcCodec };
+
+export type WebRtcStreamFailure = WebRtcFailureReason & { sessionId: string };
+
+export type WebRtcFallbackDecision =
+  | { type: 'retry-codec'; codec: WebRtcCodec }
+  | { type: 'switch-to-http' };
+
+const FALLBACK_ATTEMPTS: Record<WebRtcCodec, readonly WebRtcCodec[]> = {
+  h264: ['h264', 'vp8', 'vp9'],
+  vp9: ['vp9', 'vp8'],
+  vp8: ['vp8'],
+};
+
+export function nextWebRtcFallbackCodec(
+  requested: WebRtcCodec,
+  current: WebRtcCodec,
+): WebRtcCodec | null {
+  const attempts = FALLBACK_ATTEMPTS[requested];
+  const currentIndex = attempts.indexOf(current);
+  if (currentIndex === -1) return attempts[0] ?? null;
+  return attempts[currentIndex + 1] ?? null;
+}
+
+export function webRtcFallbackDecision(
+  requested: WebRtcCodec,
+  current: WebRtcCodec,
+  failure: WebRtcFailureReason,
+): WebRtcFallbackDecision | null {
+  if (failure.kind === 'permanent') return { type: 'switch-to-http' };
+  if (failure.codec !== current) return null;
+  const nextCodec = nextWebRtcFallbackCodec(requested, current);
+  return nextCodec && nextCodec !== current
+    ? { type: 'retry-codec', codec: nextCodec }
+    : { type: 'switch-to-http' };
+}
+
+export type WebRtcFailureEvent =
+  | 'first-frame-timeout'
+  | 'connection-failed'
+  | 'signaling-failed';
+
+export function webRtcFailureDisposition(
+  event: WebRtcFailureEvent,
+  connectionState: RTCPeerConnectionState,
+): 'codec' | 'transport' {
+  return event === 'first-frame-timeout' && connectionState === 'connected'
+    ? 'codec'
+    : 'transport';
+}

--- a/packages/@expo/hub-client/src/webrtc-negotiation.ts
+++ b/packages/@expo/hub-client/src/webrtc-negotiation.ts
@@ -1,0 +1,126 @@
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type SendBeaconLike = (url: string | URL, data?: BodyInit | null) => boolean;
+
+export class WebRtcSignalingBusyError extends Error {
+  constructor() {
+    super('WebRTC signaling stayed busy for too long. Reload to try again.');
+    this.name = 'WebRtcSignalingBusyError';
+  }
+}
+
+export class WebRtcSignalingTimeoutError extends Error {
+  constructor() {
+    super('WebRTC signaling timed out.');
+    this.name = 'WebRtcSignalingTimeoutError';
+  }
+}
+
+function abortError(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+function waitForRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(finish, delayMs);
+    function finish() {
+      signal?.removeEventListener('abort', abort);
+      resolve();
+    }
+    function abort() {
+      clearTimeout(timer);
+      reject(signal ? abortError(signal) : new DOMException('The operation was aborted', 'AbortError'));
+    }
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}
+
+export async function closeWebRtcSession({
+  url,
+  sessionId,
+  keepalive = false,
+  sendBeacon,
+  fetchImpl = fetch,
+}: {
+  url: string;
+  sessionId: string;
+  keepalive?: boolean;
+  sendBeacon?: SendBeaconLike;
+  fetchImpl?: FetchLike;
+}): Promise<void> {
+  const body = JSON.stringify({ sessionId });
+  const beacon =
+    sendBeacon ??
+    (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function'
+      ? navigator.sendBeacon.bind(navigator)
+      : undefined);
+  if (keepalive && beacon) {
+    try {
+      // text/plain is CORS-safelisted, so unload does not rely on a preflight.
+      if (beacon(url, new Blob([body], { type: 'text/plain;charset=UTF-8' }))) return;
+    } catch {}
+  }
+  await fetchImpl(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive,
+  }).then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+/** Post an SDP offer, retrying while native offer setup is serialized. */
+export async function postWebRtcOffer({
+  url,
+  body,
+  signal,
+  requestTimeoutMs,
+  busyRetryIntervalMs,
+  busyRetryCount,
+  fetchImpl = fetch,
+}: {
+  url: string;
+  body: string;
+  signal?: AbortSignal;
+  requestTimeoutMs: number;
+  busyRetryIntervalMs: number;
+  busyRetryCount: number;
+  fetchImpl?: FetchLike;
+}): Promise<Response> {
+  for (let attempt = 0; attempt <= busyRetryCount; attempt++) {
+    if (signal?.aborted) throw abortError(signal);
+
+    const requestController = new AbortController();
+    let timedOut = false;
+    const abortRequest = () => requestController.abort(signal ? abortError(signal) : undefined);
+    signal?.addEventListener('abort', abortRequest, { once: true });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      requestController.abort();
+    }, requestTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: requestController.signal,
+        body,
+      });
+    } catch (error) {
+      if (timedOut && !signal?.aborted) throw new WebRtcSignalingTimeoutError();
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', abortRequest);
+    }
+
+    if (response.status !== 409) return response;
+    await response.body?.cancel();
+    if (attempt === busyRetryCount) throw new WebRtcSignalingBusyError();
+    await waitForRetry(busyRetryIntervalMs, signal);
+  }
+  throw new WebRtcSignalingBusyError();
+}

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -1,24 +1,34 @@
-import { type DeviceClient } from '@expo/hub-client';
+import { type DeviceClient, type DeviceStreamMode } from '@expo/hub-client';
 import { SidebarToggle } from '../primitives';
 import { CurrentAppSection } from './CurrentAppSection';
 import { KeyboardSection } from './KeyboardSection';
 import { OutputSection } from './OutputSection';
+import { StreamSection, type StreamModeAvailability } from './StreamSection';
 
 /**
- * Right column: the selected device's output (Current app + Logs). Mirrors the
- * left {@link Sidebar} — same width, transparent over the `bg.subtle` canvas —
- * with its padding flipped so the wider gutter sits on the outer (right) edge.
+ * Right column: the selected device's details (Current app + Stream + Logs).
+ * Mirrors the left {@link Sidebar} — same width, transparent over the
+ * `bg.subtle` canvas — with its padding flipped so the wider gutter sits on the outer (right) edge.
  * The header holds a {@link SidebarToggle} on the inner edge to collapse it.
  */
 export function LogSidebar({
   onToggle,
   client,
+  streamMode,
+  streamModeAvailability,
+  onStreamModeChange,
   width = 400,
 }: {
   /** When set, a sidebar toggle is shown to collapse this panel. */
   onToggle?: () => void;
   /** Active device connection — feeds the current-app and logs panels. */
   client?: DeviceClient;
+  /** Viewer-selected simulator stream mode. */
+  streamMode?: DeviceStreamMode;
+  /** Which modes the current browser context can use. */
+  streamModeAvailability?: StreamModeAvailability;
+  /** Change the viewer-local stream mode. */
+  onStreamModeChange?: (mode: DeviceStreamMode) => void;
   /** Column width in px, driven by the resize handle. Defaults to 400. */
   width?: number;
 }) {
@@ -43,6 +53,13 @@ export function LogSidebar({
       )}
       <CurrentAppSection client={client} />
       {client?.platform === 'ios' && <KeyboardSection client={client} />}
+      {streamMode && streamModeAvailability && onStreamModeChange && client?.platform === 'ios' && (
+        <StreamSection
+          mode={streamMode}
+          availability={streamModeAvailability}
+          onChange={onStreamModeChange}
+        />
+      )}
       <OutputSection client={client} />
     </aside>
   );

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -43,31 +43,40 @@ export function StreamSection({
   const triggerStyle: CSSProperties = {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 12,
-    width: '100%',
+    width: 92,
     height: 44,
     boxSizing: 'border-box',
-    padding: '0 12px',
+    padding: '6px 0',
+    border: 0,
+    background: 'transparent',
+    fontFamily: 'inherit',
+    outline: 'none',
+    cursor: 'pointer',
+    touchAction: 'manipulation',
+  };
+
+  const triggerContentStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 6,
+    width: '100%',
+    height: 32,
+    boxSizing: 'border-box',
+    padding: '0 8px',
     border: `1px solid ${border.default}`,
     borderRadius: radius.lg,
     backgroundColor: bg.default,
     color: text.default,
-    fontFamily: 'inherit',
-    fontSize: 16,
-    fontWeight: 400,
-    lineHeight: 1.4,
-    outline: 'none',
+    ...textSize.xs,
     boxShadow: focused ? `0 0 0 3px ${bg.element}` : 'none',
-    cursor: 'pointer',
-    touchAction: 'manipulation',
     transition: 'box-shadow 150ms ease',
   };
 
   return (
-    <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <span style={{ ...textSize.sm, fontWeight: 500, color: text.default }}>Stream</span>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, color: text.secondary }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: text.secondary }}>
         <span id={labelId} style={{ ...textSize.xs }}>
           Mode
         </span>
@@ -76,9 +85,10 @@ export function StreamSection({
           sideOffset={6}
           aria-labelledby={labelId}
           style={{
-            width: 'var(--radix-dropdown-menu-trigger-width)',
-            minWidth: 'var(--radix-dropdown-menu-trigger-width)',
+            width: 92,
+            minWidth: 92,
             boxSizing: 'border-box',
+            padding: 4,
           }}
           trigger={
             <button
@@ -88,8 +98,10 @@ export function StreamSection({
               onFocus={() => setFocused(true)}
               onBlur={() => setFocused(false)}
               style={triggerStyle}>
-              <span id={valueId}>{selectedLabel}</span>
-              <ChevronDownIcon size={16} color={icon.secondary} />
+              <span style={triggerContentStyle}>
+                <span id={valueId}>{selectedLabel}</span>
+                <ChevronDownIcon size={14} color={icon.secondary} />
+              </span>
             </button>
           }>
           <RadioGroup value={mode} onValueChange={(value) => onChange(value as DeviceStreamMode)}>
@@ -99,15 +111,15 @@ export function StreamSection({
                 value={option.value}
                 disabled={!availability[option.value]}
                 className={cx(
-                  'relative z-40 flex cursor-pointer items-center justify-between rounded-lg px-3 outline-none select-none',
+                  'relative z-40 flex cursor-pointer items-center justify-between rounded-lg px-2 outline-none select-none',
                   'data-[highlighted]:bg-hover',
                   'data-[disabled]:cursor-default data-[disabled]:opacity-60'
                 )}
                 style={{ minHeight: 44 }}>
-                <span style={{ ...textSize.sm, color: text.default }}>{option.label}</span>
+                <span style={{ ...textSize.xs, color: text.default }}>{option.label}</span>
                 <ItemIndicator asChild>
                   <span style={{ display: 'flex', color: icon.default }}>
-                    <CheckIcon size={16} />
+                    <CheckIcon size={14} />
                   </span>
                 </ItemIndicator>
               </RadioItem>

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -1,7 +1,19 @@
 import { type DeviceStreamMode } from '@expo/hub-client';
+import { ItemIndicator, RadioGroup, RadioItem } from '@radix-ui/react-dropdown-menu';
 import { type CSSProperties, useId, useState } from 'react';
 
-import { ChevronDownIcon, bg, border, icon, radius, text, textSize } from '../primitives';
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  Dropdown,
+  bg,
+  border,
+  cx,
+  icon,
+  radius,
+  text,
+  textSize,
+} from '../primitives';
 
 export type StreamModeAvailability = Record<DeviceStreamMode, boolean>;
 
@@ -21,16 +33,22 @@ export function StreamSection({
   availability: StreamModeAvailability;
   onChange: (mode: DeviceStreamMode) => void;
 }) {
-  const selectId = useId();
+  const labelId = useId();
+  const valueId = useId();
   const helpId = useId();
   const restricted = !availability.h264 || !availability.webrtc;
   const [focused, setFocused] = useState(false);
+  const selectedLabel = STREAM_OPTIONS.find((option) => option.value === mode)?.label ?? mode;
 
-  const selectStyle: CSSProperties = {
+  const triggerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
     width: '100%',
     height: 44,
     boxSizing: 'border-box',
-    padding: '0 40px 0 12px',
+    padding: '0 12px',
     border: `1px solid ${border.default}`,
     borderRadius: radius.lg,
     backgroundColor: bg.default,
@@ -39,9 +57,6 @@ export function StreamSection({
     fontSize: 16,
     fontWeight: 400,
     lineHeight: 1.4,
-    appearance: 'none',
-    WebkitAppearance: 'none',
-    MozAppearance: 'none',
     outline: 'none',
     boxShadow: focused ? `0 0 0 3px ${bg.element}` : 'none',
     cursor: 'pointer',
@@ -52,40 +67,54 @@ export function StreamSection({
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <span style={{ ...textSize.sm, fontWeight: 500, color: text.default }}>Stream</span>
-      <label
-        htmlFor={selectId}
-        style={{ display: 'flex', flexDirection: 'column', gap: 6, color: text.secondary }}>
-        <span style={{ ...textSize.xs }}>Mode</span>
-        <span style={{ position: 'relative', display: 'block' }}>
-          <select
-            id={selectId}
-            aria-describedby={restricted ? helpId : undefined}
-            value={mode}
-            onChange={(event) => onChange(event.currentTarget.value as DeviceStreamMode)}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-            style={selectStyle}>
-            {STREAM_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value} disabled={!availability[option.value]}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <span
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              right: 12,
-              top: '50%',
-              display: 'flex',
-              transform: 'translateY(-50%)',
-              color: icon.secondary,
-              pointerEvents: 'none',
-            }}>
-            <ChevronDownIcon size={16} />
-          </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, color: text.secondary }}>
+        <span id={labelId} style={{ ...textSize.xs }}>
+          Mode
         </span>
-      </label>
+        <Dropdown
+          align="start"
+          sideOffset={6}
+          aria-labelledby={labelId}
+          style={{
+            width: 'var(--radix-dropdown-menu-trigger-width)',
+            minWidth: 'var(--radix-dropdown-menu-trigger-width)',
+            boxSizing: 'border-box',
+          }}
+          trigger={
+            <button
+              type="button"
+              aria-labelledby={`${labelId} ${valueId}`}
+              aria-describedby={restricted ? helpId : undefined}
+              onFocus={() => setFocused(true)}
+              onBlur={() => setFocused(false)}
+              style={triggerStyle}>
+              <span id={valueId}>{selectedLabel}</span>
+              <ChevronDownIcon size={16} color={icon.secondary} />
+            </button>
+          }>
+          <RadioGroup value={mode} onValueChange={(value) => onChange(value as DeviceStreamMode)}>
+            {STREAM_OPTIONS.map((option) => (
+              <RadioItem
+                key={option.value}
+                value={option.value}
+                disabled={!availability[option.value]}
+                className={cx(
+                  'relative z-40 flex cursor-pointer items-center justify-between rounded-lg px-3 outline-none select-none',
+                  'data-[highlighted]:bg-hover',
+                  'data-[disabled]:cursor-default data-[disabled]:opacity-60'
+                )}
+                style={{ minHeight: 44 }}>
+                <span style={{ ...textSize.sm, color: text.default }}>{option.label}</span>
+                <ItemIndicator asChild>
+                  <span style={{ display: 'flex', color: icon.default }}>
+                    <CheckIcon size={16} />
+                  </span>
+                </ItemIndicator>
+              </RadioItem>
+            ))}
+          </RadioGroup>
+        </Dropdown>
+      </div>
       {restricted && (
         <span id={helpId} style={{ ...textSize.xs, color: text.tertiary }}>
           H.264 and WebRTC require localhost or HTTPS. MJPEG is used on insecure HTTP.

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -43,45 +43,42 @@ export function StreamSection({
   const triggerStyle: CSSProperties = {
     display: 'flex',
     alignItems: 'center',
-    width: 92,
-    height: 44,
-    boxSizing: 'border-box',
-    padding: '6px 0',
-    border: 0,
-    background: 'transparent',
-    fontFamily: 'inherit',
-    outline: 'none',
-    cursor: 'pointer',
-    touchAction: 'manipulation',
-  };
-
-  const triggerContentStyle: CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
     justifyContent: 'space-between',
     gap: 6,
-    width: '100%',
-    height: 32,
+    width: 92,
+    height: 28,
     boxSizing: 'border-box',
     padding: '0 8px',
     border: `1px solid ${border.default}`,
     borderRadius: radius.lg,
     backgroundColor: bg.default,
     color: text.default,
+    fontFamily: 'inherit',
     ...textSize.xs,
+    outline: 'none',
     boxShadow: focused ? `0 0 0 3px ${bg.element}` : 'none',
+    cursor: 'pointer',
+    touchAction: 'manipulation',
     transition: 'box-shadow 150ms ease',
   };
 
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <span style={{ ...textSize.sm, fontWeight: 500, color: text.default }}>Stream</span>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: text.secondary }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          gap: 8,
+          color: text.secondary,
+        }}>
         <span id={labelId} style={{ ...textSize.xs }}>
           Mode
         </span>
         <Dropdown
-          align="start"
+          align="end"
           sideOffset={6}
           aria-labelledby={labelId}
           style={{
@@ -97,11 +94,10 @@ export function StreamSection({
               aria-describedby={restricted ? helpId : undefined}
               onFocus={() => setFocused(true)}
               onBlur={() => setFocused(false)}
+              className="relative before:absolute before:inset-x-0 before:-inset-y-2 before:content-['']"
               style={triggerStyle}>
-              <span style={triggerContentStyle}>
-                <span id={valueId}>{selectedLabel}</span>
-                <ChevronDownIcon size={14} color={icon.secondary} />
-              </span>
+              <span id={valueId}>{selectedLabel}</span>
+              <ChevronDownIcon size={14} color={icon.secondary} />
             </button>
           }>
           <RadioGroup value={mode} onValueChange={(value) => onChange(value as DeviceStreamMode)}>

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -1,0 +1,69 @@
+import { type DeviceStreamMode } from '@expo/hub-client';
+import { useId } from 'react';
+
+import { bg, border, radius, text, textSize } from '../primitives';
+
+export type StreamModeAvailability = Record<DeviceStreamMode, boolean>;
+
+const STREAM_OPTIONS: Array<{ value: DeviceStreamMode; label: string }> = [
+  { value: 'mjpeg', label: 'MJPEG' },
+  { value: 'h264', label: 'H.264' },
+  { value: 'webrtc', label: 'WebRTC' },
+];
+
+/** Viewer-local stream transport control for the right dashboard sidebar. */
+export function StreamSection({
+  mode,
+  availability,
+  onChange,
+}: {
+  mode: DeviceStreamMode;
+  availability: StreamModeAvailability;
+  onChange: (mode: DeviceStreamMode) => void;
+}) {
+  const selectId = useId();
+  const helpId = useId();
+  const restricted = !availability.h264 || !availability.webrtc;
+
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <span style={{ ...textSize.sm, fontWeight: 500, color: text.default }}>Stream</span>
+      <label
+        htmlFor={selectId}
+        style={{ display: 'flex', flexDirection: 'column', gap: 6, color: text.secondary }}>
+        <span style={{ ...textSize.xs }}>Mode</span>
+        <select
+          id={selectId}
+          aria-describedby={restricted ? helpId : undefined}
+          value={mode}
+          onChange={(event) => onChange(event.currentTarget.value as DeviceStreamMode)}
+          style={{
+            width: '100%',
+            minHeight: 44,
+            boxSizing: 'border-box',
+            padding: '8px 12px',
+            border: `1px solid ${border.default}`,
+            borderRadius: radius.lg,
+            backgroundColor: bg.default,
+            color: text.default,
+            fontFamily: 'inherit',
+            fontSize: 16,
+            lineHeight: 1.4,
+            cursor: 'pointer',
+            touchAction: 'manipulation',
+          }}>
+          {STREAM_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value} disabled={!availability[option.value]}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {restricted && (
+        <span id={helpId} style={{ ...textSize.xs, color: text.tertiary }}>
+          H.264 and WebRTC require localhost or HTTPS. MJPEG is used on insecure HTTP.
+        </span>
+      )}
+    </section>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -1,7 +1,7 @@
 import { type DeviceStreamMode } from '@expo/hub-client';
-import { useId } from 'react';
+import { type CSSProperties, useId, useState } from 'react';
 
-import { bg, border, radius, text, textSize } from '../primitives';
+import { ChevronDownIcon, bg, border, icon, radius, text, textSize } from '../primitives';
 
 export type StreamModeAvailability = Record<DeviceStreamMode, boolean>;
 
@@ -24,6 +24,30 @@ export function StreamSection({
   const selectId = useId();
   const helpId = useId();
   const restricted = !availability.h264 || !availability.webrtc;
+  const [focused, setFocused] = useState(false);
+
+  const selectStyle: CSSProperties = {
+    width: '100%',
+    height: 44,
+    boxSizing: 'border-box',
+    padding: '0 40px 0 12px',
+    border: `1px solid ${border.default}`,
+    borderRadius: radius.lg,
+    backgroundColor: bg.default,
+    color: text.default,
+    fontFamily: 'inherit',
+    fontSize: 16,
+    fontWeight: 400,
+    lineHeight: 1.4,
+    appearance: 'none',
+    WebkitAppearance: 'none',
+    MozAppearance: 'none',
+    outline: 'none',
+    boxShadow: focused ? `0 0 0 3px ${bg.element}` : 'none',
+    cursor: 'pointer',
+    touchAction: 'manipulation',
+    transition: 'box-shadow 150ms ease',
+  };
 
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -32,32 +56,35 @@ export function StreamSection({
         htmlFor={selectId}
         style={{ display: 'flex', flexDirection: 'column', gap: 6, color: text.secondary }}>
         <span style={{ ...textSize.xs }}>Mode</span>
-        <select
-          id={selectId}
-          aria-describedby={restricted ? helpId : undefined}
-          value={mode}
-          onChange={(event) => onChange(event.currentTarget.value as DeviceStreamMode)}
-          style={{
-            width: '100%',
-            minHeight: 44,
-            boxSizing: 'border-box',
-            padding: '8px 12px',
-            border: `1px solid ${border.default}`,
-            borderRadius: radius.lg,
-            backgroundColor: bg.default,
-            color: text.default,
-            fontFamily: 'inherit',
-            fontSize: 16,
-            lineHeight: 1.4,
-            cursor: 'pointer',
-            touchAction: 'manipulation',
-          }}>
-          {STREAM_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value} disabled={!availability[option.value]}>
-              {option.label}
-            </option>
-          ))}
-        </select>
+        <span style={{ position: 'relative', display: 'block' }}>
+          <select
+            id={selectId}
+            aria-describedby={restricted ? helpId : undefined}
+            value={mode}
+            onChange={(event) => onChange(event.currentTarget.value as DeviceStreamMode)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            style={selectStyle}>
+            {STREAM_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} disabled={!availability[option.value]}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <span
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              right: 12,
+              top: '50%',
+              display: 'flex',
+              transform: 'translateY(-50%)',
+              color: icon.secondary,
+              pointerEvents: 'none',
+            }}>
+            <ChevronDownIcon size={16} />
+          </span>
+        </span>
       </label>
       {restricted && (
         <span id={helpId} style={{ ...textSize.xs, color: text.tertiary }}>

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -58,6 +58,10 @@ export { LogControls } from './dashboard/LogControls';
 export { LogList } from './dashboard/LogList';
 export { LogRow } from './dashboard/LogRow';
 export { StreamControls } from './dashboard/StreamControls';
+export {
+  StreamSection,
+  type StreamModeAvailability,
+} from './dashboard/StreamSection';
 export { RecentDevicesModal, type RecentDevicesModalProps } from './dashboard/RecentDevicesModal';
 export { BootErrorModal, type BootErrorModalProps } from './dashboard/BootErrorModal';
 

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
   Sidebar,
   SidebarToggle,
   StreamPanel,
+  type StreamModeAvailability,
   bg,
   shadow,
   text,
@@ -30,6 +31,10 @@ import { useColorScheme } from './dashboard/useColorScheme';
 import { useDeviceLists } from './dashboard/useDevices';
 import { useIsNarrow } from './dashboard/useIsNarrow';
 import { useNewDeviceOptions } from './dashboard/useNewDeviceOptions';
+import {
+  browserStreamModeAvailability,
+  resolveStreamMode,
+} from './dashboard/streamMode';
 
 /** Append `extra` devices not already present in `base` (deduped by id). */
 function mergeById(base: Device[], extra: Device[]): Device[] {
@@ -91,7 +96,16 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   const logsNarrow = useIsNarrow(LOGS_MAX_WIDTH);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [logsOpen, setLogsOpen] = useState(true);
-  const [streamMode] = useState<DeviceStreamMode>(DEFAULT_STREAM_MODE);
+  const streamModeAvailability = useMemo<StreamModeAvailability>(
+    browserStreamModeAvailability,
+    []
+  );
+  const [streamMode, setStreamMode] = useState<DeviceStreamMode>(() =>
+    resolveStreamMode(DEFAULT_STREAM_MODE, streamModeAvailability)
+  );
+  const handleStreamModeChange = (mode: DeviceStreamMode) => {
+    setStreamMode(resolveStreamMode(mode, streamModeAvailability));
+  };
   // Draggable widths for each inline sidebar. The `*Start` refs snapshot the
   // width when a drag begins so each move re-derives width from the start point
   // (delta-from-start), which clamps cleanly without drifting.
@@ -299,7 +313,14 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
               )
             }
           />
-          <LogSidebar client={client} onToggle={() => setLogsOpen(false)} width={logsWidth} />
+          <LogSidebar
+            client={client}
+            streamMode={streamMode}
+            streamModeAvailability={streamModeAvailability}
+            onStreamModeChange={handleStreamModeChange}
+            onToggle={() => setLogsOpen(false)}
+            width={logsWidth}
+          />
         </>
       )}
 
@@ -362,7 +383,14 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
               backgroundColor: bg.subtle,
               boxShadow: shadow.lg,
             }}>
-            <LogSidebar client={client} onToggle={() => setLogsOpen(false)} width={logsWidth} />
+            <LogSidebar
+              client={client}
+              streamMode={streamMode}
+              streamModeAvailability={streamModeAvailability}
+              onStreamModeChange={handleStreamModeChange}
+              onToggle={() => setLogsOpen(false)}
+              width={logsWidth}
+            />
           </div>
         </>
       )}

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -2,7 +2,12 @@
 
 import '@expo/hub-components/theme.css';
 import '../global.css';
-import { DeviceScreen, displayScreen, useActiveDeviceClient } from '@expo/hub-client';
+import {
+  DeviceScreen,
+  displayScreen,
+  useActiveDeviceClient,
+  type DeviceStreamMode,
+} from '@expo/hub-client';
 import {
   EmptyState,
   LogSidebar,
@@ -48,6 +53,7 @@ const DEFAULT_SIDEBAR_WIDTH = 400;
 const MIN_SIDEBAR_WIDTH = 280;
 const MAX_SIDEBAR_WIDTH = 560;
 const MIN_STREAM_WIDTH = 320;
+const DEFAULT_STREAM_MODE: DeviceStreamMode = 'h264';
 
 /**
  * Clamp a dragged sidebar width to `[MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH]`, and
@@ -85,6 +91,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   const logsNarrow = useIsNarrow(LOGS_MAX_WIDTH);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [logsOpen, setLogsOpen] = useState(true);
+  const [streamMode] = useState<DeviceStreamMode>(DEFAULT_STREAM_MODE);
   // Draggable widths for each inline sidebar. The `*Start` refs snapshot the
   // width when a drag begins so each move re-derives width from the start point
   // (delta-from-start), which clamps cleanly without drifting.
@@ -204,7 +211,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   // selected device. Null until the user picks one, so nothing connects (or
   // boots) on load.
   const client = useActiveDeviceClient(
-    selected ? { platform: selected.platform, device: selected.id } : null,
+    selected ? { platform: selected.platform, device: selected.id, streamMode } : null,
     basePath()
   );
 

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -58,7 +58,7 @@ const DEFAULT_SIDEBAR_WIDTH = 400;
 const MIN_SIDEBAR_WIDTH = 280;
 const MAX_SIDEBAR_WIDTH = 560;
 const MIN_STREAM_WIDTH = 320;
-const DEFAULT_STREAM_MODE: DeviceStreamMode = 'h264';
+const DEFAULT_STREAM_MODE: DeviceStreamMode = 'mjpeg';
 
 /**
  * Clamp a dragged sidebar width to `[MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH]`, and

--- a/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveStreamMode, streamModeAvailability } from '../streamMode';
+
+describe('stream mode availability', () => {
+  test('enables all modes in a capable secure context such as localhost', () => {
+    expect(
+      streamModeAvailability({ secureContext: true, h264Decoder: true, webRtc: true }),
+    ).toEqual({ mjpeg: true, h264: true, webrtc: true });
+  });
+
+  test('disables H.264 and WebRTC on insecure LAN HTTP', () => {
+    const availability = streamModeAvailability({
+      secureContext: false,
+      h264Decoder: true,
+      webRtc: true,
+    });
+    expect(availability).toEqual({ mjpeg: true, h264: false, webrtc: false });
+    expect(resolveStreamMode('h264', availability)).toBe('mjpeg');
+    expect(resolveStreamMode('webrtc', availability)).toBe('mjpeg');
+  });
+
+  test('keeps MJPEG available when optional browser APIs are missing', () => {
+    const availability = streamModeAvailability({
+      secureContext: true,
+      h264Decoder: false,
+      webRtc: false,
+    });
+    expect(resolveStreamMode('mjpeg', availability)).toBe('mjpeg');
+    expect(resolveStreamMode('h264', availability)).toBe('mjpeg');
+  });
+});

--- a/packages/expo-device-hub/src/dashboard/streamMode.ts
+++ b/packages/expo-device-hub/src/dashboard/streamMode.ts
@@ -1,0 +1,40 @@
+import { type DeviceStreamMode } from '@expo/hub-client';
+import { type StreamModeAvailability } from '@expo/hub-components';
+
+export interface StreamBrowserFeatures {
+  secureContext: boolean;
+  h264Decoder: boolean;
+  webRtc: boolean;
+}
+
+/** Derive selectable transports without granting secure-only APIs on LAN HTTP. */
+export function streamModeAvailability(
+  features: StreamBrowserFeatures,
+): StreamModeAvailability {
+  return {
+    mjpeg: true,
+    h264: features.secureContext && features.h264Decoder,
+    webrtc: features.secureContext && features.webRtc,
+  };
+}
+
+export function browserStreamModeAvailability(): StreamModeAvailability {
+  if (typeof window === 'undefined') {
+    return { mjpeg: true, h264: false, webrtc: false };
+  }
+  return streamModeAvailability({
+    secureContext: window.isSecureContext,
+    h264Decoder: typeof window.VideoDecoder !== 'undefined',
+    webRtc:
+      typeof window.RTCPeerConnection !== 'undefined' &&
+      typeof window.RTCRtpReceiver !== 'undefined',
+  });
+}
+
+/** Keep the requested mode when available, otherwise use the universal MJPEG path. */
+export function resolveStreamMode(
+  requested: DeviceStreamMode,
+  availability: StreamModeAvailability,
+): DeviceStreamMode {
+  return availability[requested] ? requested : 'mjpeg';
+}


### PR DESCRIPTION
For iOS simulators only. 

Carries over H.264 and WebRTC implementation from expo/serve-sim fork to the hub-client package.

Also adds UI to the hub-components for selecting the different streaming modes.

Updates the expo-device-hub to default to MJPEG streaming mode.