### PR TITLE
Handle Expo dev server disconnections

### DIFF
--- a/packages/@expo/hub-components/src/components/icons.tsx
+++ b/packages/@expo/hub-components/src/components/icons.tsx
@@ -153,6 +153,40 @@ export function PowerIcon({ size = 16, color = 'currentColor', strokeWidth = 1.6
   );
 }
 
+/** Lucide-inspired `unplug` — two separated cable ends for connection-loss states. */
+export function CableDisconnectIcon({
+  size = 16,
+  color = 'currentColor',
+  strokeWidth = 1.67,
+  style,
+}: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={style}>
+      <path
+        d="m19 5 3-3M2 22l3-3"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4l2.6 2.6ZM12 6l6 6 2.3-2.3a2.4 2.4 0 0 0 0-3.4l-2.6-2.6a2.4 2.4 0 0 0-3.4 0L12 6Z"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7.5 13.5 10 11m.5 5.5L13 14m1-4 2.5-2.5m.5 6 2.5-2.5"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function TrashIcon({ size = 16, color = 'currentColor', strokeWidth = 1.67, style }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={style}>

--- a/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
+++ b/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
+  CableDisconnectIcon,
   Logo,
-  PowerIcon,
   RefreshIcon,
   bg,
   border,
@@ -36,7 +36,9 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
         minWidth: 0,
         minHeight: '100vh',
         padding: 24,
-        backgroundColor: bg.screen,
+        backgroundColor: `color-mix(in srgb, ${bg.screen} 68%, transparent)`,
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
         color: text.default,
         fontFamily: 'var(--expo-font-sans)',
       }}>
@@ -49,7 +51,7 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
           maxWidth: 440,
           padding: '40px 32px',
           boxSizing: 'border-box',
-          backgroundColor: bg.default,
+          backgroundColor: `color-mix(in srgb, ${bg.default} 92%, transparent)`,
           border: `1px solid ${border.secondary}`,
           borderRadius: radius.xl,
           boxShadow: shadow.sm,
@@ -65,19 +67,19 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
             width: 56,
             height: 56,
             marginBottom: 20,
-            border: `1px solid ${connecting ? border.secondary : border.warning}`,
+            border: `1px solid ${border.secondary}`,
             borderRadius: radius.full,
-            backgroundColor: connecting ? bg.subtle : bg.warning,
+            backgroundColor: connecting ? bg.subtle : bg.default,
           }}>
           {connecting ? (
             <RefreshIcon size={24} color={icon.secondary} />
           ) : (
-            <PowerIcon size={24} color={icon.warning} />
+            <CableDisconnectIcon size={24} color={icon.default} />
           )}
         </div>
         <div aria-live="assertive">
           <h1 style={{ ...heading['2xl'], margin: 0, color: text.default }}>
-            {connecting ? 'Connecting to the Expo dev server' : 'Expo dev server disconnected'}
+            {connecting ? 'Connecting to the Expo dev server' : 'Server disconnected'}
           </h1>
           <p
             style={{
@@ -86,9 +88,15 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
               margin: '12px 0 0',
               color: text.secondary,
             }}>
-            {connecting
-              ? 'If this takes more than a few seconds, restart the Expo dev server in your terminal. Once it is running, reload this page.'
-              : 'Restart the Expo dev server in your terminal. Once it is running again, reload this page.'}
+            {connecting ? (
+              'If this takes more than a few seconds, restart the Expo dev server in your terminal. Once it is running, reload this page.'
+            ) : (
+              <>
+                Restart the server in your terminal.
+                <br />
+                Once started reload this page if necessary.
+              </>
+            )}
           </p>
         </div>
         <Button

