### PR TITLE
Add selectable H.264 and WebRTC streaming

### DIFF
--- a/.changeset/select-stream-transport.md
+++ b/.changeset/select-stream-transport.md
@@ -1,0 +1,6 @@
+---
+'@expo/hub-client': minor
+'expo-device-hub': minor
+---
+
+Add selectable MJPEG, H.264, and WebRTC simulator streaming with secure-origin availability controls.

--- a/packages/@expo/hub-client/src/DeviceScreen.tsx
+++ b/packages/@expo/hub-client/src/DeviceScreen.tsx
@@ -20,8 +20,8 @@ const FINGER_CURSOR =
 /**
  * Shared renderer for a live {@link DeviceClient}, used in place of the static
  * `<img>` inside {@link PhoneFrame}. It paints whatever element the active
- * implementation asks for (`<canvas>` for serve-emu H.264, `<img>` for serve-sim
- * MJPEG) and forwards normalized pointer input.
+ * implementation asks for (`<canvas>` for H.264, `<video>` for WebRTC, or
+ * `<img>` for MJPEG) and forwards normalized pointer input.
  *
  * Input is measured in *display* space (the hook remaps to the device's raw
  * frame for the current orientation). Single-finger drags go through
@@ -240,6 +240,8 @@ export function DeviceScreen({ client, borderRadius, squircle }: DeviceScreenPro
     <div style={surfaceStyle}>
       {videoKind === 'canvas' ? (
         <canvas ref={attachVideo} style={mediaStyle} />
+      ) : videoKind === 'video' ? (
+        <video ref={attachVideo} muted playsInline autoPlay style={mediaStyle} />
       ) : (
         <img ref={attachVideo} alt="Device screen" draggable={false} style={mediaStyle} />
       )}

--- a/packages/@expo/hub-client/src/__tests__/avcc.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/avcc.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { AVCC_TAG_DESCRIPTION, AVCC_TAG_KEYFRAME, AvccDemuxer, avcCodecString } from "../avcc";
+
+function envelope(tag: number, payload: number[]): Uint8Array {
+  const bytes = new Uint8Array(payload.length + 5);
+  new DataView(bytes.buffer).setUint32(0, payload.length + 1);
+  bytes[4] = tag;
+  bytes.set(payload, 5);
+  return bytes;
+}
+
+describe("AvccDemuxer", () => {
+  test("buffers split envelopes and emits complete chunks in order", () => {
+    const demuxer = new AvccDemuxer();
+    const description = envelope(AVCC_TAG_DESCRIPTION, [1, 0x64, 0, 0x28]);
+    const frame = envelope(AVCC_TAG_KEYFRAME, [7, 8, 9]);
+    const joined = new Uint8Array(description.length + frame.length);
+    joined.set(description);
+    joined.set(frame, description.length);
+
+    expect(demuxer.push(joined.subarray(0, 7))).toEqual([]);
+    expect(demuxer.push(joined.subarray(7))).toEqual([
+      { type: "description", payload: new Uint8Array([1, 0x64, 0, 0x28]) },
+      { type: "keyframe", payload: new Uint8Array([7, 8, 9]) },
+    ]);
+  });
+
+  test("reset drops a partial envelope", () => {
+    const demuxer = new AvccDemuxer();
+    const frame = envelope(AVCC_TAG_KEYFRAME, [1, 2, 3]);
+    demuxer.push(frame.subarray(0, 6));
+    demuxer.reset();
+    expect(demuxer.push(frame)).toEqual([{ type: "keyframe", payload: new Uint8Array([1, 2, 3]) }]);
+  });
+});
+
+describe("avcCodecString", () => {
+  test("reads profile, constraints, and level from an avcC description", () => {
+    expect(avcCodecString(new Uint8Array([1, 0x64, 0, 0x28]))).toBe("avc1.640028");
+  });
+
+  test("returns the baseline codec for a malformed description", () => {
+    expect(avcCodecString(new Uint8Array([1, 2, 3]))).toBe("avc1.42E01E");
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-negotiation.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-negotiation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  closeWebRtcSession,
+  postWebRtcOffer,
+  WebRtcSignalingBusyError,
+  WebRtcSignalingTimeoutError,
+} from "../webrtc-negotiation";
+
+describe("WebRTC signaling", () => {
+  test("uses a fresh request deadline after a busy response", async () => {
+    const signals: AbortSignal[] = [];
+    let requests = 0;
+    const response = await postWebRtcOffer({
+      url: "https://example.test/webrtc/offer",
+      body: "{}",
+      requestTimeoutMs: 100,
+      busyRetryIntervalMs: 0,
+      busyRetryCount: 1,
+      fetchImpl: async (_url, init) => {
+        signals.push(init?.signal as AbortSignal);
+        requests++;
+        return new Response(null, { status: requests === 1 ? 409 : 200 });
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  test("reports signaling contention after exhausting busy retries", async () => {
+    await expect(
+      postWebRtcOffer({
+        url: "https://example.test/webrtc/offer",
+        body: "{}",
+        requestTimeoutMs: 100,
+        busyRetryIntervalMs: 0,
+        busyRetryCount: 1,
+        fetchImpl: async () => new Response(null, { status: 409 }),
+      }),
+    ).rejects.toBeInstanceOf(WebRtcSignalingBusyError);
+  });
+
+  test("reports a timeout for an individual signaling request", async () => {
+    await expect(
+      postWebRtcOffer({
+        url: "https://example.test/webrtc/offer",
+        body: "{}",
+        requestTimeoutMs: 5,
+        busyRetryIntervalMs: 0,
+        busyRetryCount: 0,
+        fetchImpl: async (_url, init) => {
+          await new Promise<void>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          });
+          return new Response();
+        },
+      }),
+    ).rejects.toBeInstanceOf(WebRtcSignalingTimeoutError);
+  });
+
+  test("uses a beacon to release a session during pagehide", async () => {
+    let fetched = false;
+    const beaconBodies: Blob[] = [];
+    await closeWebRtcSession({
+      url: "https://example.test/webrtc/close",
+      sessionId: "session-1",
+      keepalive: true,
+      sendBeacon: (_url, body) => {
+        beaconBodies.push(body as Blob);
+        return true;
+      },
+      fetchImpl: async () => {
+        fetched = true;
+        return new Response();
+      },
+    });
+
+    expect(fetched).toBe(false);
+    expect(await beaconBodies[0]?.text()).toBe('{"sessionId":"session-1"}');
+  });
+});

--- a/packages/@expo/hub-client/src/avcc.ts
+++ b/packages/@expo/hub-client/src/avcc.ts
@@ -1,0 +1,104 @@
+/**
+ * Wire parser for serve-sim's `/stream.avcc` H.264 stream.
+ *
+ * Each envelope is `[length:u32-be][tag:u8][payload...]`, where `length`
+ * includes the tag byte. The parser keeps incomplete envelopes between reads
+ * because a single video frame is commonly split across network chunks.
+ */
+
+export const AVCC_TAG_DESCRIPTION = 0x01;
+export const AVCC_TAG_KEYFRAME = 0x02;
+export const AVCC_TAG_DELTA = 0x03;
+export const AVCC_TAG_SEED = 0x04;
+
+export type AvccChunkType = "description" | "keyframe" | "delta" | "seed";
+
+export interface AvccChunk {
+  type: AvccChunkType;
+  payload: Uint8Array;
+}
+
+const TAG_TO_TYPE: Record<number, AvccChunkType | undefined> = {
+  [AVCC_TAG_DESCRIPTION]: "description",
+  [AVCC_TAG_KEYFRAME]: "keyframe",
+  [AVCC_TAG_DELTA]: "delta",
+  [AVCC_TAG_SEED]: "seed",
+};
+
+export class AvccDemuxer {
+  private buffer = new Uint8Array(64 * 1024);
+  private length = 0;
+  private start = 0;
+
+  private append(bytes: Uint8Array): void {
+    if (this.length + bytes.length > this.buffer.length) {
+      if (this.start > 0) {
+        this.buffer.copyWithin(0, this.start, this.length);
+        this.length -= this.start;
+        this.start = 0;
+      }
+      if (this.length + bytes.length > this.buffer.length) {
+        let capacity = this.buffer.length;
+        while (capacity < this.length + bytes.length) capacity *= 2;
+        const grown = new Uint8Array(capacity);
+        grown.set(this.buffer.subarray(0, this.length));
+        this.buffer = grown;
+      }
+    }
+    this.buffer.set(bytes, this.length);
+    this.length += bytes.length;
+  }
+
+  push(bytes: Uint8Array): AvccChunk[] {
+    if (bytes.length > 0) this.append(bytes);
+
+    const chunks: AvccChunk[] = [];
+    const buffer = this.buffer;
+    while (this.length - this.start >= 4) {
+      const offset = this.start;
+      const length =
+        ((buffer[offset]! << 24) |
+          (buffer[offset + 1]! << 16) |
+          (buffer[offset + 2]! << 8) |
+          buffer[offset + 3]!) >>>
+        0;
+      if (this.length - offset - 4 < length) break;
+      if (length < 1) {
+        this.start += 4;
+        continue;
+      }
+      const type = TAG_TO_TYPE[buffer[offset + 4]!];
+      if (type) {
+        chunks.push({ type, payload: buffer.slice(offset + 5, offset + 4 + length) });
+      }
+      this.start += 4 + length;
+    }
+
+    if (this.start > 0) {
+      if (this.start < this.length) this.buffer.copyWithin(0, this.start, this.length);
+      this.length -= this.start;
+      this.start = 0;
+    }
+    return chunks;
+  }
+
+  reset(): void {
+    this.length = 0;
+    this.start = 0;
+  }
+}
+
+/** Build an `avc1.PPCCLL` WebCodecs string from an avcC description. */
+export function avcCodecString(description: Uint8Array): string {
+  if (description.length < 4) return "avc1.42E01E";
+  const hex = (byte: number) => byte.toString(16).padStart(2, "0");
+  return `avc1.${hex(description[1]!)}${hex(description[2]!)}${hex(description[3]!)}`;
+}
+
+export function isAvccSupported(): boolean {
+  return (
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as typeof globalThis & { VideoDecoder?: unknown }).VideoDecoder !==
+      "undefined"
+  );
+}

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -21,6 +21,9 @@ import { type CSSProperties } from 'react';
 
 export type DevicePlatform = 'ios' | 'android';
 
