### PR TITLE
feat(cli): add `--platform ios|android`

### DIFF
--- a/.changeset/green-cats-smile.md
+++ b/.changeset/green-cats-smile.md
@@ -2,4 +2,4 @@
 'expo-device-hub': minor
 ---
 
-Add `--platform ios|android` to the standalone CLI to show and discover only the selected platform.
+Add `--platform ios|android` to the standalone CLI.

--- a/.changeset/green-cats-smile.md
+++ b/.changeset/green-cats-smile.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add `--platform ios|android` to the standalone CLI to show and discover only the selected platform.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
+Pass `--platform` to focus the standalone dashboard on one platform:
+
+```sh
+npx expo-device-hub --platform ios
+npx expo-device-hub --platform android
+```
+
 ## Repository structure
 
 This is a [Bun](https://bun.sh) workspace orchestrated with [Turborepo](https://turbo.build).

--- a/packages/@expo/hub-components/src/dashboard/EmptyState.tsx
+++ b/packages/@expo/hub-components/src/dashboard/EmptyState.tsx
@@ -1,11 +1,25 @@
 import { PhoneIcon, bg, border, heading, icon, radius, shadow, text, textSize } from '../primitives';
+import { type Platform } from './data';
 
 /**
  * Shown in the stream panel when no devices are available — i.e. there are no
  * booted simulators, emulators, or connected physical devices to mirror. Points
  * the user at the sidebar's + buttons to boot one.
  */
-export function EmptyState() {
+export function EmptyState({ platform }: { platform?: Platform }) {
+  const title =
+    platform === 'ios'
+      ? 'No booted simulators'
+      : platform === 'android'
+        ? 'No booted emulators'
+        : 'No booted devices';
+  const description =
+    platform === 'ios'
+      ? 'There are no booted simulators. Use the + button to add one.'
+      : platform === 'android'
+        ? 'There are no booted emulators or connected devices. Use the + button to add one.'
+        : 'There are no booted simulators, emulators, or connected devices. Use the + button to add a simulator or emulator.';
+
   return (
     <section
       style={{
@@ -41,10 +55,9 @@ export function EmptyState() {
         }}>
         <PhoneIcon size={28} color={icon.secondary} />
       </div>
-      <h2 style={{ ...heading.lg, color: text.default, margin: 0 }}>No booted devices</h2>
+      <h2 style={{ ...heading.lg, color: text.default, margin: 0 }}>{title}</h2>
       <p style={{ ...textSize.sm, color: text.secondary, margin: 0, maxWidth: 320 }}>
-        There are no booted simulators, emulators, or connected devices. Use the + button to add a
-        simulator or emulator.
+        {description}
       </p>
     </section>
   );

--- a/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   type AddDeviceTarget,
   type Device,
   type NewDeviceOptions,
+  type Platform,
 } from './data';
 
 /** Left column: simulators + emulators lists. The device output (logs) lives in {@link LogSidebar}. */
@@ -19,6 +20,7 @@ export function Sidebar({
   onSelect,
   onAddDevice,
   onToggle,
+  platform,
   width = 400,
 }: {
   /** Simulators to list — real iOS devices from the plugin server. */
@@ -39,6 +41,8 @@ export function Sidebar({
   onAddDevice: (target: AddDeviceTarget) => Promise<AddDeviceOutcome>;
   /** When set, a sidebar toggle is shown right-aligned in the logo row. */
   onToggle?: () => void;
+  /** Restrict the sidebar to one platform. Both sections render by default. */
+  platform?: Platform;
   /** Column width in px, driven by the resize handle. Defaults to 400. */
   width?: number;
 }) {
@@ -60,30 +64,34 @@ export function Sidebar({
         <Logo />
         {onToggle && <SidebarToggle onClick={onToggle} />}
       </div>
-      <DeviceSection
-        title="Simulators"
-        addLabel="Add simulator"
-        kind="simulator"
-        emptyLabel="No booted simulators. Use the + button to add one."
-        devices={simulators}
-        recent={recentSimulators}
-        options={simulatorOptions}
-        selectedId={selectedId}
-        onSelect={onSelect}
-        onAdd={onAddDevice}
-      />
-      <DeviceSection
-        title="Emulators"
-        addLabel="Add emulator"
-        kind="emulator"
-        emptyLabel="No booted emulators or devices. Use the + button to add one."
-        devices={emulators}
-        recent={recentEmulators}
-        options={emulatorOptions}
-        selectedId={selectedId}
-        onSelect={onSelect}
-        onAdd={onAddDevice}
-      />
+      {platform !== 'android' && (
+        <DeviceSection
+          title="Simulators"
+          addLabel="Add simulator"
+          kind="simulator"
+          emptyLabel="No booted simulators. Use the + button to add one."
+          devices={simulators}
+          recent={recentSimulators}
+          options={simulatorOptions}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onAdd={onAddDevice}
+        />
+      )}
+      {platform !== 'ios' && (
+        <DeviceSection
+          title="Emulators"
+          addLabel="Add emulator"
+          kind="emulator"
+          emptyLabel="No booted emulators or devices. Use the + button to add one."
+          devices={emulators}
+          recent={recentEmulators}
+          options={emulatorOptions}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onAdd={onAddDevice}
+        />
+      )}
     </aside>
   );
 }

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -57,6 +57,13 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
+Pass `--platform` to focus the standalone dashboard on one platform:
+
+```sh
+npx expo-device-hub --platform ios
+npx expo-device-hub --platform android
+```
+
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/public/index.html
+++ b/packages/expo-device-hub/public/index.html
@@ -14,6 +14,10 @@
         if (mount.charAt(0) !== '{' && window.__EXPO_DEVICE_HUB_BASE_PATH__ == null) {
           window.__EXPO_DEVICE_HUB_BASE_PATH__ = mount;
         }
+        var platform = '{{platform}}';
+        if (platform === 'ios' || platform === 'android') {
+          window.__EXPO_DEVICE_HUB_PLATFORM__ = platform;
+        }
       })();
     </script>
     <!-- The `react-native-web` recommended style reset: https://necolas.github.io/react-native-web/docs/setup/#root-element -->

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -35,6 +35,7 @@ import {
   browserStreamModeAvailability,
   resolveStreamMode,
 } from './dashboard/streamMode';
+import { dashboardPlatformFilter } from './platform-filter';
 
 /** Append `extra` devices not already present in `base` (deduped by id). */
 function mergeById(base: Device[], extra: Device[]): Device[] {
@@ -86,6 +87,7 @@ function clampSidebarWidth(width: number, otherWidth: number): number {
  */
 export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps }) {
   const scheme = useColorScheme();
+  const platform = dashboardPlatformFilter();
   const { booted, recent } = useDeviceLists();
   // Installed runtimes/system images and models for the new-device forms.
   const newDeviceOptions = useNewDeviceOptions();
@@ -118,19 +120,23 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   // id and split back into the two sections by platform.
   const simulators = useMemo(
     () =>
-      mergeById(
-        booted.simulators,
-        added.filter((device) => device.platform === 'ios')
-      ),
-    [booted.simulators, added]
+      platform === 'android'
+        ? []
+        : mergeById(
+            booted.simulators,
+            added.filter((device) => device.platform === 'ios')
+          ),
+    [booted.simulators, added, platform]
   );
   const emulators = useMemo(
     () =>
-      mergeById(
-        booted.emulators,
-        added.filter((device) => device.platform === 'android')
-      ),
-    [booted.emulators, added]
+      platform === 'ios'
+        ? []
+        : mergeById(
+            booted.emulators,
+            added.filter((device) => device.platform === 'android')
+          ),
+    [booted.emulators, added, platform]
   );
 
   // Create/boot the chosen target on the host. The modal awaits this result, so
@@ -259,6 +265,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
             onSelect={setSelectedId}
             onAddDevice={handleAddDevice}
             onToggle={() => setSidebarOpen(false)}
+            platform={platform}
             width={sidebarWidth}
           />
           {/* Drag the seam between the devices sidebar and the stream to resize. */}
@@ -291,7 +298,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           framed={!narrow}
         />
       ) : (
-        <EmptyState />
+        <EmptyState platform={platform} />
       )}
 
       {/* Room for two sidebars + open: the logs sidebar sits inline to the right of the stream. */}
@@ -356,6 +363,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
               onSelect={setSelectedId}
               onAddDevice={handleAddDevice}
               onToggle={() => setSidebarOpen(false)}
+              platform={platform}
               width={sidebarWidth}
             />
           </div>

--- a/packages/expo-device-hub/src/dashboard/__tests__/platformFilter.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/platformFilter.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { dashboardPlatformFilter, parsePlatformFilter } from '../../platform-filter';
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('parsePlatformFilter', () => {
+  test('accepts only iOS and Android', () => {
+    expect(parsePlatformFilter('ios')).toBe('ios');
+    expect(parsePlatformFilter('android')).toBe('android');
+    expect(parsePlatformFilter('web')).toBeUndefined();
+    expect(parsePlatformFilter(undefined)).toBeUndefined();
+  });
+});
+
+describe('dashboardPlatformFilter', () => {
+  test('reads the platform provided by the standalone shell', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_PLATFORM__: 'ios' };
+    expect(dashboardPlatformFilter()).toBe('ios');
+  });
+
+  test('returns undefined when the shell provides no platform', () => {
+    expect(dashboardPlatformFilter()).toBeUndefined();
+  });
+});

--- a/packages/expo-device-hub/src/platform-filter.ts
+++ b/packages/expo-device-hub/src/platform-filter.ts
@@ -1,0 +1,17 @@
+export type PlatformFilter = 'ios' | 'android';
+
+export function parsePlatformFilter(value: unknown): PlatformFilter | undefined {
+  return value === 'ios' || value === 'android' ? value : undefined;
+}
+
+declare global {
+  interface Window {
+    __EXPO_DEVICE_HUB_PLATFORM__?: PlatformFilter;
+  }
+}
+
+/** Platform selected by the standalone CLI, or undefined when both should be shown. */
+export function dashboardPlatformFilter(): PlatformFilter | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return parsePlatformFilter(window.__EXPO_DEVICE_HUB_PLATFORM__);
+}

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseCliOptions } from '../cli/options';
+
+describe('parseCliOptions', () => {
+  test('keeps the existing defaults when no options are provided', () => {
+    expect(parseCliOptions([])).toEqual({
+      port: undefined,
+      host: '127.0.0.1',
+      platform: undefined,
+      help: false,
+    });
+  });
+
+  test('accepts each supported platform', () => {
+    expect(parseCliOptions(['--platform', 'ios']).platform).toBe('ios');
+    expect(parseCliOptions(['--platform=android']).platform).toBe('android');
+  });
+
+  test('rejects unsupported platforms', () => {
+    expect(() => parseCliOptions(['--platform', 'web'])).toThrow('Invalid --platform: web');
+  });
+
+  test('parses the existing host, port, and help options', () => {
+    expect(parseCliOptions(['--host', '0.0.0.0', '-p', '4300'])).toEqual({
+      port: 4300,
+      host: '0.0.0.0',
+      platform: undefined,
+      help: false,
+    });
+    expect(parseCliOptions(['--help'])).toEqual({ host: '127.0.0.1', help: true });
+  });
+});