--- a/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
+++ b/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
@@ -1,0 +1,105 @@
+import {
+  Button,
+  Logo,
+  PowerIcon,
+  RefreshIcon,
+  bg,
+  border,
+  heading,
+  icon,
+  radius,
+  shadow,
+  text,
+  textSize,
+} from '../primitives';
+
+export type ServerConnectionOverlayProps = {
+  status: 'connecting' | 'disconnected';
+  onReload: () => void;
+};
+
+/** Full-page blocker shown until the dashboard can verify its dev server connection. */
+export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOverlayProps) {
+  const connecting = status === 'connecting';
+
+  return (
+    <main
+      aria-busy={connecting}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 100,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        boxSizing: 'border-box',
+        minWidth: 0,
+        minHeight: '100vh',
+        padding: 24,
+        backgroundColor: bg.screen,
+        color: text.default,
+        fontFamily: 'var(--expo-font-sans)',
+      }}>
+      <section
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          width: '100%',
+          maxWidth: 440,
+          padding: '40px 32px',
+          boxSizing: 'border-box',
+          backgroundColor: bg.default,
+          border: `1px solid ${border.secondary}`,
+          borderRadius: radius.xl,
+          boxShadow: shadow.sm,
+          textAlign: 'center',
+        }}>
+        <Logo style={{ marginBottom: 32 }} />
+        <div
+          aria-hidden="true"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 56,
+            height: 56,
+            marginBottom: 20,
+            border: `1px solid ${connecting ? border.secondary : border.warning}`,
+            borderRadius: radius.full,
+            backgroundColor: connecting ? bg.subtle : bg.warning,
+          }}>
+          {connecting ? (
+            <RefreshIcon size={24} color={icon.secondary} />
+          ) : (
+            <PowerIcon size={24} color={icon.warning} />
+          )}
+        </div>
+        <div aria-live="assertive">
+          <h1 style={{ ...heading['2xl'], margin: 0, color: text.default }}>
+            {connecting ? 'Connecting to the Expo dev server' : 'Expo dev server disconnected'}
+          </h1>
+          <p
+            style={{
+              ...textSize.sm,
+              maxWidth: 360,
+              margin: '12px 0 0',
+              color: text.secondary,
+            }}>
+            {connecting
+              ? 'If this takes more than a few seconds, restart the Expo dev server in your terminal. Once it is running, reload this page.'
+              : 'Restart the Expo dev server in your terminal. Once it is running again, reload this page.'}
+          </p>
+        </div>
+        <Button
+          theme="primary"
+          size="lg"
+          leftSlot={<RefreshIcon size={18} />}
+          onClick={onReload}
+          style={{ marginTop: 24 }}>
+          Reload page
+        </Button>
+      </section>
+    </main>
+  );
+}

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -60,6 +60,10 @@ export { LogRow } from './dashboard/LogRow';
 export { StreamControls } from './dashboard/StreamControls';
 export { RecentDevicesModal, type RecentDevicesModalProps } from './dashboard/RecentDevicesModal';
 export { BootErrorModal, type BootErrorModalProps } from './dashboard/BootErrorModal';
+export {
+  ServerConnectionOverlay,
+  type ServerConnectionOverlayProps,
+} from './dashboard/ServerConnectionOverlay';
 
 // ── Shared dashboard types + config ──
 export * from './dashboard/data';

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -19,6 +19,7 @@ import {
   type Device,
 } from '@expo/hub-components';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { basePath } from './dashboard/basePath';
 import { bootDevice, createDevice, removeDevice, shutdownDevice } from './dashboard/deviceActions';
@@ -211,18 +212,13 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
     basePath()
   );
 
-  if (connectionStatus !== 'connected') {
-    return (
-      <ServerConnectionOverlay
-        status={connectionStatus}
-        onReload={() => window.location.reload()}
-      />
-    );
-  }
+  const connectionBlocked = connectionStatus !== 'connected';
 
   return (
     <div
+      aria-hidden={connectionBlocked || undefined}
       className={scheme === 'dark' ? 'dark-theme' : undefined}
+      inert={connectionBlocked || undefined}
       style={{
         display: 'flex',
         position: 'relative',
@@ -385,6 +381,14 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           <SidebarToggle floating side="right" onClick={() => setLogsOpen(true)} />
         </div>
       )}
+      {connectionBlocked &&
+        createPortal(
+          <ServerConnectionOverlay
+            status={connectionStatus}
+            onReload={() => window.location.reload()}
+          />,
+          document.body
+        )}
     </div>
   );
 }

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   EmptyState,
   LogSidebar,
   ResizeHandle,
+  ServerConnectionOverlay,
   Sidebar,
   SidebarToggle,
   StreamPanel,
@@ -75,7 +76,7 @@ function clampSidebarWidth(width: number, otherWidth: number): number {
  */
 export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps }) {
   const scheme = useColorScheme();
-  const { booted, recent } = useDeviceLists();
+  const { booted, recent, connectionStatus } = useDeviceLists();
   // Installed runtimes/system images and models for the new-device forms.
   const newDeviceOptions = useNewDeviceOptions();
   const [selectedId, setSelectedId] = useState('');
@@ -204,9 +205,20 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   // selected device. Null until the user picks one, so nothing connects (or
   // boots) on load.
   const client = useActiveDeviceClient(
-    selected ? { platform: selected.platform, device: selected.id } : null,
+    connectionStatus === 'connected' && selected
+      ? { platform: selected.platform, device: selected.id }
+      : null,
     basePath()
   );
+
+  if (connectionStatus !== 'connected') {
+    return (
+      <ServerConnectionOverlay
+        status={connectionStatus}
+        onReload={() => window.location.reload()}
+      />
+    );
+  }
 
   return (
     <div

--- a/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { DEVICE_LIST_MESSAGE_TYPE } from '../../device-list-protocol';
+import { DEVICE_LIST_MESSAGE_TYPE, HEARTBEAT_MESSAGE_TYPE } from '../../device-list-protocol';
 import {
   devicesWebSocketUrl,
   parseDeviceListMessage,
+  parseDeviceListSocketMessage,
   splitDeviceList,
+  subscribeToDeviceList,
   type DeviceList,
 } from '../useDevices';
 
@@ -39,24 +41,35 @@ describe('device-list WebSocket client helpers', () => {
   test('builds ws and wss URLs under the configured mount', () => {
     (globalThis as any).window = { __EXPO_DEVICE_HUB_BASE_PATH__: '/hub/' };
     expect(devicesWebSocketUrl('http://localhost:3400/dashboard')).toBe(
-      'ws://localhost:3400/hub/api/devices/ws'
+      'ws://localhost:3400/hub/api/devices/ws',
     );
     expect(devicesWebSocketUrl('https://example.com/dashboard')).toBe(
-      'wss://example.com/hub/api/devices/ws'
+      'wss://example.com/hub/api/devices/ws',
     );
   });
 
   test('accepts device-list messages and ignores other payloads', () => {
     expect(
-      parseDeviceListMessage(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: list }))
+      parseDeviceListMessage(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: list })),
     ).toEqual(list);
     expect(parseDeviceListMessage(JSON.stringify({ type: 'other', devices: list }))).toBeNull();
     expect(parseDeviceListMessage('not json')).toBeNull();
     expect(
       parseDeviceListMessage(
-        JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: { ...list, errors: {} } })
-      )
+        JSON.stringify({
+          type: DEVICE_LIST_MESSAGE_TYPE,
+          devices: { ...list, errors: {} },
+        }),
+      ),
     ).toBeNull();