+/** Playback pipeline requested by the Hub UI. The client intentionally has no default. */
+export type DeviceStreamMode = 'h264' | 'webrtc' | 'mjpeg';
+
 /**
  * Lifecycle of a single connection:
  *   idle       — nothing to connect to (no base URL / disabled)
@@ -134,10 +137,12 @@ export interface DeviceConnectionOptions {
    * helper via `/api?device=<udid>`; when omitted the first available is used.
    */
   device?: string | null;
+  /** Playback pipeline selected by the host UI. Required so the client owns no default policy. */
+  streamMode: DeviceStreamMode;
 }
 
 /** Which element the implementation paints into. */
-export type VideoSurfaceKind = 'canvas' | 'img';
+export type VideoSurfaceKind = 'canvas' | 'img' | 'video';
 
 /**
  * The live state + controls for one device connection. Returned by the hook and
@@ -182,7 +187,9 @@ export interface DeviceClient {
    * Ref callback for the paint target. The hook owns the element: for `canvas`
    * it decodes frames into it; for `img` it points its `src` at the stream.
    */
-  attachVideo: (el: HTMLCanvasElement | HTMLImageElement | null) => void;
+  attachVideo: (
+    el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null,
+  ) => void;
 
   /** Forward a normalized touch/drag to the device. */
   sendTouch: (sample: TouchSample) => void;

--- a/packages/@expo/hub-client/src/useActiveDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useActiveDeviceClient.ts
@@ -1,5 +1,5 @@
 import { endpointFor } from './connections';
-import { type DeviceClient, type DevicePlatform } from './types';
+import { type DeviceClient, type DevicePlatform, type DeviceStreamMode } from './types';
 import { useAndroidDeviceClient } from './useAndroidDevice';
 import { useIosDeviceClient } from './useIosDevice';
 import { NOOP_DEVICE_CLIENT } from './useNoopDeviceClient';