--- a/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { configureClientShell } from '../client-shell';
+
+describe('configureClientShell', () => {
+  const shell = '<base href="{{mount}}/"> <script>var platform = "{{platform}}"</script>';
+
+  test('leaves the platform empty when the CLI option is omitted', () => {
+    expect(configureClientShell(shell, '', undefined)).toBe(
+      '<base href="/"> <script>var platform = ""</script>'
+    );
+  });
+
+  test('injects the selected platform and mount path', () => {
+    expect(configureClientShell(shell, '/hub', 'android')).toBe(
+      '<base href="/hub/"> <script>var platform = "android"</script>'
+    );
+  });
+});

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -1,27 +1,15 @@
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { networkInterfaces } from 'node:os';
-import { parseArgs } from 'node:util';
 import { WebSocketServer } from 'ws';
 import { URL } from 'node:url';
 
 import { requestOrigin, toFetchRequest, toUpgradeRequest, writeFetchResponse } from './cli/node-fetch-server';
+import { DEFAULT_PORT, HELP, parseCliOptions, type CliOptions } from './cli/options';
 import { staticFileHandler } from './cli/static-files';
 
 type HubServerModule = typeof import('./index');
 type WebSocketRouteHandler = (socket: unknown, request: Request, server: WebSocketServer) => void;