+  });
+
+  test('accepts heartbeat messages without treating them as device lists', () => {
+    const heartbeat = JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE });
+    expect(parseDeviceListSocketMessage(heartbeat)).toEqual({
+      type: HEARTBEAT_MESSAGE_TYPE,
+    });
+    expect(parseDeviceListMessage(heartbeat)).toBeNull();
   });
 
   test('preserves captured utility errors for the browser console', () => {
@@ -70,8 +83,11 @@ describe('device-list WebSocket client helpers', () => {
 
     expect(
       parseDeviceListMessage(
-        JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: { ...list, errors } })
-      )
+        JSON.stringify({
+          type: DEVICE_LIST_MESSAGE_TYPE,
+          devices: { ...list, errors },
+        }),
+      ),
     ).toEqual({ ...list, errors });
   });
 
@@ -80,5 +96,161 @@ describe('device-list WebSocket client helpers', () => {
       booted: { simulators: [list.simulators[0]], emulators: [] },
       recent: { simulators: [], emulators: [list.emulators[0]] },
     });
+  });
+});
+
+class FakeSocket {
+  closed = false;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  close(): void {
+    this.closed = true;
+  }
+
+  message(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+}
+
+function manualTimers() {
+  let nextId = 1;
+  const timers = new Map<number, { callback: () => void; delay: number }>();
+  return {
+    schedule(callback: () => void, delay: number) {
+      const id = nextId++;
+      timers.set(id, { callback, delay });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    cancelSchedule(timer: ReturnType<typeof setTimeout>) {
+      timers.delete(timer as unknown as number);
+    },
+    runDelay(delay: number) {
+      const entry = [...timers.entries()].find(([, timer]) => timer.delay === delay);
+      if (!entry) throw new Error(`No ${delay}ms timer scheduled`);
+      timers.delete(entry[0]);
+      entry[1].callback();
+    },
+  };
+}
+
+describe('device-list WebSocket subscription', () => {
+  test('reports a closed server immediately after a live connection', () => {
+    const timers = manualTimers();
+    const socket = new FakeSocket();
+    const statuses: string[] = [];
+    const unsubscribe = subscribeToDeviceList({
+      url: 'ws://localhost/devices',
+      createSocket: () => socket,
+      schedule: timers.schedule,
+      cancelSchedule: timers.cancelSchedule,
+      reconnectMinMs: 5,
+      reconnectMaxMs: 20,
+      heartbeatTimeoutMs: 60,
+      onSnapshot: () => {},
+      onStatus: (status) => statuses.push(status),
+    });
+
+    socket.message(JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE }));
+    socket.onclose?.();
+
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
+    unsubscribe();
+  });
+
+  test('times out when the server never sends a valid protocol message', () => {
+    const timers = manualTimers();
+    const socket = new FakeSocket();
+    const statuses: string[] = [];
+    const unsubscribe = subscribeToDeviceList({
+      url: 'ws://localhost/devices',
+      createSocket: () => socket,
+      schedule: timers.schedule,
+      cancelSchedule: timers.cancelSchedule,
+      reconnectMinMs: 5,
+      reconnectMaxMs: 20,
+      heartbeatTimeoutMs: 60,
+      onSnapshot: () => {},
+      onStatus: (status) => statuses.push(status),
+    });
+
+    socket.message('not json');
+    timers.runDelay(60);
+
+    expect(socket.closed).toBe(true);
+    expect(statuses).toEqual(['connecting', 'disconnected']);
+    unsubscribe();
+  });
+
+  test('requires valid messages, detects a missed heartbeat, and reconnects', () => {
+    const timers = manualTimers();
+    const sockets: FakeSocket[] = [];
+    const statuses: string[] = [];
+    const snapshots: unknown[] = [];
+    const unsubscribe = subscribeToDeviceList({
+      url: 'ws://localhost/devices',
+      createSocket: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      schedule: timers.schedule,
+      cancelSchedule: timers.cancelSchedule,
+      reconnectMinMs: 5,
+      reconnectMaxMs: 20,
+      heartbeatTimeoutMs: 60,
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    expect(statuses).toEqual(['connecting']);
+    sockets[0].message('not json');
+    expect(statuses).toEqual(['connecting']);
+
+    sockets[0].message(JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE }));
+    expect(statuses).toEqual(['connecting', 'connected']);
+
+    timers.runDelay(60);
+    expect(sockets[0].closed).toBe(true);
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
+
+    timers.runDelay(5);
+    expect(sockets).toHaveLength(2);
+    sockets[1].message(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: list }));
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected', 'connected']);
+    expect(snapshots).toEqual([list]);
+
+    unsubscribe();
+    expect(sockets[1].closed).toBe(true);
+  });
+
+  test('marks connection failures as disconnected and retries with backoff', () => {
+    const timers = manualTimers();
+    let attempts = 0;
+    const statuses: string[] = [];
+    const unsubscribe = subscribeToDeviceList({
+      url: 'ws://localhost/devices',
+      createSocket: () => {
+        attempts++;
+        throw new Error('server unavailable');
+      },
+      schedule: timers.schedule,
+      cancelSchedule: timers.cancelSchedule,
+      reconnectMinMs: 5,
+      reconnectMaxMs: 20,
+      heartbeatTimeoutMs: 60,
+      onSnapshot: () => {},
+      onStatus: (status) => statuses.push(status),
+    });
+
+    expect(attempts).toBe(1);
+    expect(statuses).toEqual(['connecting', 'disconnected']);
+    timers.runDelay(5);
+    timers.runDelay(10);
+    expect(attempts).toBe(3);
+    expect(statuses).toEqual(['connecting', 'disconnected']);
+
+    unsubscribe();
   });
 });