@@ -18,6 +18,7 @@ export interface ActiveDeviceTarget {
 export function useActiveDeviceClient(
   target: ActiveDeviceTarget | null,
   hubBase: string,
+  streamMode: DeviceStreamMode,
 ): DeviceClient {
   const iosActive = target?.platform === 'ios';
   const androidActive = target?.platform === 'android';
@@ -26,11 +27,13 @@ export function useActiveDeviceClient(
     enabled: iosActive,
     baseUrl: iosActive ? endpointFor('ios', hubBase) : null,
     device: iosActive ? target?.device ?? null : null,
+    streamMode,
   });
   const android = useAndroidDeviceClient({
     enabled: androidActive,
     baseUrl: androidActive ? endpointFor('android', hubBase) : null,
     device: androidActive ? target?.device ?? null : null,
+    streamMode,
   });
 
   if (iosActive) return ios;

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -110,9 +110,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   // unique even though lines are kept (the stream effect may re-run).
   const logSeqRef = useRef(0);
 
-  const attachVideo = useCallback((el: HTMLCanvasElement | HTMLImageElement | null) => {
-    canvasRef.current = (el as HTMLCanvasElement) ?? null;
-  }, []);
+  const attachVideo = useCallback(
+    (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
+      canvasRef.current = (el as HTMLCanvasElement) ?? null;
+    },
+    [],
+  );
 
   const attachLogs = useCallback(() => setLogsEnabled(true), []);
   const detachLogs = useCallback(() => setLogsEnabled(false), []);

--- a/packages/@expo/hub-client/src/useAvccStream.ts
+++ b/packages/@expo/hub-client/src/useAvccStream.ts
@@ -1,0 +1,183 @@
+import { useEffect, useRef } from "react";
+
+import { AvccDemuxer, avcCodecString, isAvccSupported, type AvccChunkType } from "./avcc";
+
+interface AvccStreamCallbacks {
+  onFirstFrame?: () => void;
+  onFrame?: () => void;
+  onResize?: (width: number, height: number) => void;
+  onError?: (message: string) => void;
+}
+
+const RETRY_DELAY_MS = 1000;
+const FRAME_DURATION_US = 16_667;
+
+/** Decode serve-sim's H.264 AVCC response into a canvas with WebCodecs. */
+export function useAvccStream({
+  url,
+  enabled,
+  canvasRef,
+  onFirstFrame,
+  onFrame,
+  onResize,
+  onError,
+}: {
+  url: string;
+  enabled: boolean;
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+} & AvccStreamCallbacks): void {
+  const callbacks = useRef({ onFirstFrame, onFrame, onResize, onError });
+  callbacks.current = { onFirstFrame, onFrame, onResize, onError };
+
+  useEffect(() => {
+    if (!enabled || !url || !isAvccSupported()) return;
+
+    const controller = new AbortController();
+    const demuxer = new AvccDemuxer();
+    let stopped = false;
+    let painted = false;
+    let timestamp = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let decoder: VideoDecoder | null = null;
+
+    const isLive = () => !stopped && !controller.signal.aborted;
+
+    const paint = (source: CanvasImageSource, width: number, height: number) => {
+      if (!isLive()) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+        callbacks.current.onResize?.(width, height);
+      }
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      context.drawImage(source, 0, 0, width, height);
+      callbacks.current.onFrame?.();
+      if (!painted) {
+        painted = true;
+        callbacks.current.onFirstFrame?.();
+      }
+    };
+
+    const makeDecoder = () =>
+      new VideoDecoder({
+        output: (frame) => {
+          try {
+            if (isLive()) paint(frame, frame.displayWidth, frame.displayHeight);
+          } finally {
+            frame.close();
+          }
+        },
+        error: (error) => callbacks.current.onError?.(`H.264 decoder failed: ${error.message}`),
+      });
+
+    const paintSeed = async (jpeg: Uint8Array) => {
+      const bitmap = await createImageBitmap(new Blob([jpeg as BlobPart], { type: "image/jpeg" }));
+      try {
+        if (isLive()) paint(bitmap, bitmap.width, bitmap.height);
+      } finally {
+        bitmap.close();
+      }
+    };
+
+    const configureDecoder = (description: Uint8Array) => {
+      if (!decoder || decoder.state === "closed") decoder = makeDecoder();
+      try {
+        decoder.configure({
+          codec: avcCodecString(description),
+          description,
+          optimizeFor: "latency",
+          hardwareAcceleration: "prefer-hardware",
+        } as VideoDecoderConfig & { optimizeFor: "latency" });
+      } catch (error) {
+        callbacks.current.onError?.(
+          `H.264 decoder configuration failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    };
+
+    const decodeFrame = (type: "keyframe" | "delta", data: Uint8Array) => {
+      if (decoder?.state !== "configured") return;
+      try {
+        decoder.decode(
+          new EncodedVideoChunk({
+            type: type === "keyframe" ? "key" : "delta",
+            timestamp,
+            data,
+          }),
+        );
+        timestamp += FRAME_DURATION_US;
+      } catch {
+        // A reconnect starts with a fresh decoder description and keyframe.
+      }
+    };
+
+    const handleChunk = (type: AvccChunkType, payload: Uint8Array) => {
+      switch (type) {
+        case "seed":
+          void paintSeed(payload).catch(() => {});
+          break;
+        case "description":
+          configureDecoder(payload);
+          break;
+        case "keyframe":
+        case "delta":
+          decodeFrame(type, payload);
+          break;
+      }
+    };
+
+    const scheduleRetry = () => {
+      if (!isLive() || retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        void read();
+      }, RETRY_DELAY_MS);
+    };
+
+    const read = async () => {
+      demuxer.reset();
+      try {
+        const response = await fetch(`${url.replace(/\/$/, "")}/stream.avcc`, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+        if (!response.ok) {
+          callbacks.current.onError?.(`H.264 stream failed: HTTP ${response.status}`);
+          return;
+        }
+        const reader = response.body?.getReader();
+        if (!reader) {
+          callbacks.current.onError?.("H.264 stream returned no response body.");
+          return;
+        }
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+          for (const chunk of demuxer.push(value)) handleChunk(chunk.type, chunk.payload);
+        }
+      } catch {
+        // Abort and transient network errors share the reconnect path.
+      } finally {
+        if (isLive()) scheduleRetry();
+      }
+    };
+
+    void read();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      controller.abort();
+      demuxer.reset();
+      if (decoder && decoder.state !== "closed") {
+        try {
+          decoder.close();
+        } catch {}
+      }
+    };
+  }, [url, enabled, canvasRef]);
+}

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -7,10 +7,10 @@
  *   1. `GET <base>/api` → the live config: the helper `url`/`streamUrl`/`wsUrl`,
  *      the `device` udid, the per-session `execToken`, and the `logsEndpoint` /
  *      `gridApiEndpoint` route paths.
- *   2. Video: MJPEG `<img>` from the helper's `streamUrl`. Input + screen config:
- *      the helper's binary WebSocket (`0x03` touch, `0x04` button, `0x05`
- *      multi-touch out; `0x82` screen config in). Coordinates are mapped to the
- *      device's raw frame per orientation (see `./orientation`).
+ *   2. Video: caller-selected MJPEG, HTTP H.264/AVCC, or WebRTC, matching the
+ *      serve-sim UI. Input + screen config use the helper's binary WebSocket
+ *      (`0x03` touch, `0x04` button, `0x05` multi-touch out; `0x82` screen
+ *      config in). Coordinates are mapped to the raw frame per orientation.
  *   3. Logs: streamed over the middleware's **exec-ws** WebSocket exactly like
  *      the serve-sim client — `{token}` → `{sub, path: logsEndpoint}` → `{sub,
  *      data}` (raw SSE) — rather than a direct route on the helper (the helper
@@ -24,6 +24,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isAvccSupported } from './avcc';
 import {
   HID_EDGE_BOTTOM,
   homeIndicatorEdge,
@@ -48,6 +49,8 @@ import {
   type TouchSample,
 } from './types';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
+import { useAvccStream } from './useAvccStream';
+import { useWebRtcStream } from './useWebRtcStream';
 
 const MAX_LOGS = 200;
 const RECONNECT_MS = 1500;
@@ -239,6 +242,8 @@ function execWsCommand(
 
 /** Resolved connection: where to stream video/input, and how to reach logs/devices. */
 interface ResolvedConfig {
+  /** Same-origin helper base used by H.264 and WebRTC endpoints. */
+  helperUrl: string;
   streamUrl: string;
   wsUrl: string;
   device: string | null;
@@ -267,12 +272,13 @@ interface PreviewApi {
 }
 
 export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClient {
-  const { baseUrl, enabled = true, device: targetDevice = null } = options;
+  const { baseUrl, enabled = true, device: targetDevice = null, streamMode } = options;
   const active = enabled && !!baseUrl;
 
   const [status, setStatus] = useState<ConnectionStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [screen, setScreen] = useState<ScreenSize | null>(null);
+  const [fps, setFps] = useState(0);
   const [logs, setLogs] = useState<DeviceLog[]>([]);
   // Logs are opt-in: nothing streams until the user attaches.
   const [logsEnabled, setLogsEnabled] = useState(false);
@@ -289,7 +295,10 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   // unique even though lines are kept (the stream effect may re-run).
   const logSeqRef = useRef(0);
   const imgRef = useRef<HTMLImageElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamUrlRef = useRef<string | null>(null);
+  const fpsRef = useRef({ count: 0, startedAt: performance.now() });
   // True while the in-flight single-finger drag began in the home-indicator band.
   const edgeGestureRef = useRef(false);
   // Latest screen config, read by the (stable) input callbacks for orientation.
@@ -308,12 +317,27 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   }, []);
 
   const attachVideo = useCallback(
-    (el: HTMLCanvasElement | HTMLImageElement | null) => {
-      imgRef.current = (el as HTMLImageElement) ?? null;
-      if (el) applyStreamSrc();
+    (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
+      if (streamMode === 'h264') canvasRef.current = (el as HTMLCanvasElement) ?? null;
+      else if (streamMode === 'webrtc') videoRef.current = (el as HTMLVideoElement) ?? null;
+      else {
+        imgRef.current = (el as HTMLImageElement) ?? null;
+        if (el) applyStreamSrc();
+      }
     },
-    [applyStreamSrc],
+    [applyStreamSrc, streamMode],
   );
+
+  const recordFrame = useCallback(() => {
+    const counter = fpsRef.current;
+    counter.count++;
+    const now = performance.now();
+    if (now - counter.startedAt < 1000) return;
+    const next = Math.round((counter.count * 1000) / (now - counter.startedAt));
+    counter.count = 0;
+    counter.startedAt = now;
+    setFps((previous) => (previous === next ? previous : next));
+  }, []);
 
   const sendTouch = useCallback((sample: TouchSample) => {
     const ws = wsRef.current;
@@ -448,6 +472,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       const c = proxyPreviewConfigForBrowser(rawConfig, window.location);
       const basePath = c.basePath ?? '';
       return {
+        helperUrl: c.url!,
         streamUrl: c.streamUrl ?? `${c.url}/stream.mjpeg`,
         wsUrl: toQueryStyleHelperWsUrl(c.wsUrl ?? `${toWs(c.url!)}/ws`),
         device: c.device ?? null,
@@ -497,10 +522,20 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     };
   }, [active, baseUrl, targetDevice]);
 
+  const helperUrl = config?.helperUrl ?? '';
+  useEffect(() => {
+    fpsRef.current = { count: 0, startedAt: performance.now() };
+    setFps(0);
+    if (helperUrl) {
+      setStatus('connecting');
+      setError(null);
+    }
+  }, [helperUrl, streamMode]);
+
   // ── MJPEG video (<img>) ──
   const streamUrl = config?.streamUrl ?? null;
   useEffect(() => {
-    if (!streamUrl) {
+    if (streamMode !== 'mjpeg' || !streamUrl) {
       streamUrlRef.current = null;
       return;
     }
@@ -550,9 +585,111 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       img?.removeEventListener('error', onError);
       const el = imgRef.current;
       if (el) el.removeAttribute('src');
-      setScreen(null);
     };
-  }, [streamUrl, applyStreamSrc]);
+  }, [streamMode, streamUrl, applyStreamSrc]);
+
+  // ── HTTP H.264 (`/stream.avcc`) decoded into a canvas with WebCodecs. ──
+  useEffect(() => {
+    if (streamMode !== 'h264' || !helperUrl || isAvccSupported()) return;
+    setStatus('error');
+    setError('H.264 requires WebCodecs in a secure browser context.');
+  }, [helperUrl, streamMode]);
+  useAvccStream({
+    url: helperUrl,
+    enabled: active && streamMode === 'h264',
+    canvasRef,
+    onFirstFrame: () => {
+      setStatus('streaming');
+      setError(null);
+    },
+    onFrame: recordFrame,
+    onResize: (width, height) => {
+      if (hasWsConfigRef.current) return;
+      setScreen((previous) =>
+        previous?.width === width && previous.height === height
+          ? previous
+          : { width, height },
+      );
+    },
+    onError: (message) => {
+      setStatus('error');
+      setError(message);
+    },
+  });
+
+  // ── WebRTC: same receive-only offer/answer flow as the serve-sim UI. ──
+  const {
+    error: webRtcError,
+    markFrameDecoded: markWebRtcFrameDecoded,
+    stream: webRtcStream,
+  } = useWebRtcStream({
+    offerUrl: helperUrl ? `${helperUrl.replace(/\/$/, '')}/webrtc/offer` : '',
+    closeUrl: helperUrl ? `${helperUrl.replace(/\/$/, '')}/webrtc/close` : '',
+    enabled: active && streamMode === 'webrtc',
+    codec: 'h264',
+  });
+  useEffect(() => {
+    if (streamMode !== 'webrtc') return;
+    if (webRtcError) {
+      setStatus('error');
+      setError(webRtcError);
+    } else if (!webRtcStream) {
+      setStatus('connecting');
+      setError(null);
+    }
+  }, [streamMode, webRtcError, webRtcStream]);
+  useEffect(() => {
+    if (streamMode !== 'webrtc') return;
+    const video = videoRef.current;
+    if (!video) return;
+
+    let stopped = false;
+    let firstFrame = true;
+    let callbackId = 0;
+    const updateDimensions = () => {
+      if (hasWsConfigRef.current || video.videoWidth <= 0 || video.videoHeight <= 0) return;
+      setScreen((previous) =>
+        previous?.width === video.videoWidth && previous.height === video.videoHeight
+          ? previous
+          : { width: video.videoWidth, height: video.videoHeight },
+      );
+    };
+    const markFrame = () => {
+      if (stopped) return;
+      updateDimensions();
+      recordFrame();
+      if (firstFrame) {
+        firstFrame = false;
+        markWebRtcFrameDecoded();
+        setStatus('streaming');
+        setError(null);
+      }
+    };
+    const onVideoFrame = () => {
+      markFrame();
+      callbackId = video.requestVideoFrameCallback(onVideoFrame);
+    };
+    const onTimeUpdate = () => markFrame();
+
+    video.srcObject = webRtcStream;
+    if (webRtcStream) {
+      const hasVideoFrameCallback = typeof video.requestVideoFrameCallback === 'function';
+      if (hasVideoFrameCallback) callbackId = video.requestVideoFrameCallback(onVideoFrame);
+      else video.addEventListener('timeupdate', onTimeUpdate);
+      video.addEventListener('loadeddata', markFrame, { once: true });
+      void video.play().catch(() => {});
+    }
+
+    return () => {
+      stopped = true;
+      video.removeEventListener('loadeddata', markFrame);
+      video.removeEventListener('timeupdate', onTimeUpdate);
+      if (callbackId && typeof video.cancelVideoFrameCallback === 'function') {
+        video.cancelVideoFrameCallback(callbackId);
+      }
+      video.srcObject = null;
+    };
+  }, [markWebRtcFrameDecoded, recordFrame, streamMode, webRtcStream]);
 
   // ── Helper control WebSocket (touch/buttons out, screen config in) ──
   const wsUrl = config?.wsUrl ?? null;
@@ -810,7 +947,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     status,
     error,
     screen,
-    fps: 0,
+    fps,
     devices,
     logs,
     logsEnabled,
@@ -818,7 +955,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     detachLogs,
     clearLogs,
     foregroundApp,
-    videoKind: 'img',
+    videoKind: streamMode === 'h264' ? 'canvas' : streamMode === 'webrtc' ? 'video' : 'img',
     attachVideo,
     sendTouch,
     sendMultiTouch,

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  closeWebRtcSession,
+  postWebRtcOffer,
+  WebRtcSignalingBusyError,
+  WebRtcSignalingTimeoutError,
+} from "./webrtc-negotiation";
+
+export type WebRtcCodec = "h264" | "vp8" | "vp9";
+export type WebRtcStreamFailure =
+  | { sessionId: string; kind: "permanent" }
+  | { sessionId: string; kind: "codec"; codec: WebRtcCodec };
+
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+  { urls: ["stun:stun.l.google.com:19302"] },
+  { urls: ["stun:stun1.l.google.com:19302"] },
+];
+const ICE_GATHERING_TIMEOUT_MS = 3_000;
+const SIGNALING_REQUEST_TIMEOUT_MS = 20_000;
+const FIRST_FRAME_TIMEOUT_MS = 4_000;
+const BUSY_RETRY_INTERVAL_MS = 500;
+const BUSY_RETRY_COUNT = 30;
+const TRANSPORT_RETRY_BASE_MS = 500;
+const TRANSPORT_RETRY_MAX_MS = 5_000;
+
+function createSessionId(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** Negotiate and own one receive-only serve-sim WebRTC session. */
+export function useWebRtcStream({
+  offerUrl,
+  closeUrl,
+  enabled,
+  codec,
+  iceServers,
+}: {
+  offerUrl: string;
+  closeUrl: string;
+  enabled: boolean;
+  codec: WebRtcCodec;
+  iceServers?: RTCIceServer[];
+}) {
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [failure, setFailure] = useState<WebRtcStreamFailure | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [retryGeneration, setRetryGeneration] = useState(0);
+  const firstFrameTimeoutRef = useRef<number | undefined>(undefined);
+  const firstFrameDecodedRef = useRef(false);
+  const transportRetryAttemptRef = useRef(0);
+
+  const markFrameDecoded = useCallback(() => {
+    firstFrameDecodedRef.current = true;
+    transportRetryAttemptRef.current = 0;
+    if (firstFrameTimeoutRef.current !== undefined) {
+      window.clearTimeout(firstFrameTimeoutRef.current);
+      firstFrameTimeoutRef.current = undefined;
+    }
+    setFailure(null);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    transportRetryAttemptRef.current = 0;
+  }, [enabled, offerUrl, closeUrl, codec, iceServers]);
+
+  useEffect(() => {
+    if (!enabled || !offerUrl || !closeUrl) return;
+    setFailure(null);
+    if (typeof RTCPeerConnection === "undefined" || typeof RTCRtpReceiver === "undefined") {
+      setStream(null);
+      setError("WebRTC is not supported by this browser.");
+      setFailure({ sessionId: createSessionId(), kind: "permanent" });
+      return;
+    }
+
+    let stopped = false;
+    let peer: RTCPeerConnection | null = null;
+    let retryTimer: number | undefined;
+    let closePromise: Promise<void> | null = null;
+    let failing = false;
+    const lifecycleController = new AbortController();
+    const sessionId = createSessionId();
+    const servers = iceServers?.length ? iceServers : DEFAULT_ICE_SERVERS;
+    setStream(null);
+    setFailure(null);
+    setError(null);
+    firstFrameDecodedRef.current = false;
+    if (firstFrameTimeoutRef.current !== undefined) {
+      window.clearTimeout(firstFrameTimeoutRef.current);
+      firstFrameTimeoutRef.current = undefined;
+    }
+
+    const closeRemoteSession = (keepalive = false): Promise<void> => {
+      if (closePromise) return closePromise;
+      closePromise = closeWebRtcSession({ url: closeUrl, sessionId, keepalive });
+      return closePromise;
+    };
+    const releaseOnPageHide = () => void closeRemoteSession(true);
+    window.addEventListener("pagehide", releaseOnPageHide);
+    window.addEventListener("beforeunload", releaseOnPageHide);
+
+    const closePeer = () => {
+      setStream(null);
+      peer?.close();
+    };
+
+    const failPermanently = (message: string) => {
+      if (stopped || failing) return;
+      failing = true;
+      setError(message);
+      setFailure({ sessionId, kind: "permanent" });
+      closePeer();
+      void closeRemoteSession();
+    };
+
+    const failCodec = () => {
+      if (stopped || failing) return;
+      failing = true;
+      setError("WebRTC connected, but the browser could not decode its video.");
+      closePeer();
+      void closeRemoteSession().finally(() => {
+        if (!stopped) setFailure({ sessionId, kind: "codec", codec });
+      });
+    };
+
+    const retryTransport = (message: string) => {
+      if (stopped || failing) return;
+      failing = true;
+      setFailure(null);
+      const attempt = transportRetryAttemptRef.current++;
+      const delay = Math.min(
+        TRANSPORT_RETRY_BASE_MS * 2 ** Math.min(attempt, 4),
+        TRANSPORT_RETRY_MAX_MS,
+      );
+      setError(`${message} Retrying…`);
+      closePeer();
+      void closeRemoteSession().finally(() => {
+        if (stopped) return;
+        retryTimer = window.setTimeout(() => {
+          if (!stopped) setRetryGeneration((generation) => generation + 1);
+        }, delay);
+      });
+    };
+
+    const waitForIce = (connection: RTCPeerConnection) =>
+      new Promise<void>((resolve) => {
+        if (connection.iceGatheringState === "complete") {
+          resolve();
+          return;
+        }
+        let timeout: number | undefined;
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          connection.removeEventListener("icegatheringstatechange", onState);
+          if (timeout !== undefined) window.clearTimeout(timeout);
+          resolve();
+        };
+        const onState = () => {
+          if (connection.iceGatheringState === "complete") finish();
+        };
+        connection.addEventListener("icegatheringstatechange", onState);
+        timeout = window.setTimeout(finish, ICE_GATHERING_TIMEOUT_MS);
+      });
+
+    void (async () => {
+      try {
+        peer = new RTCPeerConnection({ iceServers: servers, iceTransportPolicy: "all" });
+
+        const transceiver = peer.addTransceiver("video", { direction: "recvonly" });
+        const capabilities = RTCRtpReceiver.getCapabilities("video");
+        const preferredMimeType =
+          codec === "h264" ? "video/H264" : codec === "vp9" ? "video/VP9" : "video/VP8";
+        if (capabilities?.codecs.length && "setCodecPreferences" in transceiver) {
+          const preferred = preferredMimeType.toLowerCase();
+          transceiver.setCodecPreferences([
+            ...capabilities.codecs.filter(
+              (candidate) => candidate.mimeType.toLowerCase() === preferred,
+            ),
+            ...capabilities.codecs.filter(
+              (candidate) => candidate.mimeType.toLowerCase() !== preferred,
+            ),
+          ]);
+        }
+
+        peer.ontrack = (event) => {
+          if (stopped) return;
+          firstFrameDecodedRef.current = false;
+          event.track.onended = () => retryTransport("WebRTC video track ended.");
+          setStream(event.streams[0] ?? new MediaStream([event.track]));
+          if (firstFrameTimeoutRef.current !== undefined) {
+            window.clearTimeout(firstFrameTimeoutRef.current);
+          }
+          firstFrameTimeoutRef.current = window.setTimeout(() => {
+            firstFrameTimeoutRef.current = undefined;
+            if (stopped || firstFrameDecodedRef.current) return;
+            if (peer?.connectionState === "connected") failCodec();
+            else retryTransport("WebRTC did not establish a video path.");
+          }, FIRST_FRAME_TIMEOUT_MS);
+        };
+        peer.onconnectionstatechange = () => {
+          if (!stopped && peer?.connectionState === "failed") {
+            retryTransport("WebRTC connection failed.");
+          }
+        };
+
+        const offer = await peer.createOffer();
+        await peer.setLocalDescription(offer);
+        await waitForIce(peer);
+        const local = peer.localDescription;
+        if (!local) throw new Error("WebRTC offer was not created");
+        const response = await postWebRtcOffer({
+          url: offerUrl,
+          signal: lifecycleController.signal,
+          requestTimeoutMs: SIGNALING_REQUEST_TIMEOUT_MS,
+          busyRetryIntervalMs: BUSY_RETRY_INTERVAL_MS,
+          busyRetryCount: BUSY_RETRY_COUNT,
+          body: JSON.stringify({
+            type: local.type,
+            sdp: local.sdp,
+            sessionId,
+            codec,
+            iceServers: servers,
+          }),
+        });
+        if (!response.ok) {
+          await response.body?.cancel();
+          failPermanently(`WebRTC offer failed: HTTP ${response.status}`);
+          return;
+        }
+        const answer = (await response.json()) as RTCSessionDescriptionInit;
+        if (stopped) {
+          await closeRemoteSession(true);
+          return;
+        }
+        try {
+          await peer.setRemoteDescription(answer);
+        } catch {
+          failPermanently("WebRTC returned an invalid session description.");
+        }
+      } catch (caught) {
+        if (stopped || lifecycleController.signal.aborted) return;
+        if (caught instanceof WebRtcSignalingBusyError) {
+          failPermanently(caught.message);
+          return;
+        }
+        const message =
+          caught instanceof WebRtcSignalingTimeoutError
+            ? "WebRTC signaling timed out."
+            : "WebRTC signaling failed.";
+        retryTransport(message);
+      }
+    })();
+
+    return () => {
+      stopped = true;
+      window.removeEventListener("pagehide", releaseOnPageHide);
+      window.removeEventListener("beforeunload", releaseOnPageHide);
+      lifecycleController.abort();
+      if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+      if (firstFrameTimeoutRef.current !== undefined) {
+        window.clearTimeout(firstFrameTimeoutRef.current);
+        firstFrameTimeoutRef.current = undefined;
+      }
+      void closeRemoteSession(true);
+      setStream(null);
+      peer?.close();
+    };
+  }, [enabled, offerUrl, closeUrl, codec, iceServers, retryGeneration]);
+
+  return { stream, failure, error, markFrameDecoded };
+}

--- a/packages/@expo/hub-client/src/webrtc-negotiation.ts
+++ b/packages/@expo/hub-client/src/webrtc-negotiation.ts
@@ -1,0 +1,128 @@
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+type SendBeaconLike = (url: string | URL, data?: BodyInit | null) => boolean;
+
+export class WebRtcSignalingBusyError extends Error {
+  constructor() {
+    super("WebRTC signaling stayed busy for too long. Reload to try again.");
+    this.name = "WebRtcSignalingBusyError";
+  }
+}
+
+export class WebRtcSignalingTimeoutError extends Error {
+  constructor() {
+    super("WebRTC signaling timed out.");
+    this.name = "WebRtcSignalingTimeoutError";
+  }
+}
+
+function abortError(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+function waitForRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(finish, delayMs);
+    function finish() {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }
+    function abort() {
+      clearTimeout(timer);
+      reject(
+        signal ? abortError(signal) : new DOMException("The operation was aborted", "AbortError"),
+      );
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+export async function closeWebRtcSession({
+  url,
+  sessionId,
+  keepalive = false,
+  sendBeacon,
+  fetchImpl = fetch,
+}: {
+  url: string;
+  sessionId: string;
+  keepalive?: boolean;
+  sendBeacon?: SendBeaconLike;
+  fetchImpl?: FetchLike;
+}): Promise<void> {
+  const body = JSON.stringify({ sessionId });
+  const beacon =
+    sendBeacon ??
+    (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function"
+      ? navigator.sendBeacon.bind(navigator)
+      : undefined);
+  if (keepalive && beacon) {
+    try {
+      if (beacon(url, new Blob([body], { type: "text/plain;charset=UTF-8" }))) return;
+    } catch {}
+  }
+  await fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive,
+  }).then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+/** Post an SDP offer, retrying while native offer setup is busy. */
+export async function postWebRtcOffer({
+  url,
+  body,
+  signal,
+  requestTimeoutMs,
+  busyRetryIntervalMs,
+  busyRetryCount,
+  fetchImpl = fetch,
+}: {
+  url: string;
+  body: string;
+  signal?: AbortSignal;
+  requestTimeoutMs: number;
+  busyRetryIntervalMs: number;
+  busyRetryCount: number;
+  fetchImpl?: FetchLike;
+}): Promise<Response> {
+  for (let attempt = 0; attempt <= busyRetryCount; attempt++) {
+    if (signal?.aborted) throw abortError(signal);
+
+    const requestController = new AbortController();
+    let timedOut = false;
+    const abortRequest = () => requestController.abort(signal ? abortError(signal) : undefined);
+    signal?.addEventListener("abort", abortRequest, { once: true });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      requestController.abort();
+    }, requestTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: requestController.signal,
+        body,
+      });
+    } catch (error) {
+      if (timedOut && !signal?.aborted) throw new WebRtcSignalingTimeoutError();
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abortRequest);
+    }
+
+    if (response.status !== 409) return response;
+    await response.body?.cancel();
+    if (attempt === busyRetryCount) throw new WebRtcSignalingBusyError();
+    await waitForRetry(busyRetryIntervalMs, signal);
+  }
+
+  throw new WebRtcSignalingBusyError();
+}

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -2,6 +2,7 @@ import { type DeviceClient } from '@expo/hub-client';
 import { SidebarToggle } from '../primitives';
 import { CurrentAppSection } from './CurrentAppSection';
 import { OutputSection } from './OutputSection';
+import { StreamSettingsSection, type StreamSettingsProps } from './StreamSettingsSection';
 
 /**
  * Right column: the selected device's output (Current app + Logs). Mirrors the
@@ -12,12 +13,15 @@ import { OutputSection } from './OutputSection';
 export function LogSidebar({
   onToggle,
   client,
+  streamSettings,
   width = 400,
 }: {
   /** When set, a sidebar toggle is shown to collapse this panel. */
   onToggle?: () => void;
   /** Active device connection — feeds the current-app and logs panels. */
   client?: DeviceClient;
+  /** iOS playback controls. Omitted for Android devices and empty states. */
+  streamSettings?: StreamSettingsProps;
   /** Column width in px, driven by the resize handle. Defaults to 400. */
   width?: number;
 }) {
@@ -41,6 +45,7 @@ export function LogSidebar({
         </div>
       )}
       <CurrentAppSection client={client} />
+      {streamSettings && <StreamSettingsSection {...streamSettings} />}
       <OutputSection client={client} />
     </aside>
   );

--- a/packages/@expo/hub-components/src/dashboard/StreamSettingsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSettingsSection.tsx
@@ -1,0 +1,63 @@
+import { type DeviceStreamMode } from '@expo/hub-client';
+import { useId, useState } from 'react';
+
+import { bg, border, radius, text, textSize } from '../primitives';
+
+export interface StreamSettingsProps {
+  mode: DeviceStreamMode;
+  onModeChange: (mode: DeviceStreamMode) => void;
+  secureModesAvailable: boolean;
+}
+
+/** Playback transport selector for the iOS stream in the right sidebar. */
+export function StreamSettingsSection({
+  mode,
+  onModeChange,
+  secureModesAvailable,
+}: StreamSettingsProps) {
+  const selectId = useId();
+  const descriptionId = useId();
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <label
+        htmlFor={selectId}
+        style={{ ...textSize.sm, fontWeight: 500, color: text.default }}>
+        Stream
+      </label>
+      <select
+        id={selectId}
+        aria-describedby={!secureModesAvailable ? descriptionId : undefined}
+        value={mode}
+        onChange={(event) => onModeChange(event.target.value as DeviceStreamMode)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        style={{
+          ...textSize.base,
+          width: '100%',
+          minHeight: 44,
+          padding: '8px 12px',
+          color: text.default,
+          backgroundColor: bg.default,
+          border: `1px solid ${focused ? border.info : border.default}`,
+          borderRadius: radius.md,
+          boxShadow: focused ? `0 0 0 3px ${bg.info}` : 'none',
+          outline: 'none',
+        }}>
+        <option value="h264" disabled={!secureModesAvailable}>
+          H.264
+        </option>
+        <option value="webrtc" disabled={!secureModesAvailable}>
+          WebRTC
+        </option>
+        <option value="mjpeg">MJPEG</option>
+      </select>
+      {!secureModesAvailable && (
+        <p id={descriptionId} style={{ ...textSize.xs, margin: 0, color: text.secondary }}>
+          Use localhost or HTTPS to enable H.264 and WebRTC.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -47,6 +47,10 @@ export * from './theme/tokens';
 // types-only devDependency) so this library never imports the client at runtime.
 export { Sidebar } from './dashboard/Sidebar';
 export { LogSidebar } from './dashboard/LogSidebar';
+export {
+  StreamSettingsSection,
+  type StreamSettingsProps,
+} from './dashboard/StreamSettingsSection';
 export { StreamPanel } from './dashboard/StreamPanel';
 export { EmptyState } from './dashboard/EmptyState';
 export { DeviceSection, type DeviceSectionProps } from './dashboard/DeviceSection';

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -2,7 +2,12 @@
 
 import '@expo/hub-components/theme.css';
 import '../global.css';
-import { DeviceScreen, displayScreen, useActiveDeviceClient } from '@expo/hub-client';
+import {
+  DeviceScreen,
+  displayScreen,
+  useActiveDeviceClient,
+  type DeviceStreamMode,
+} from '@expo/hub-client';
 import {
   EmptyState,
   LogSidebar,
@@ -25,6 +30,7 @@ import { useColorScheme } from './dashboard/useColorScheme';
 import { useDeviceLists } from './dashboard/useDevices';
 import { useIsNarrow } from './dashboard/useIsNarrow';
 import { useNewDeviceOptions } from './dashboard/useNewDeviceOptions';
+import { initialStreamMode, supportsSecureStreamModes } from './dashboard/streamMode';
 
 /** Append `extra` devices not already present in `base` (deduped by id). */
 function mergeById(base: Device[], extra: Device[]): Device[] {
@@ -79,6 +85,14 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   // Installed runtimes/system images and models for the new-device forms.
   const newDeviceOptions = useNewDeviceOptions();
   const [selectedId, setSelectedId] = useState('');
+  const secureModesAvailable = supportsSecureStreamModes({
+    protocol: window.location.protocol,
+    hostname: window.location.hostname,
+    isSecureContext: window.isSecureContext,
+  });
+  const [streamMode, setStreamMode] = useState<DeviceStreamMode>(() =>
+    initialStreamMode(secureModesAvailable)
+  );
   // Devices started through the picker, retained until host discovery catches up.
   const [added, setAdded] = useState<Device[]>([]);
   const narrow = useIsNarrow(NARROW_MAX_WIDTH);
@@ -206,8 +220,13 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   const client = useActiveDeviceClient(
     selected ? { platform: selected.platform, device: selected.id } : null,
     basePath(),
-    'h264'
+    streamMode
   );
+
+  const streamSettings =
+    selected?.platform === 'ios'
+      ? { mode: streamMode, onModeChange: setStreamMode, secureModesAvailable }
+      : undefined;
 
   return (
     <div
@@ -293,7 +312,12 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
               )
             }
           />
-          <LogSidebar client={client} onToggle={() => setLogsOpen(false)} width={logsWidth} />
+          <LogSidebar
+            client={client}
+            streamSettings={streamSettings}
+            onToggle={() => setLogsOpen(false)}
+            width={logsWidth}
+          />
         </>
       )}
 
@@ -356,7 +380,12 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
               backgroundColor: bg.subtle,
               boxShadow: shadow.lg,
             }}>
-            <LogSidebar client={client} onToggle={() => setLogsOpen(false)} width={logsWidth} />
+            <LogSidebar
+              client={client}
+              streamSettings={streamSettings}
+              onToggle={() => setLogsOpen(false)}
+              width={logsWidth}
+            />
           </div>
         </>
       )}

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -205,7 +205,8 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   // boots) on load.
   const client = useActiveDeviceClient(
     selected ? { platform: selected.platform, device: selected.id } : null,
-    basePath()
+    basePath(),
+    'h264'
   );
 
   return (

--- a/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  DEFAULT_STREAM_MODE,
+  initialStreamMode,
+  supportsSecureStreamModes,
+} from '../streamMode';
+
+function supports(protocol: string, hostname: string, isSecureContext = false): boolean {
+  return supportsSecureStreamModes({ protocol, hostname, isSecureContext });
+}
+
+describe('stream mode availability', () => {
+  test('keeps H.264 as the Hub default on supported origins', () => {
+    expect(DEFAULT_STREAM_MODE).toBe('h264');
+    expect(initialStreamMode(true)).toBe('h264');
+  });
+
+  test('allows local HTTP development', () => {
+    expect(supports('http:', 'localhost')).toBe(true);
+    expect(supports('http:', 'dev.localhost')).toBe(true);
+    expect(supports('http:', '127.0.0.1')).toBe(true);
+    expect(supports('http:', '[::1]')).toBe(true);
+  });
+
+  test('allows secure contexts and HTTPS', () => {
+    expect(supports('http:', 'device.test', true)).toBe(true);
+    expect(supports('https:', 'device.test')).toBe(true);
+  });
+
+  test('uses MJPEG and disables secure modes on insecure LAN origins', () => {
+    expect(supports('http:', '192.168.1.25')).toBe(false);
+    expect(initialStreamMode(false)).toBe('mjpeg');
+  });
+});

--- a/packages/expo-device-hub/src/dashboard/streamMode.ts
+++ b/packages/expo-device-hub/src/dashboard/streamMode.ts
@@ -1,0 +1,32 @@
+import { type DeviceStreamMode } from '@expo/hub-client';
+
+/** The Hub owns playback policy; hub-client always receives an explicit mode. */
+export const DEFAULT_STREAM_MODE: DeviceStreamMode = 'h264';
+
+export interface StreamEnvironment {
+  protocol: string;
+  hostname: string;
+  isSecureContext: boolean;
+}
+
+/**
+ * WebCodecs and WebRTC are only offered from trustworthy origins. Browsers
+ * treat loopback HTTP as trustworthy, but check it explicitly so localhost
+ * development keeps working in environments that report isSecureContext late.
+ */
+export function supportsSecureStreamModes(environment: StreamEnvironment): boolean {
+  if (environment.isSecureContext || environment.protocol === 'https:') return true;
+
+  const hostname = environment.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  return (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1'
+  );
+}
+
+/** Fall back to the universally available MJPEG pipeline on insecure LAN URLs. */
+export function initialStreamMode(secureModesAvailable: boolean): DeviceStreamMode {
+  return secureModesAvailable ? DEFAULT_STREAM_MODE : 'mjpeg';
+}


### PR DESCRIPTION
## Summary

- port serve-sim’s AVCC/WebCodecs and receive-only WebRTC playback paths into `@expo/hub-client`
- add an iOS stream selector to the Hub’s right panel while keeping the client API policy-free
- keep H.264 as the Hub default on localhost/HTTPS and fall back to MJPEG on insecure LAN origins, where H.264 and WebRTC are disabled
- add transport, signaling, and origin-policy coverage plus a release changeset

## Verification

- `bun install --frozen-lockfile`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- example app at `http://localhost:8081/_expo/plugins/expo-device-hub`: H.264 canvas and WebRTC video both rendered live simulator frames
- example app at `http://192.168.0.224:8081/_expo/plugins/expo-device-hub`: MJPEG rendered and H.264/WebRTC were disabled