-
-const DEFAULT_PORT = 3400;
-
-const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
-
-Usage: expo-device-hub [options]
-
-Options:
-  -p, --port <port>  Port to listen on (default: ${DEFAULT_PORT}, or the next available port)
-      --host <host>  Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on your local network)
-  -h, --help         Show this help
-`;
 
 function fail(message: string): never {
   console.error(message);
@@ -62,32 +50,23 @@ function tryListen(server: Server, port: number, host: string): Promise<boolean>
 }
 
 async function main(): Promise<void> {
-  let values: { port?: string; host: string; help: boolean };
+  let options: CliOptions;
   try {
-    ({ values } = parseArgs({
-      options: {
-        port: { type: 'string', short: 'p' },
-        // Bind the IPv4 loopback explicitly: 'localhost' resolves to ::1 first on
-        // macOS, but serve-sim's in-process state mints 127.0.0.1 URLs, so a
-        // v6-only listener leaves the advertised stream/ws endpoints unreachable.
-        host: { type: 'string', default: '127.0.0.1' },
-        help: { type: 'boolean', short: 'h', default: false },
-      },
-    }));
+    options = parseCliOptions(process.argv.slice(2));
   } catch (error) {
-    fail(`${error instanceof Error ? error.message : error}\n\n${HELP}`);
+    fail(error instanceof Error ? error.message : String(error));
   }
-  if (values.help) {
+  if (options.help) {
     console.log(HELP);
     return;
   }
 
-  const explicitPort = values.port !== undefined ? Number(values.port) : undefined;
-  if (explicitPort !== undefined && (!Number.isInteger(explicitPort) || explicitPort < 0 || explicitPort > 65535)) {
-    fail(`Invalid --port: ${values.port}\n\n${HELP}`);
-  }
-
   process.env.EXPO_DEVICE_HUB_BASE_PATH = '';
+  if (options.platform) {
+    process.env.EXPO_DEVICE_HUB_PLATFORM = options.platform;
+  } else {
+    delete process.env.EXPO_DEVICE_HUB_PLATFORM;
+  }
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time
   const hubServer = (await import('./index.mjs')) as HubServerModule;
   const handler = hubServer.default;
@@ -151,13 +130,13 @@ async function main(): Promise<void> {
     });
   }
 
-  if (explicitPort !== undefined) {
-    if (!(await tryListen(server, explicitPort, values.host))) {
-      fail(`Port ${explicitPort} is already in use — pick another with --port.`);
+  if (options.port !== undefined) {
+    if (!(await tryListen(server, options.port, options.host))) {
+      fail(`Port ${options.port} is already in use — pick another with --port.`);
     }
   } else {
     let candidate = DEFAULT_PORT;
-    while (!(await tryListen(server, candidate, values.host))) {
+    while (!(await tryListen(server, candidate, options.host))) {
       candidate++;
       if (candidate > 65535) {
         fail(`No available port found starting from ${DEFAULT_PORT}.`);
@@ -166,18 +145,19 @@ async function main(): Promise<void> {
   }
 
   const boundPort = (server.address() as AddressInfo).port;
-  const isLoopback = values.host === 'localhost' || values.host === '127.0.0.1' || values.host === '::1';
-  const isWildcard = values.host === '0.0.0.0' || values.host === '::';
+  const isLoopback =
+    options.host === 'localhost' || options.host === '127.0.0.1' || options.host === '::1';
+  const isWildcard = options.host === '0.0.0.0' || options.host === '::';
   console.log('Expo Device Hub ready\n');
   if (isLoopback || isWildcard) {
     console.log(`  Local:   http://localhost:${boundPort}`);
   }
   if (isWildcard) {
-    console.log(`  Network: http://${lanAddress() ?? values.host}:${boundPort}`);
+    console.log(`  Network: http://${lanAddress() ?? options.host}:${boundPort}`);
   } else if (isLoopback) {
     console.log('  Network: pass --host 0.0.0.0 to expose on your local network');
   } else {
-    console.log(`  Network: http://${values.host}:${boundPort}`);
+    console.log(`  Network: http://${options.host}:${boundPort}`);
   }
 }
 

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -1,0 +1,57 @@
+import { parseArgs } from 'node:util';
+
+import { parsePlatformFilter, type PlatformFilter } from '../../platform-filter';
+
+export const DEFAULT_PORT = 3400;
+
+export const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
+
+Usage: expo-device-hub [options]
+
+Options:
+  -p, --port <port>          Port to listen on (default: ${DEFAULT_PORT}, or the next available port)
+      --host <host>          Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on your local network)
+      --platform <platform>  Show only iOS simulators or Android emulators (ios or android)
+  -h, --help                 Show this help
+`;
+
+export type CliOptions = {
+  port?: number;
+  host: string;
+  platform?: PlatformFilter;
+  help: boolean;
+};
+
+export function parseCliOptions(args: string[]): CliOptions {
+  let values: { port?: string; host: string; platform?: string; help: boolean };
+  try {
+    ({ values } = parseArgs({
+      args,
+      options: {
+        port: { type: 'string', short: 'p' },
+        // Bind the IPv4 loopback explicitly: 'localhost' resolves to ::1 first on
+        // macOS, but serve-sim's in-process state mints 127.0.0.1 URLs, so a
+        // v6-only listener leaves the advertised stream/ws endpoints unreachable.
+        host: { type: 'string', default: '127.0.0.1' },
+        platform: { type: 'string' },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+    }));
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : error}\n\n${HELP}`);
+  }
+
+  if (values.help) return { host: values.host, help: true };
+
+  const port = values.port !== undefined ? Number(values.port) : undefined;
+  if (port !== undefined && (!Number.isInteger(port) || port < 0 || port > 65535)) {
+    throw new Error(`Invalid --port: ${values.port}\n\n${HELP}`);
+  }
+
+  const platform = parsePlatformFilter(values.platform);
+  if (values.platform !== undefined && platform === undefined) {
+    throw new Error(`Invalid --platform: ${values.platform}\n\n${HELP}`);
+  }
+
+  return { port, host: values.host, platform, help: false };
+}