--- a/packages/expo-device-hub/src/dashboard/useDevices.ts
+++ b/packages/expo-device-hub/src/dashboard/useDevices.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { type Device } from '@expo/hub-components';
 
-import { DEVICE_LIST_MESSAGE_TYPE } from '../device-list-protocol';
+import { DEVICE_LIST_MESSAGE_TYPE, HEARTBEAT_MESSAGE_TYPE } from '../device-list-protocol';
 import { basePath } from './basePath';
 import { isUtilityError, logUtilityErrors, type UtilityError } from './utilityErrors';
 
@@ -24,87 +24,186 @@ export type DeviceList = {
 };
 
 export type DeviceListSnapshot = DeviceList & { errors?: UtilityError[] };
+export type DeviceListConnectionStatus = 'connecting' | 'connected' | 'disconnected';
+
+export type DeviceListSocketMessage =
+  | { type: typeof HEARTBEAT_MESSAGE_TYPE }
+  | { type: typeof DEVICE_LIST_MESSAGE_TYPE; devices: DeviceListSnapshot };
 
 const EMPTY: DeviceList = { simulators: [], emulators: [] };
 
 const RECONNECT_MIN_MS = 500;
 const RECONNECT_MAX_MS = 10_000;
+const HEARTBEAT_TIMEOUT_MS = 6_000;
+
+type DeviceListSocket = {
+  close(): void;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: (() => void) | null;
+};
+
+type ConnectionTimer = ReturnType<typeof setTimeout>;
+
+type DeviceListSubscriptionOptions = {
+  url?: string;
+  createSocket?: (url: string) => DeviceListSocket;
+  schedule?: (callback: () => void, delay: number) => ConnectionTimer;
+  cancelSchedule?: (timer: ConnectionTimer) => void;
+  reconnectMinMs?: number;
+  reconnectMaxMs?: number;
+  heartbeatTimeoutMs?: number;
+  onSnapshot: (snapshot: DeviceListSnapshot) => void;
+  onStatus: (status: DeviceListConnectionStatus) => void;
+};
+
+/**
+ * Owns the device-list socket lifecycle independently from React so reconnect
+ * and heartbeat-timeout behavior can be tested with fake sockets and clocks.
+ */
+export function subscribeToDeviceList({
+  url = devicesWebSocketUrl(),
+  createSocket = (socketUrl) => new WebSocket(socketUrl) as DeviceListSocket,
+  schedule = setTimeout,
+  cancelSchedule = clearTimeout,
+  reconnectMinMs = RECONNECT_MIN_MS,
+  reconnectMaxMs = RECONNECT_MAX_MS,
+  heartbeatTimeoutMs = HEARTBEAT_TIMEOUT_MS,
+  onSnapshot,
+  onStatus,
+}: DeviceListSubscriptionOptions): () => void {
+  let cancelled = false;
+  let socket: DeviceListSocket | null = null;
+  let reconnectTimer: ConnectionTimer | null = null;
+  let watchdogTimer: ConnectionTimer | null = null;
+  let reconnectDelay = reconnectMinMs;
+  let status: DeviceListConnectionStatus = 'connecting';
+
+  const updateStatus = (next: DeviceListConnectionStatus) => {
+    if (status === next) return;
+    status = next;
+    onStatus(next);
+  };
+
+  const clearWatchdog = () => {
+    if (watchdogTimer === null) return;
+    cancelSchedule(watchdogTimer);
+    watchdogTimer = null;
+  };
+
+  const scheduleReconnect = () => {
+    if (cancelled || reconnectTimer !== null) return;
+    reconnectTimer = schedule(() => {
+      reconnectTimer = null;
+      connect();
+    }, reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, reconnectMaxMs);
+  };
+
+  const disconnect = (target: DeviceListSocket) => {
+    if (cancelled || socket !== target) return;
+    socket = null;
+    clearWatchdog();
+    updateStatus('disconnected');
+    try {
+      target.close();
+    } catch {}
+    scheduleReconnect();
+  };
+
+  const armWatchdog = (target: DeviceListSocket) => {
+    clearWatchdog();
+    watchdogTimer = schedule(() => disconnect(target), heartbeatTimeoutMs);
+  };
+
+  const markAlive = (target: DeviceListSocket) => {
+    if (cancelled || socket !== target) return;
+    reconnectDelay = reconnectMinMs;
+    updateStatus('connected');
+    armWatchdog(target);
+  };
+
+  function connect() {
+    if (cancelled) return;
+
+    let nextSocket: DeviceListSocket;
+    try {
+      nextSocket = createSocket(url);
+    } catch {
+      updateStatus('disconnected');
+      scheduleReconnect();
+      return;
+    }
+    socket = nextSocket;
+    armWatchdog(nextSocket);
+
+    // Opening the transport is not enough to prove this is a compatible,
+    // responsive Hub server. A valid protocol message marks it connected.
+    nextSocket.onmessage = (event) => {
+      const message = parseDeviceListSocketMessage(event.data);
+      if (!message) return;
+
+      markAlive(nextSocket);
+      if (message.type === DEVICE_LIST_MESSAGE_TYPE) onSnapshot(message.devices);
+    };
+    nextSocket.onerror = () => disconnect(nextSocket);
+    nextSocket.onclose = () => disconnect(nextSocket);
+  }
+
+  onStatus(status);
+  connect();
+
+  return () => {
+    cancelled = true;
+    if (reconnectTimer !== null) cancelSchedule(reconnectTimer);
+    clearWatchdog();
+    const activeSocket = socket;
+    socket = null;
+    try {
+      activeSocket?.close();
+    } catch {}
+  };
+}
 
 /**
  * Subscribes to the server's shared device-discovery loop. The server does the
  * host polling once regardless of how many dashboards are open and sends only
  * changed snapshots. Returns the empty list until the first snapshot arrives.
  */
-function useDeviceList(): DeviceList {
+function useDeviceList(): {
+  devices: DeviceList;
+  connectionStatus: DeviceListConnectionStatus;
+} {
   const [devices, setDevices] = useState<DeviceList>(EMPTY);
+  const [connectionStatus, setConnectionStatus] =
+    useState<DeviceListConnectionStatus>('connecting');
 
   useEffect(() => {
-    let cancelled = false;
-    let socket: WebSocket | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let reconnectDelay = RECONNECT_MIN_MS;
     let activeErrorIds = new Set<string>();
 
-    function connect() {
-      if (cancelled) return;
-      let nextSocket: WebSocket;
-      try {
-        nextSocket = new WebSocket(devicesWebSocketUrl());
-      } catch {
-        scheduleReconnect();
-        return;
-      }
-      socket = nextSocket;
-
-      nextSocket.onopen = () => {
-        reconnectDelay = RECONNECT_MIN_MS;
-      };
-      nextSocket.onmessage = (event) => {
-        const next = parseDeviceListMessage(event.data);
-        if (!next) return;
-
-        activeErrorIds = logUtilityErrors(next.errors, activeErrorIds);
-
-        const { errors: _errors, ...nextDevices } = next;
+    return subscribeToDeviceList({
+      onSnapshot: (snapshot) => {
+        activeErrorIds = logUtilityErrors(snapshot.errors, activeErrorIds);
+        const { errors: _errors, ...nextDevices } = snapshot;
         setDevices(nextDevices);
-      };
-      nextSocket.onerror = () => nextSocket.close();
-      nextSocket.onclose = () => {
-        // Ignore a late close from a socket already superseded by a reconnect.
-        if (socket !== nextSocket) return;
-        socket = null;
-        scheduleReconnect();
-      };
-    }
-
-    function scheduleReconnect() {
-      if (cancelled || reconnectTimer) return;
-      reconnectTimer = setTimeout(() => {
-        reconnectTimer = null;
-        connect();
-      }, reconnectDelay);
-      reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
-    }
-
-    connect();
-
-    return () => {
-      cancelled = true;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      socket?.close();
-    };
+      },
+      onStatus: setConnectionStatus,
+    });
   }, []);
 
-  return devices;
+  return { devices, connectionStatus };
 }
 
-export function parseDeviceListMessage(data: unknown): DeviceListSnapshot | null {
+export function parseDeviceListSocketMessage(data: unknown): DeviceListSocketMessage | null {
   if (typeof data !== 'string') return null;
   try {
     const message = JSON.parse(data) as {
       type?: unknown;
       devices?: { simulators?: unknown; emulators?: unknown; errors?: unknown };
     };
+    if (message.type === HEARTBEAT_MESSAGE_TYPE) {
+      return { type: HEARTBEAT_MESSAGE_TYPE };
+    }
     if (
       message.type !== DEVICE_LIST_MESSAGE_TYPE ||
       !Array.isArray(message.devices?.simulators) ||
@@ -115,16 +214,27 @@ export function parseDeviceListMessage(data: unknown): DeviceListSnapshot | null
     }
     const errors = message.devices.errors?.filter(isUtilityError);
     return {
-      simulators: message.devices.simulators as Device[],
-      emulators: message.devices.emulators as Device[],
-      ...(errors ? { errors } : {}),
+      type: DEVICE_LIST_MESSAGE_TYPE,
+      devices: {
+        simulators: message.devices.simulators as Device[],
+        emulators: message.devices.emulators as Device[],
+        ...(errors ? { errors } : {}),
+      },
     };
   } catch {
     return null;
   }
 }
 
-export function splitDeviceList(all: DeviceList): { booted: DeviceList; recent: DeviceList } {
+export function parseDeviceListMessage(data: unknown): DeviceListSnapshot | null {
+  const message = parseDeviceListSocketMessage(data);
+  return message?.type === DEVICE_LIST_MESSAGE_TYPE ? message.devices : null;
+}
+
+export function splitDeviceList(all: DeviceList): {
+  booted: DeviceList;
+  recent: DeviceList;
+} {
   const filter = (booted: boolean) => ({
     simulators: all.simulators.filter((device) => device.booted === booted),
     emulators: all.emulators.filter((device) => device.booted === booted),
@@ -133,7 +243,12 @@ export function splitDeviceList(all: DeviceList): { booted: DeviceList; recent: 
 }
 
 /** One connection supplying both the running sidebar and recent-device picker. */
-export function useDeviceLists(): { booted: DeviceList; recent: DeviceList } {
-  const all = useDeviceList();
-  return useMemo(() => splitDeviceList(all), [all]);
+export function useDeviceLists(): {
+  booted: DeviceList;
+  recent: DeviceList;
+  connectionStatus: DeviceListConnectionStatus;
+} {
+  const { devices, connectionStatus } = useDeviceList();
+  const lists = useMemo(() => splitDeviceList(devices), [devices]);
+  return { ...lists, connectionStatus };
 }

--- a/packages/expo-device-hub/src/device-list-protocol.ts
+++ b/packages/expo-device-hub/src/device-list-protocol.ts
@@ -1,1 +1,2 @@
 export const DEVICE_LIST_MESSAGE_TYPE = 'device-list' as const;
+export const HEARTBEAT_MESSAGE_TYPE = 'heartbeat' as const;

--- a/packages/expo-device-hub/src/server/__tests__/device-list-websocket.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/device-list-websocket.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { DEVICE_LIST_MESSAGE_TYPE } from '../../device-list-protocol';
+import { DEVICE_LIST_MESSAGE_TYPE, HEARTBEAT_MESSAGE_TYPE } from '../../device-list-protocol';
 import {
   DeviceListBroadcaster,
   type DeviceListSocket,
@@ -75,18 +75,41 @@ function manualScheduler() {
   };
 }
 
+function manualHeartbeatScheduler() {
+  let callback: (() => void) | null = null;
+  let cancelled = 0;
+  return {
+    scheduleHeartbeat(next: () => void) {
+      callback = next;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    },
+    cancelHeartbeat() {
+      callback = null;
+      cancelled++;
+    },
+    run() {
+      if (!callback) throw new Error('No heartbeat scheduled');
+      callback();
+    },
+    get cancelled() {
+      return cancelled;
+    },
+  };
+}
+
 async function flushPoll(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
 
-function decoded(socket: FakeSocket): Array<{ type: string; devices: HubDeviceList }> {
+function decoded(socket: FakeSocket): Array<{ type: string; devices?: HubDeviceList }> {
   return socket.sent.map((message) => JSON.parse(message));
 }
 
 describe('DeviceListBroadcaster', () => {
   test('shares one poller and broadcasts only semantic changes', async () => {
     const scheduler = manualScheduler();
+    const heartbeat = manualHeartbeatScheduler();
     let current = LIST;
     let loads = 0;
     const broadcaster = new DeviceListBroadcaster({
@@ -96,6 +119,8 @@ describe('DeviceListBroadcaster', () => {
       },
       schedule: scheduler.schedule,
       cancelSchedule: scheduler.cancelSchedule,
+      scheduleHeartbeat: heartbeat.scheduleHeartbeat,
+      cancelHeartbeat: heartbeat.cancelHeartbeat,
     });
     const first = new FakeSocket();
     const second = new FakeSocket();
@@ -103,31 +128,43 @@ describe('DeviceListBroadcaster', () => {
     broadcaster.subscribe(first);
     await flushPoll();
     expect(loads).toBe(1);
-    expect(decoded(first)).toEqual([{ type: DEVICE_LIST_MESSAGE_TYPE, devices: LIST }]);
+    expect(decoded(first)).toEqual([
+      { type: HEARTBEAT_MESSAGE_TYPE },
+      { type: DEVICE_LIST_MESSAGE_TYPE, devices: LIST },
+    ]);
 
     broadcaster.subscribe(second);
     expect(loads).toBe(1);
-    expect(decoded(second)).toEqual([{ type: DEVICE_LIST_MESSAGE_TYPE, devices: LIST }]);
+    expect(decoded(second)).toEqual([
+      { type: HEARTBEAT_MESSAGE_TYPE },
+      { type: DEVICE_LIST_MESSAGE_TYPE, devices: LIST },
+    ]);
+
+    heartbeat.run();
+    expect(decoded(first).at(-1)).toEqual({ type: HEARTBEAT_MESSAGE_TYPE });
+    expect(decoded(second).at(-1)).toEqual({ type: HEARTBEAT_MESSAGE_TYPE });
 
     scheduler.run();
     await flushPoll();
     expect(loads).toBe(2);
-    expect(first.sent).toHaveLength(1);
-    expect(second.sent).toHaveLength(1);
+    expect(first.sent).toHaveLength(3);
+    expect(second.sent).toHaveLength(3);
 
     current = { ...LIST, simulators: [{ ...IOS, booted: false }] };
     scheduler.run();
     await flushPoll();
-    expect(first.sent).toHaveLength(2);
-    expect(second.sent).toHaveLength(2);
+    expect(first.sent).toHaveLength(4);
+    expect(second.sent).toHaveLength(4);
 
     first.emit('close');
     second.emit('close');
     expect(scheduler.cancelled).toBe(1);
+    expect(heartbeat.cancelled).toBe(1);
   });
 
   test('keeps the last known snapshot when discovery throws', async () => {
     const scheduler = manualScheduler();
+    const heartbeat = manualHeartbeatScheduler();
     const errors: unknown[] = [];
     let fail = false;
     const broadcaster = new DeviceListBroadcaster({
@@ -137,6 +174,8 @@ describe('DeviceListBroadcaster', () => {
       },
       schedule: scheduler.schedule,
       cancelSchedule: scheduler.cancelSchedule,
+      scheduleHeartbeat: heartbeat.scheduleHeartbeat,
+      cancelHeartbeat: heartbeat.cancelHeartbeat,
       onError: (error) => errors.push(error),
     });
     const socket = new FakeSocket();
@@ -147,12 +186,13 @@ describe('DeviceListBroadcaster', () => {
     scheduler.run();
     await flushPoll();
 
-    expect(socket.sent).toHaveLength(1);
+    expect(socket.sent).toHaveLength(2);
     expect(errors).toHaveLength(1);
   });
 
   test('coalesces a refresh requested during an in-flight poll', async () => {
     const scheduler = manualScheduler();
+    const heartbeat = manualHeartbeatScheduler();
     let resolveFirst!: (list: HubDeviceList) => void;
     let loads = 0;
     const firstLoad = new Promise<HubDeviceList>((resolve) => {
@@ -162,6 +202,8 @@ describe('DeviceListBroadcaster', () => {
       load: async () => (++loads === 1 ? firstLoad : LIST),
       schedule: scheduler.schedule,
       cancelSchedule: scheduler.cancelSchedule,
+      scheduleHeartbeat: heartbeat.scheduleHeartbeat,
+      cancelHeartbeat: heartbeat.cancelHeartbeat,
     });
 
     broadcaster.subscribe(new FakeSocket());

--- a/packages/expo-device-hub/src/server/device-list-websocket.ts
+++ b/packages/expo-device-hub/src/server/device-list-websocket.ts
@@ -1,7 +1,8 @@
-import { DEVICE_LIST_MESSAGE_TYPE } from '../device-list-protocol';
+import { DEVICE_LIST_MESSAGE_TYPE, HEARTBEAT_MESSAGE_TYPE } from '../device-list-protocol';
 import { type HubDevice, type HubDeviceList, listDevices } from './devices';
 
 const POLL_INTERVAL_MS = 500;
+const HEARTBEAT_INTERVAL_MS = 2_000;
 
 export interface DeviceListSocket {
   send(data: string): void;
@@ -14,11 +15,16 @@ interface DeviceListBroadcasterOptions {
   intervalMs?: number;
   schedule?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
   cancelSchedule?: (timer: ReturnType<typeof setTimeout>) => void;
+  heartbeatIntervalMs?: number;
+  scheduleHeartbeat?: (callback: () => void, delay: number) => ReturnType<typeof setInterval>;
+  cancelHeartbeat?: (timer: ReturnType<typeof setInterval>) => void;
   onError?: (error: unknown) => void;
 }
 
 type Schedule = NonNullable<DeviceListBroadcasterOptions['schedule']>;
 type CancelSchedule = NonNullable<DeviceListBroadcasterOptions['cancelSchedule']>;
+type ScheduleHeartbeat = NonNullable<DeviceListBroadcasterOptions['scheduleHeartbeat']>;
+type CancelHeartbeat = NonNullable<DeviceListBroadcasterOptions['cancelHeartbeat']>;
 
 /**
  * A single device-discovery loop shared by every dashboard connection.
@@ -30,9 +36,13 @@ export class DeviceListBroadcaster {
   readonly #intervalMs: number;
   readonly #schedule: Schedule;
   readonly #cancelSchedule: CancelSchedule;
+  readonly #heartbeatIntervalMs: number;
+  readonly #scheduleHeartbeat: ScheduleHeartbeat;
+  readonly #cancelHeartbeat: CancelHeartbeat;
   readonly #onError: (error: unknown) => void;
 
   #timer: ReturnType<typeof setTimeout> | null = null;
+  #heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   #polling = false;
   #refreshQueued = false;
   #snapshot: HubDeviceList | null = null;
@@ -43,6 +53,9 @@ export class DeviceListBroadcaster {
     this.#intervalMs = options.intervalMs ?? POLL_INTERVAL_MS;
     this.#schedule = options.schedule ?? setTimeout;
     this.#cancelSchedule = options.cancelSchedule ?? clearTimeout;
+    this.#heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+    this.#scheduleHeartbeat = options.scheduleHeartbeat ?? setInterval;
+    this.#cancelHeartbeat = options.cancelHeartbeat ?? clearInterval;
     this.#onError =
       options.onError ??
       ((error) => console.warn('[expo-device-hub] Failed to refresh device list:', error));
@@ -56,19 +69,20 @@ export class DeviceListBroadcaster {
     const unsubscribe = () => {
       if (!active) return;
       active = false;
-      this.#clients.delete(socket);
-      if (this.#clients.size === 0) {
-        this.#refreshQueued = false;
-        this.#stopTimer();
-      }
+      this.#removeClient(socket);
     };
     socket.on('close', unsubscribe);
     socket.on('error', unsubscribe);
 
-    // A reconnecting/new tab gets the latest known state immediately. The
-    // first subscriber also starts a fresh discovery pass in the background.
-    if (this.#snapshot) this.#send(socket, this.#snapshot);
-    if (wasEmpty) this.refresh();
+    // Confirm liveness immediately, even if the first device discovery pass is
+    // slow. Changed device snapshots and periodic heartbeats both keep the
+    // browser-side watchdog alive after this initial message.
+    if (wasEmpty) {
+      this.#startHeartbeat();
+      this.refresh();
+    }
+    this.#sendHeartbeat(socket);
+    if (this.#clients.has(socket) && this.#snapshot) this.#send(socket, this.#snapshot);
   }
 
   /** Request a prompt refresh, coalescing with an in-flight discovery pass. */
@@ -116,16 +130,52 @@ export class DeviceListBroadcaster {
     for (const socket of this.#clients) this.#send(socket, snapshot);
   }
 
+  #broadcastHeartbeat(): void {
+    for (const socket of this.#clients) this.#sendHeartbeat(socket);
+  }
+
+  #sendHeartbeat(socket: DeviceListSocket): void {
+    this.#sendMessage(socket, JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE }));
+  }
+
   #send(socket: DeviceListSocket, snapshot: HubDeviceList): void {
+    this.#sendMessage(
+      socket,
+      JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: snapshot })
+    );
+  }
+
+  #sendMessage(socket: DeviceListSocket, message: string): void {
     try {
-      socket.send(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: snapshot }));
+      socket.send(message);
     } catch {
-      this.#clients.delete(socket);
-      if (this.#clients.size === 0) this.#stopTimer();
+      this.#removeClient(socket);
       try {
         socket.close();
       } catch {}
     }
+  }
+
+  #removeClient(socket: DeviceListSocket): void {
+    this.#clients.delete(socket);
+    if (this.#clients.size > 0) return;
+    this.#refreshQueued = false;
+    this.#stopTimer();
+    this.#stopHeartbeat();
+  }
+
+  #startHeartbeat(): void {
+    if (this.#heartbeatTimer !== null) return;
+    this.#heartbeatTimer = this.#scheduleHeartbeat(
+      () => this.#broadcastHeartbeat(),
+      this.#heartbeatIntervalMs
+    );
+  }
+
+  #stopHeartbeat(): void {
+    if (this.#heartbeatTimer === null) return;
+    this.#cancelHeartbeat(this.#heartbeatTimer);
+    this.#heartbeatTimer = null;
   }
 
   #stopTimer(): void {


### PR DESCRIPTION
## Summary

- send an immediate device-list heartbeat and continue broadcasting heartbeats every two seconds while dashboards are subscribed
- require valid Hub protocol messages before marking the browser connected, detect silent connections after six seconds, and reconnect with bounded exponential backoff
- replace the dashboard with a blocking Expo-styled status page while connecting or disconnected, with guidance to restart the dev server and reload

## Why

The device-list WebSocket previously emitted only when the discovered device list changed. The browser retried explicit socket closes, but it exposed no connection state and could not detect a half-open connection, so a closed dev server could leave stale interactive UI visible.

## User impact

Users now see a clear full-page connecting or disconnected state instead of a stale dashboard. Device streaming is stopped while the server is unavailable, and the page provides a direct reload action after the user restarts the Expo dev server in their terminal.

## Validation

- bun install
- bun run test
- bun run lint
- bun run build