--- a/packages/expo-device-hub/src/server/client-shell.ts
+++ b/packages/expo-device-hub/src/server/client-shell.ts
@@ -1,0 +1,10 @@
+import { type PlatformFilter } from '../platform-filter';
+
+/** Fill the runtime values consumed by the exported dashboard shell. */
+export function configureClientShell(
+  html: string,
+  mountPath: string,
+  platform: PlatformFilter | undefined
+): string {
+  return html.replaceAll('{{mount}}', mountPath).replaceAll('{{platform}}', platform ?? '');
+}

--- a/packages/expo-device-hub/src/server/device-list-websocket.ts
+++ b/packages/expo-device-hub/src/server/device-list-websocket.ts
@@ -1,5 +1,6 @@
 import { DEVICE_LIST_MESSAGE_TYPE } from '../device-list-protocol';
 import { type HubDevice, type HubDeviceList, listDevices } from './devices';
+import { SERVER_PLATFORM_FILTER } from './platform-filter';
 
 const POLL_INTERVAL_MS = 500;
 
@@ -39,7 +40,7 @@ export class DeviceListBroadcaster {
   #fingerprint: string | null = null;
 
   constructor(options: DeviceListBroadcasterOptions = {}) {
-    this.#load = options.load ?? listDevices;
+    this.#load = options.load ?? (() => listDevices(SERVER_PLATFORM_FILTER));
     this.#intervalMs = options.intervalMs ?? POLL_INTERVAL_MS;
     this.#schedule = options.schedule ?? setTimeout;
     this.#cancelSchedule = options.cancelSchedule ?? clearTimeout;

--- a/packages/expo-device-hub/src/server/devices.ts
+++ b/packages/expo-device-hub/src/server/devices.ts
@@ -17,9 +17,10 @@
 import { type AndroidDevice, listDevices as listAndroidDevices } from '@expo/hub-android-utils';
 import { listDevices as listAppleDevices } from '@expo/hub-apple-utils';
 
+import { type PlatformFilter } from '../platform-filter';
 import { type SerializableError, toSerializableError } from './utility-errors';
 
-export type HubDevicePlatform = 'ios' | 'android';
+export type HubDevicePlatform = PlatformFilter;
 
 export interface HubDevice {
   /** udid (iOS) / serial-or-AVD-name (Android). */
@@ -121,9 +122,13 @@ function latestTimestamp(...timestamps: Array<number | null>): number | undefine
   return available.length > 0 ? Math.max(...available) : undefined;
 }
 
-/** Every known simulator and emulator/device, each tagged with its `booted` state. */
-export async function listDevices(): Promise<HubDeviceList> {
-  const [simulators, emulators] = await Promise.all([listIosSimulators(), listAndroidEmulators()]);
+/** Every requested simulator and emulator/device, each tagged with its `booted` state. */
+export async function listDevices(platform?: PlatformFilter): Promise<HubDeviceList> {
+  const empty = (): PlatformDeviceList => ({ devices: [], error: null });
+  const [simulators, emulators] = await Promise.all([
+    platform === 'android' ? empty() : listIosSimulators(),
+    platform === 'ios' ? empty() : listAndroidEmulators(),
+  ]);
 
   return {
     simulators: simulators.devices,

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -20,9 +20,11 @@ import {
   removeHubDevice,
   shutdownHubDevice,
 } from './device-actions';
+import { configureClientShell } from './client-shell';
 import { deviceListWebSocketHandler, refreshDeviceList } from './device-list-websocket';
 import { type HubDeviceList, listDevices } from './devices';
 import { MOUNT_PATH } from './mount';
+import { SERVER_PLATFORM_FILTER } from './platform-filter';
 import { EMU_PREFIX, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
 import { SIM_PREFIX, handleSimRequest, simWebSocketHandler } from './serve-sim';
 import { listNewDeviceOptions } from './sim-options';
@@ -54,7 +56,7 @@ async function serveClientIndexHtml(): Promise<Response | null> {
       return null;
     }
   }
-  return new Response(clientIndexHtml.replaceAll('{{mount}}', MOUNT_PATH), {
+  return new Response(configureClientShell(clientIndexHtml, MOUNT_PATH, SERVER_PLATFORM_FILTER), {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
@@ -87,7 +89,7 @@ export default async function handler(request: Request): Promise<Response | null
   }
 
   if (pathname === DEVICES_ROUTE) {
-    const devices = await listDevices();
+    const devices = await listDevices(SERVER_PLATFORM_FILTER);
     const bootedOnly = searchParams.get('booted') === 'true' || searchParams.get('booted') === '1';
     return jsonResponse(bootedOnly ? filterBooted(devices) : devices);
   }
@@ -159,7 +161,7 @@ export default async function handler(request: Request): Promise<Response | null
     if (request.method !== 'GET') {
       return jsonResponse({ ok: false, error: 'Method Not Allowed' }, 405);
     }
-    return jsonResponse(await listNewDeviceOptions());
+    return jsonResponse(await listNewDeviceOptions(SERVER_PLATFORM_FILTER));
   }
 
   return null;

--- a/packages/expo-device-hub/src/server/platform-filter.ts
+++ b/packages/expo-device-hub/src/server/platform-filter.ts
@@ -1,0 +1,7 @@
+import { parsePlatformFilter } from '../platform-filter';
+
+/** Set only by the standalone CLI before it imports the server bundle. */
+export const SERVER_PLATFORM_FILTER =
+  process.env.EXPO_DEVICE_HUB_BASE_PATH === ''
+    ? parsePlatformFilter(process.env.EXPO_DEVICE_HUB_PLATFORM)
+    : undefined;

--- a/packages/expo-device-hub/src/server/sim-options.ts
+++ b/packages/expo-device-hub/src/server/sim-options.ts
@@ -9,13 +9,44 @@ import {
 import { type AppleSimulatorRuntime, listRuntimes } from '@expo/hub-apple-utils';
 import { type NewDeviceOptions, type Platform } from '@expo/hub-components';
 
+import { type PlatformFilter } from '../platform-filter';
 import { type SerializableError, toSerializableError } from './utility-errors';
 
 export type NewDeviceOptionsByPlatform = Record<Platform, NewDeviceOptions>;
 export type NewDeviceOptionsResponse = NewDeviceOptionsByPlatform & { errors: SerializableError[] };
 
-/** Discover installed iOS runtimes and Android images/profiles in parallel. */
-export async function listNewDeviceOptions(): Promise<NewDeviceOptionsResponse> {
+const EMPTY_OPTIONS: NewDeviceOptions = { runtimes: [] };
+
+/** Discover installed runtimes and profiles for the requested platform(s). */
+export async function listNewDeviceOptions(
+  platform?: PlatformFilter
+): Promise<NewDeviceOptionsResponse> {
+  if (platform === 'ios') {
+    const appleRuntimes = await listRuntimes();
+    return {
+      ios: appleRuntimesToOptions(appleRuntimes.value),
+      android: EMPTY_OPTIONS,
+      errors: [toSerializableError(appleRuntimes.error)].filter(
+        (error): error is SerializableError => error !== null
+      ),
+    };
+  }
+
+  if (platform === 'android') {
+    const [androidImages, androidProfiles] = await Promise.all([
+      listSystemImages(),
+      listDeviceProfiles(),
+    ]);
+    return {
+      ios: EMPTY_OPTIONS,
+      android: androidImagesToOptions(androidImages.value, androidProfiles.value),
+      errors: [
+        toSerializableError(androidImages.error),
+        toSerializableError(androidProfiles.error),
+      ].filter((error): error is SerializableError => error !== null),
+    };
+  }
+
   const [appleRuntimes, androidImages, androidProfiles] = await Promise.all([
     listRuntimes(),
     listSystemImages(),
@@ -78,10 +109,10 @@ function androidImageLabel(image: AndroidSystemImage): string {
     image.tag === 'google_apis'
       ? 'Google APIs'
       : image.tag === 'google_apis_playstore'
-      ? 'Google Play'
-      : image.tag === 'default'
-      ? 'AOSP'
-      : image.tag?.replaceAll('_', ' ');
+        ? 'Google Play'
+        : image.tag === 'default'
+          ? 'AOSP'
+          : image.tag?.replaceAll('_', ' ');
   return [api, tag, image.abi].filter(Boolean).join(' · ');
 }
 


### PR DESCRIPTION
Adds `--platform ios|android` to the standalone cli, this way when hosted we can hide unsupported platform, android on macos hosts, ios on linux hosts.