### PR TITLE
Retry Android emulator with software GPU rendering

### DIFF
--- a/packages/@expo/hub-android-utils/README.md
+++ b/packages/@expo/hub-android-utils/README.md
@@ -81,9 +81,12 @@ if (created) {
   operational failure.
 - `bootDevice(options)` launches the AVD headlessly via the `emulator` binary
   (`-no-window -no-audio -gpu host -no-boot-anim`). The emulator is
-  detached so it keeps running after the parent exits. Returns as soon as the
-  process is spawned — not once Android has finished booting — so wait for boot
-  with adb using the returned `value.serial` (`emulator-<port>`).
+  detached so it keeps running after the parent exits. If host rendering is
+  unavailable, the launch is retried once with `-gpu software`; this is silent
+  unless the `expo-device-hub:android-utils` debug namespace is enabled. Returns
+  as soon as the process is spawned — not once Android has finished booting —
+  so wait for boot with adb using the returned `value.serial`
+  (`emulator-<port>`).
 
 All four resolve their binaries the same way as `listDevices()` and return
 `{ value, error }`: the listers use `[]`, `createDevice` uses `false`, and

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -104,6 +104,60 @@ if (gpuMode === "host") {
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 
+  test("stops the detached host process group before retrying", async () => {
+    if (process.platform === "win32") return;
+
+    const invocations = join(dir, "invocations.txt");
+    const descendant = join(dir, "emulator-descendant.js");
+    const emulator = join(dir, "emulator");
+    writeFileSync(descendant, "setInterval(() => {}, 1_000);\n");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const { spawn } = require("node:child_process");
+const gpuIndex = process.argv.indexOf("-gpu");
+const gpuMode = process.argv[gpuIndex + 1];
+appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
+if (gpuMode === "host") {
+  spawn(process.execPath, [${JSON.stringify(descendant)}], {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  process.on("SIGTERM", () => {});
+  console.log("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+  setInterval(() => {}, 1_000);
+} else {
+  setTimeout(() => process.exit(0), 20);
+}
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    const hostPid = spawned.value!.child.pid;
+    let completed = false;
+    try {
+      const exited = await Promise.race([
+        spawned.value!.exited,
+        Bun.sleep(3_000).then(() => {
+          throw new Error("Timed out waiting for the software GPU retry");
+        }),
+      ]);
+      completed = true;
+      expect(exited).toEqual({ code: 0, signal: null, error: null });
+      expect(spawned.value!.gpuMode).toBe("software");
+      expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
+    } finally {
+      if (!completed && hostPid) {
+        try {
+          process.kill(-hostPid, "SIGKILL");
+        } catch {}
+      }
+    }
+  });
+
   test("also detects the hardware rendering error on stderr", async () => {
     const invocations = join(dir, "invocations.txt");
     const emulator = join(dir, "emulator");

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -34,6 +34,11 @@ describe("buildEmulatorArgs", () => {
     const args = buildEmulatorArgs({ name: "x", port: 5556 });
     expect(args[args.indexOf("-port") + 1]).toBe("5556");
   });
+
+  test("uses software rendering when requested", () => {
+    const args = buildEmulatorArgs({ name: "x", port: 5556 }, "software");
+    expect(args[args.indexOf("-gpu") + 1]).toBe("software");
+  });
 });
 
 describe("formatEmulatorCommand", () => {
@@ -46,6 +51,11 @@ describe("formatEmulatorCommand", () => {
   test("quotes parts containing whitespace", () => {
     const command = formatEmulatorCommand("/my sdk/emulator", { name: "x", port: 5554 });
     expect(command.startsWith('"/my sdk/emulator"')).toBe(true);
+  });
+
+  test("formats a software rendering command", () => {
+    const command = formatEmulatorCommand("/sdk/emulator", { name: "x", port: 5554 }, "software");
+    expect(command).toContain("-gpu software");
   });
 });
 
@@ -64,5 +74,33 @@ describe("spawnEmulator", () => {
     const spawned = await spawnEmulator(join(dir, "missing"), { name: "x", port: 5554 });
     expect(spawned.value).toBeNull();
     expect(spawned.error?.message).toBe("[android-utils] Failed to spawn `emulator`:");
+  });
+
+  test("retries with software rendering when hardware rendering is unavailable", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+const gpuMode = process.argv[gpuIndex + 1];
+appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
+if (gpuMode === "host") {
+  console.error("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+  setTimeout(() => process.exit(1), 1_000);
+} else {
+  setTimeout(() => process.exit(0), 20);
+}
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
+    expect(spawned.value!.gpuMode).toBe("software");
+    expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 });

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -104,6 +104,28 @@ if (gpuMode === "host") {
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 
+  test("reports software mode when the fallback process cannot be spawned", async () => {
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { unlinkSync } = require("node:fs");
+unlinkSync(__filename);
+console.error("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+setTimeout(() => process.exit(1), 1_000);
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+
+    const exited = await spawned.value!.exited;
+    expect(exited.error?.message).toBe("[android-utils] Failed to spawn `emulator`:");
+    expect(spawned.value!.gpuMode).toBe("software");
+  });
+
   test("does not retry after a process error has finished the lifecycle", async () => {
     const invocations = join(dir, "invocations.txt");
     const emulator = join(dir, "emulator");

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -87,7 +87,7 @@ const gpuIndex = process.argv.indexOf("-gpu");
 const gpuMode = process.argv[gpuIndex + 1];
 appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
 if (gpuMode === "host") {
-  console.error("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+  console.log("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
   setTimeout(() => process.exit(1), 1_000);
 } else {
   setTimeout(() => process.exit(0), 20);
@@ -101,6 +101,33 @@ if (gpuMode === "host") {
     expect(spawned.value).not.toBeNull();
     expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
     expect(spawned.value!.gpuMode).toBe("software");
+    expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
+  });
+
+  test("also detects the hardware rendering error on stderr", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+const gpuMode = process.argv[gpuIndex + 1];
+appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
+if (gpuMode === "host") {
+  console.error("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+  setTimeout(() => process.exit(1), 1_000);
+} else {
+  setTimeout(() => process.exit(0), 20);
+}
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 
@@ -127,7 +154,7 @@ setTimeout(() => process.exit(7), 20);
     expect(readFileSync(invocations, "utf8")).toBe("host\n");
   });
 
-  test("detects a hardware rendering error split across stderr chunks", async () => {
+  test("detects a hardware rendering error split across stdout chunks", async () => {
     const invocations = join(dir, "invocations.txt");
     const emulator = join(dir, "emulator");
     writeFileSync(
@@ -138,9 +165,10 @@ const gpuIndex = process.argv.indexOf("-gpu");
 const gpuMode = process.argv[gpuIndex + 1];
 appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
 if (gpuMode === "host") {
-  process.stderr.write("ERROR | Your GPU cannot be used for hard");
+  process.stdout.write("ERROR | Your GPU cannot be used for hard");
   setTimeout(() => {
-    process.stderr.write("ware rendering. Consider using software rendering.\\n");
+    process.stderr.write("GlxEnginegetDefaultDisplay: Failed to open display 0.\\n");
+    process.stdout.write("ware rendering. Consider using software rendering.\\n");
   }, 20);
   setTimeout(() => process.exit(1), 1_000);
 } else {
@@ -158,7 +186,7 @@ if (gpuMode === "host") {
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 
-  test("retries only once when stderr repeats the hardware rendering error", async () => {
+  test("retries only once when stdout repeats the hardware rendering error", async () => {
     const invocations = join(dir, "invocations.txt");
     const emulator = join(dir, "emulator");
     writeFileSync(
@@ -170,7 +198,7 @@ const gpuMode = process.argv[gpuIndex + 1];
 appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
 if (gpuMode === "host") {
   const error = "ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.";
-  process.stderr.write(error + "\\n" + error + "\\n");
+  process.stdout.write(error + "\\n" + error + "\\n");
   setTimeout(() => process.exit(1), 1_000);
 } else {
   setTimeout(() => process.exit(0), 20);
@@ -194,7 +222,7 @@ if (gpuMode === "host") {
       `#!/usr/bin/env node
 const { unlinkSync } = require("node:fs");
 unlinkSync(__filename);
-console.error("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
+console.log("ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.");
 setTimeout(() => process.exit(1), 1_000);
 `,
     );
@@ -237,7 +265,7 @@ setInterval(() => {}, 1_000);
     child.kill = () => true;
 
     try {
-      child.stderr?.emit(
+      child.stdout?.emit(
         "data",
         "ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.",
       );

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -102,5 +102,51 @@ if (gpuMode === "host") {
     expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
     expect(spawned.value!.gpuMode).toBe("software");
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
+  });
+
+  test("does not retry after a process error has finished the lifecycle", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+appendFileSync(${JSON.stringify(invocations)}, process.argv[gpuIndex + 1] + "\\n");
+setInterval(() => {}, 1_000);
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+
+    for (let attempt = 0; attempt < 100 && !existsSync(invocations); attempt++) {
+      await Bun.sleep(10);
+    }
+    expect(readFileSync(invocations, "utf8")).toBe("host\n");
+
+    const child = spawned.value!.child;
+    const kill = child.kill.bind(child);
+    child.kill = () => true;
+
+    try {
+      child.stderr?.emit(
+        "data",
+        "ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.",
+      );
+      const processError = new Error("failed to stop emulator");
+      child.emit("error", processError);
+      child.emit("close", 1, null);
+
+      const exited = await spawned.value!.exited;
+      expect(exited.error?.error).toBe(processError);
+      await Bun.sleep(50);
+      expect(readFileSync(invocations, "utf8")).toBe("host\n");
+    } finally {
+      kill();
+      if (spawned.value!.child !== child) spawned.value!.child.kill();
+    }
   });
 });

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -104,6 +104,89 @@ if (gpuMode === "host") {
     expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
   });
 
+  test("does not retry for unrelated stderr", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+appendFileSync(${JSON.stringify(invocations)}, process.argv[gpuIndex + 1] + "\\n");
+console.error("WARNING | Host rendering probe returned an unknown result.");
+setTimeout(() => process.exit(7), 20);
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    expect(await spawned.value!.exited).toEqual({ code: 7, signal: null, error: null });
+    expect(spawned.value!.gpuMode).toBe("host");
+    expect(readFileSync(invocations, "utf8")).toBe("host\n");
+  });
+
+  test("detects a hardware rendering error split across stderr chunks", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+const gpuMode = process.argv[gpuIndex + 1];
+appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
+if (gpuMode === "host") {
+  process.stderr.write("ERROR | Your GPU cannot be used for hard");
+  setTimeout(() => {
+    process.stderr.write("ware rendering. Consider using software rendering.\\n");
+  }, 20);
+  setTimeout(() => process.exit(1), 1_000);
+} else {
+  setTimeout(() => process.exit(0), 20);
+}
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
+    expect(spawned.value!.gpuMode).toBe("software");
+    expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
+  });
+
+  test("retries only once when stderr repeats the hardware rendering error", async () => {
+    const invocations = join(dir, "invocations.txt");
+    const emulator = join(dir, "emulator");
+    writeFileSync(
+      emulator,
+      `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const gpuIndex = process.argv.indexOf("-gpu");
+const gpuMode = process.argv[gpuIndex + 1];
+appendFileSync(${JSON.stringify(invocations)}, gpuMode + "\\n");
+if (gpuMode === "host") {
+  const error = "ERROR | Your GPU cannot be used for hardware rendering. Consider using software rendering.";
+  process.stderr.write(error + "\\n" + error + "\\n");
+  setTimeout(() => process.exit(1), 1_000);
+} else {
+  setTimeout(() => process.exit(0), 20);
+}
+`,
+    );
+    chmodSync(emulator, 0o755);
+
+    const spawned = await spawnEmulator(emulator, { name: "x", port: 5554 });
+    expect(spawned.error).toBeNull();
+    expect(spawned.value).not.toBeNull();
+    expect(await spawned.value!.exited).toEqual({ code: 0, signal: null, error: null });
+    expect(spawned.value!.gpuMode).toBe("software");
+    expect(readFileSync(invocations, "utf8")).toBe("host\nsoftware\n");
+  });
+
   test("reports software mode when the fallback process cannot be spawned", async () => {
     const emulator = join(dir, "emulator");
     writeFileSync(

--- a/packages/@expo/hub-android-utils/src/boot-device.ts
+++ b/packages/@expo/hub-android-utils/src/boot-device.ts
@@ -9,13 +9,15 @@ import type { BootDeviceOptions, BootedDevice } from "./types";
  *
  * Spawns a detached, windowless emulator and returns as soon as the process is
  * launched — not once Android has finished booting; track readiness with adb
- * via the returned `serial`. `exited` resolves if the process dies — before
- * the device is adb-online that means the boot failed; the emulator's output
- * is discarded (the detached child outlives us), so failure reports point the
- * user at re-running the returned `command` to see it. Resolves `emulator`
- * from `ANDROID_HOME` / `ANDROID_SDK_ROOT` (falling back to the default macOS
- * SDK location). The result's `value` is `null` if the process could not be
- * spawned, with the invocation-specific failure in `error`.
+ * via the returned `serial`. If host GPU rendering is unavailable, the process
+ * is retried once with software rendering. `exited` follows that retry and
+ * resolves if the active process dies — before the device is adb-online that
+ * means the boot failed. Emulator output is otherwise discarded (the detached
+ * child outlives us), so failure reports point the user at re-running the
+ * returned `command` to see it. Resolves `emulator` from `ANDROID_HOME` /
+ * `ANDROID_SDK_ROOT` (falling back to the default macOS SDK location). The
+ * result's `value` is `null` if the process could not be spawned, with the
+ * invocation-specific failure in `error`.
  */
 export async function bootDevice(
   options: BootDeviceOptions,

--- a/packages/@expo/hub-android-utils/src/boot-device.ts
+++ b/packages/@expo/hub-android-utils/src/boot-device.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { emulatorSerial, formatEmulatorCommand, spawnEmulator } from "./emulator";
 import { type AndroidUtilsResult, reportError, result } from "./errors";
 import { resolveEmulatorPath } from "./sdk-paths";
-import type { BootDeviceOptions, BootedDevice, EmulatorExit } from "./types";
+import type { BootDeviceOptions, BootedDevice } from "./types";
 
 /**
  * Boot an AVD headlessly via the `emulator` binary.
@@ -24,24 +24,17 @@ export async function bootDevice(
     const emulator = resolveEmulatorPath(process.env, homedir());
     const spawned = await spawnEmulator(emulator, options);
     if (spawned.error || !spawned.value) return result(null, spawned.error);
-    const child = spawned.value;
-
-    const exited = new Promise<EmulatorExit>((resolve) => {
-      child.once("exit", (code, signal) => resolve({ code, signal, error: null }));
-      child.once("error", (error) =>
-        resolve({
-          code: null,
-          signal: null,
-          error: reportError("[android-utils] `emulator` process error:", error),
-        }),
-      );
-    });
+    const running = spawned.value;
 
     return result({
       serial: emulatorSerial(options.port),
-      pid: child.pid ?? null,
-      command: formatEmulatorCommand(emulator, options),
-      exited,
+      get pid() {
+        return running.child.pid ?? null;
+      },
+      get command() {
+        return formatEmulatorCommand(emulator, options, running.gpuMode);
+      },
+      exited: running.exited,
     });
   } catch (error) {
     return result(null, reportError("[android-utils] Failed to boot device:", error));

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -62,10 +62,10 @@ export function formatEmulatorCommand(
  * Spawn a detached, headless `emulator` process.
  *
  * The child is fully detached (its own process group, unreferenced stdio,
- * `unref`ed) so it keeps running after the parent exits. If the emulator says
- * host rendering is unavailable, the host attempt is stopped and retried once
- * with software rendering. Resolves with the managed process lifecycle, or
- * `null` plus `error` if the first process could not be spawned.
+ * `unref`ed) so it keeps running after the parent exits. If stdout or stderr
+ * says host rendering is unavailable, the host attempt is stopped and retried
+ * once with software rendering. Resolves with the managed process lifecycle,
+ * or `null` plus `error` if the first process could not be spawned.
  */
 export async function spawnEmulator(
   emulatorPath: string,
@@ -81,25 +81,36 @@ export async function spawnEmulator(
     const monitor = (child: ChildProcess, gpuMode: EmulatorGpuMode): void => {
       let fallbackRequested = false;
       let finished = false;
+      let stdoutTail = "";
       let stderrTail = "";
 
       function cleanup(): void {
+        child.stdout?.removeListener("data", onStdout);
         child.stderr?.removeListener("data", onStderr);
         child.removeListener("error", onError);
         child.removeListener("close", onClose);
       }
 
-      function onStderr(chunk: Buffer | string): void {
-        if (finished || gpuMode !== "host" || fallbackRequested) return;
+      function inspectOutput(tail: string, chunk: Buffer | string): string {
+        if (finished || gpuMode !== "host" || fallbackRequested) return tail;
 
-        stderrTail = `${stderrTail}${chunk}`.slice(-HARDWARE_GPU_ERROR.length * 2);
-        if (!stderrTail.includes(HARDWARE_GPU_ERROR)) return;
+        const nextTail = `${tail}${chunk}`.slice(-HARDWARE_GPU_ERROR.length * 2);
+        if (!nextTail.includes(HARDWARE_GPU_ERROR)) return nextTail;
 
         fallbackRequested = true;
         logDebug(
           "[android-utils] Hardware GPU rendering unavailable; retrying `emulator` with software rendering.",
         );
         child.kill();
+        return nextTail;
+      }
+
+      function onStdout(chunk: Buffer | string): void {
+        stdoutTail = inspectOutput(stdoutTail, chunk);
+      }
+
+      function onStderr(chunk: Buffer | string): void {
+        stderrTail = inspectOutput(stderrTail, chunk);
       }
 
       function onError(error: Error): void {
@@ -134,6 +145,7 @@ export async function spawnEmulator(
         monitor(activeChild, activeGpuMode);
       }
 
+      child.stdout?.on("data", onStdout);
       child.stderr?.on("data", onStderr);
       child.once("error", onError);
       child.once("close", onClose);
@@ -161,7 +173,7 @@ function spawnEmulatorProcess(
   try {
     const child = spawn(emulatorPath, buildEmulatorArgs(options, gpuMode), {
       detached: true,
-      stdio: ["ignore", "ignore", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
     return new Promise((resolve) => {
@@ -172,8 +184,10 @@ function spawnEmulatorProcess(
       child.once("spawn", () => {
         child.removeListener("error", onError);
         child.unref();
-        const stderr = child.stderr as (typeof child.stderr & { unref(): void }) | null;
-        stderr?.unref();
+        for (const stream of [child.stdout, child.stderr]) {
+          const pipe = stream as (typeof stream & { unref(): void }) | null;
+          pipe?.unref();
+        }
         resolve(result(child));
       });
     });

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -22,8 +22,9 @@ export function emulatorSerial(port: number): string {
 
 /**
  * Build the `emulator` arguments for a boot.
- * Always use `host` GPU, `auto` results in low fps when using with `-no-window`
- * or the windows is in the background. (~10fps scrcpy, or ~30fps with grpc streaming)
+ * Prefer the `host` GPU because `auto` results in low fps with `-no-window` or
+ * when the window is in the background. Software rendering is used only when
+ * the host attempt reports that hardware rendering is unavailable.
  */
 export function buildEmulatorArgs(
   options: BootDeviceOptions,

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -123,14 +123,14 @@ export async function spawnEmulator(
           return;
         }
 
-        const retried = await spawnEmulatorProcess(emulatorPath, options, "software");
+        activeGpuMode = "software";
+        const retried = await spawnEmulatorProcess(emulatorPath, options, activeGpuMode);
         if (retried.error || !retried.value) {
           resolve({ code: null, signal: null, error: retried.error });
           return;
         }
 
         activeChild = retried.value;
-        activeGpuMode = "software";
         monitor(activeChild, activeGpuMode);
       }
 

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { type AndroidUtilsResult, logDebug, reportError, result } from "./errors";
 import type { BootDeviceOptions, EmulatorExit } from "./types";
 
@@ -13,6 +13,25 @@ export interface SpawnedEmulator {
   readonly gpuMode: EmulatorGpuMode;
   /** Resolves when the active process exits without another retry. */
   readonly exited: Promise<EmulatorExit>;
+}
+
+function stopEmulatorAttempt(child: ChildProcess): void {
+  if (process.platform === "win32" && child.pid) {
+    const stopped = spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    if (!stopped.error && stopped.status === 0) return;
+  } else if (child.pid) {
+    try {
+      process.kill(-child.pid, "SIGKILL");
+      return;
+    } catch {
+      // The process may have exited between emitting output and being signaled.
+    }
+  }
+
+  child.kill("SIGKILL");
 }
 
 /** The adb serial for an emulator started on the given console port. */
@@ -101,7 +120,7 @@ export async function spawnEmulator(
         logDebug(
           "[android-utils] Hardware GPU rendering unavailable; retrying `emulator` with software rendering.",
         );
-        child.kill();
+        stopEmulatorAttempt(child);
         return nextTail;
       }
 

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -1,6 +1,19 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { type AndroidUtilsResult, reportError, result } from "./errors";
-import type { BootDeviceOptions } from "./types";
+import { type AndroidUtilsResult, logDebug, reportError, result } from "./errors";
+import type { BootDeviceOptions, EmulatorExit } from "./types";
+
+const HARDWARE_GPU_ERROR = "Your GPU cannot be used for hardware rendering";
+
+export type EmulatorGpuMode = "host" | "software";
+
+export interface SpawnedEmulator {
+  /** The active process, updated if startup falls back to software rendering. */
+  readonly child: ChildProcess;
+  /** The active GPU mode, updated if startup falls back to software rendering. */
+  readonly gpuMode: EmulatorGpuMode;
+  /** Resolves when the active process exits without another retry. */
+  readonly exited: Promise<EmulatorExit>;
+}
 
 /** The adb serial for an emulator started on the given console port. */
 export function emulatorSerial(port: number): string {
@@ -12,14 +25,17 @@ export function emulatorSerial(port: number): string {
  * Always use `host` GPU, `auto` results in low fps when using with `-no-window`
  * or the windows is in the background. (~10fps scrcpy, or ~30fps with grpc streaming)
  */
-export function buildEmulatorArgs(options: BootDeviceOptions): string[] {
+export function buildEmulatorArgs(
+  options: BootDeviceOptions,
+  gpuMode: EmulatorGpuMode = "host",
+): string[] {
   return [
     "-avd",
     options.name,
     "-no-audio",
     "-no-window",
     "-gpu",
-    "host",
+    gpuMode,
     "-no-boot-anim",
     "-port",
     String(options.port),
@@ -31,8 +47,12 @@ export function buildEmulatorArgs(options: BootDeviceOptions): string[] {
  * offer the user to reproduce a failed boot with the full emulator output
  * visible in their terminal.
  */
-export function formatEmulatorCommand(emulatorPath: string, options: BootDeviceOptions): string {
-  return [emulatorPath, ...buildEmulatorArgs(options)]
+export function formatEmulatorCommand(
+  emulatorPath: string,
+  options: BootDeviceOptions,
+  gpuMode: EmulatorGpuMode = "host",
+): string {
+  return [emulatorPath, ...buildEmulatorArgs(options, gpuMode)]
     .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
     .join(" ");
 }
@@ -40,18 +60,90 @@ export function formatEmulatorCommand(emulatorPath: string, options: BootDeviceO
 /**
  * Spawn a detached, headless `emulator` process.
  *
- * The child is fully detached (its own process group, ignored stdio, `unref`ed)
- * so it keeps running after the parent exits. Resolves with the
- * {@link ChildProcess}, or `null` plus `error` if it could not be spawned.
+ * The child is fully detached (its own process group, unreferenced stdio,
+ * `unref`ed) so it keeps running after the parent exits. If the emulator says
+ * host rendering is unavailable, the host attempt is stopped and retried once
+ * with software rendering. Resolves with the managed process lifecycle, or
+ * `null` plus `error` if the first process could not be spawned.
  */
-export function spawnEmulator(
+export async function spawnEmulator(
   emulatorPath: string,
   options: BootDeviceOptions,
+): Promise<AndroidUtilsResult<SpawnedEmulator | null>> {
+  const initial = await spawnEmulatorProcess(emulatorPath, options, "host");
+  if (initial.error || !initial.value) return result(null, initial.error);
+
+  let activeChild = initial.value;
+  let activeGpuMode: EmulatorGpuMode = "host";
+
+  const exited = new Promise<EmulatorExit>((resolve) => {
+    const monitor = (child: ChildProcess, gpuMode: EmulatorGpuMode): void => {
+      let fallbackRequested = false;
+      let stderrTail = "";
+
+      const onStderr = (chunk: Buffer | string): void => {
+        stderrTail = `${stderrTail}${chunk}`.slice(-HARDWARE_GPU_ERROR.length * 2);
+        if (gpuMode !== "host" || fallbackRequested || !stderrTail.includes(HARDWARE_GPU_ERROR)) {
+          return;
+        }
+
+        fallbackRequested = true;
+        logDebug(
+          "[android-utils] Hardware GPU rendering unavailable; retrying `emulator` with software rendering.",
+        );
+        child.kill();
+      };
+
+      child.stderr?.on("data", onStderr);
+      child.once("error", (error) => {
+        resolve({
+          code: null,
+          signal: null,
+          error: reportError("[android-utils] `emulator` process error:", error),
+        });
+      });
+      child.once("close", async (code, signal) => {
+        child.stderr?.removeListener("data", onStderr);
+        if (!fallbackRequested) {
+          resolve({ code, signal, error: null });
+          return;
+        }
+
+        const retried = await spawnEmulatorProcess(emulatorPath, options, "software");
+        if (retried.error || !retried.value) {
+          resolve({ code: null, signal: null, error: retried.error });
+          return;
+        }
+
+        activeChild = retried.value;
+        activeGpuMode = "software";
+        monitor(activeChild, activeGpuMode);
+      });
+    };
+
+    monitor(activeChild, activeGpuMode);
+  });
+
+  return result({
+    get child() {
+      return activeChild;
+    },
+    get gpuMode() {
+      return activeGpuMode;
+    },
+    exited,
+  });
+}
+
+function spawnEmulatorProcess(
+  emulatorPath: string,
+  options: BootDeviceOptions,
+  gpuMode: EmulatorGpuMode,
 ): Promise<AndroidUtilsResult<ChildProcess | null>> {
   try {
-    const child = spawn(emulatorPath, buildEmulatorArgs(options), {
+    const child = spawn(emulatorPath, buildEmulatorArgs(options, gpuMode), {
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
     });
 
     return new Promise((resolve) => {
@@ -62,6 +154,8 @@ export function spawnEmulator(
       child.once("spawn", () => {
         child.removeListener("error", onError);
         child.unref();
+        const stderr = child.stderr as (typeof child.stderr & { unref(): void }) | null;
+        stderr?.unref();
         resolve(result(child));
       });
     });

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -80,31 +80,44 @@ export async function spawnEmulator(
   const exited = new Promise<EmulatorExit>((resolve) => {
     const monitor = (child: ChildProcess, gpuMode: EmulatorGpuMode): void => {
       let fallbackRequested = false;
+      let finished = false;
       let stderrTail = "";
 
-      const onStderr = (chunk: Buffer | string): void => {
+      function cleanup(): void {
+        child.stderr?.removeListener("data", onStderr);
+        child.removeListener("error", onError);
+        child.removeListener("close", onClose);
+      }
+
+      function onStderr(chunk: Buffer | string): void {
+        if (finished || gpuMode !== "host" || fallbackRequested) return;
+
         stderrTail = `${stderrTail}${chunk}`.slice(-HARDWARE_GPU_ERROR.length * 2);
-        if (gpuMode !== "host" || fallbackRequested || !stderrTail.includes(HARDWARE_GPU_ERROR)) {
-          return;
-        }
+        if (!stderrTail.includes(HARDWARE_GPU_ERROR)) return;
 
         fallbackRequested = true;
         logDebug(
           "[android-utils] Hardware GPU rendering unavailable; retrying `emulator` with software rendering.",
         );
         child.kill();
-      };
+      }
 
-      child.stderr?.on("data", onStderr);
-      child.once("error", (error) => {
+      function onError(error: Error): void {
+        if (finished) return;
+        finished = true;
+        cleanup();
         resolve({
           code: null,
           signal: null,
           error: reportError("[android-utils] `emulator` process error:", error),
         });
-      });
-      child.once("close", async (code, signal) => {
-        child.stderr?.removeListener("data", onStderr);
+      }
+
+      async function onClose(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
+        if (finished) return;
+        finished = true;
+        cleanup();
+
         if (!fallbackRequested) {
           resolve({ code, signal, error: null });
           return;
@@ -119,7 +132,11 @@ export async function spawnEmulator(
         activeChild = retried.value;
         activeGpuMode = "software";
         monitor(activeChild, activeGpuMode);
-      });
+      }
+
+      child.stderr?.on("data", onStderr);
+      child.once("error", onError);
+      child.once("close", onClose);
     };
 
     monitor(activeChild, activeGpuMode);

--- a/packages/@expo/hub-android-utils/src/errors.ts
+++ b/packages/@expo/hub-android-utils/src/errors.ts
@@ -12,6 +12,11 @@ export interface AndroidUtilsResult<T> {
   error: AndroidUtilsError | null;
 }
 
+/** Emit an informational message when the debug namespace is enabled. */
+export function logDebug(message: string): void {
+  debug("%s", message);
+}
+
 /** Create a utility failure and emit it when the debug namespace is enabled. */
 export function reportError(message: string, error: unknown): AndroidUtilsError {
   const captured = { message, error };

--- a/packages/@expo/hub-android-utils/src/types.ts
+++ b/packages/@expo/hub-android-utils/src/types.ts
@@ -122,13 +122,13 @@ export interface EmulatorExit {
 export interface BootedDevice {
   /** adb serial for the emulator, `emulator-<port>`. */
   serial: string;
-  /** OS process id of the spawned emulator; `null` when unavailable. */
+  /** OS process id of the active emulator; updated after a software GPU retry. */
   pid: number | null;
   /**
-   * The exact boot invocation as a runnable shell command. The emulator's
-   * output is discarded (the detached child outlives us), so this is what a
-   * failure report offers the user to reproduce the boot with the full
-   * emulator output visible.
+   * The active boot invocation as a runnable shell command. This switches to
+   * `-gpu software` after a host rendering fallback. Emulator output is
+   * otherwise discarded (the detached child outlives us), so this is what a
+   * failure report offers the user to reproduce the boot with full output.
    */
   command: string;
   /**

--- a/scripts/test-emulator-gpu-fallback.mjs
+++ b/scripts/test-emulator-gpu-fallback.mjs
@@ -5,22 +5,39 @@ const avdName = process.argv[2] ?? "Pixel_9";
 const hardwareRenderingError =
   "Your GPU cannot be used for hardware rendering";
 
+// The real server keeps Node alive. This timer plays that role while leaving
+// the emulator process and its pipes unreferenced, just like expo-device-hub.
+const serverKeepAlive = setInterval(() => {}, 60_000);
+
 function startEmulator(gpuMode) {
   return new Promise((resolve) => {
-    const emulator = spawn("emulator", [
-      "-avd",
-      avdName,
-      "-no-audio",
-      "-no-window",
-      "-gpu",
-      gpuMode,
-      "-no-boot-anim",
-    ]);
+    const emulator = spawn(
+      "emulator",
+      [
+        "-avd",
+        avdName,
+        "-no-audio",
+        "-no-window",
+        "-gpu",
+        gpuMode,
+        "-no-boot-anim",
+      ],
+      {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
 
     let stdoutTail = "";
     let stderrTail = "";
     let fallbackRequested = false;
     let finished = false;
+
+    emulator.once("spawn", () => {
+      emulator.unref();
+      emulator.stdout.unref();
+      emulator.stderr.unref();
+    });
 
     const inspectOutput = (tail, data) => {
       const output = tail + data.toString();
@@ -70,12 +87,16 @@ function startEmulator(gpuMode) {
   });
 }
 
-const hostAttempt = await startEmulator("host");
+try {
+  const hostAttempt = await startEmulator("host");
 
-if (hostAttempt.fallbackRequested && !hostAttempt.error) {
-  console.log("[fallback] Retrying with -gpu software.");
-  const softwareAttempt = await startEmulator("software");
-  process.exitCode = softwareAttempt.error ? 1 : (softwareAttempt.code ?? 1);
-} else {
-  process.exitCode = hostAttempt.error ? 1 : (hostAttempt.code ?? 1);
+  if (hostAttempt.fallbackRequested && !hostAttempt.error) {
+    console.log("[fallback] Retrying with -gpu software.");
+    const softwareAttempt = await startEmulator("software");
+    process.exitCode = softwareAttempt.error ? 1 : (softwareAttempt.code ?? 1);
+  } else {
+    process.exitCode = hostAttempt.error ? 1 : (hostAttempt.code ?? 1);
+  }
+} finally {
+  clearInterval(serverKeepAlive);
 }

--- a/scripts/test-emulator-gpu-fallback.mjs
+++ b/scripts/test-emulator-gpu-fallback.mjs
@@ -1,0 +1,81 @@
+import { spawn } from "node:child_process";
+
+// Usage: node scripts/test-emulator-gpu-fallback.mjs [AVD_NAME]
+const avdName = process.argv[2] ?? "Pixel_9";
+const hardwareRenderingError =
+  "Your GPU cannot be used for hardware rendering";
+
+function startEmulator(gpuMode) {
+  return new Promise((resolve) => {
+    const emulator = spawn("emulator", [
+      "-avd",
+      avdName,
+      "-no-audio",
+      "-no-window",
+      "-gpu",
+      gpuMode,
+      "-no-boot-anim",
+    ]);
+
+    let stdoutTail = "";
+    let stderrTail = "";
+    let fallbackRequested = false;
+    let finished = false;
+
+    const inspectOutput = (tail, data) => {
+      const output = tail + data.toString();
+
+      if (
+        gpuMode === "host" &&
+        !fallbackRequested &&
+        output.includes(hardwareRenderingError)
+      ) {
+        fallbackRequested = true;
+        console.log(
+          "[fallback] Hardware rendering is unavailable; stopping the host GPU attempt.",
+        );
+        emulator.kill();
+      }
+
+      return output.slice(-(hardwareRenderingError.length - 1));
+    };
+
+    emulator.stdout.on("data", (data) => {
+      console.log("[stdout]", data.toString());
+      stdoutTail = inspectOutput(stdoutTail, data);
+    });
+
+    emulator.stderr.on("data", (data) => {
+      console.error("[stderr]", data.toString());
+      stderrTail = inspectOutput(stderrTail, data);
+    });
+
+    emulator.on("error", (error) => {
+      console.error("[error]", error);
+
+      if (!finished) {
+        finished = true;
+        resolve({ fallbackRequested, error });
+      }
+    });
+
+    emulator.on("close", (code, signal) => {
+      console.log("[close]", { gpuMode, code, signal });
+
+      if (!finished) {
+        finished = true;
+        resolve({ fallbackRequested, code });
+      }
+    });
+  });
+}
+
+const hostAttempt = await startEmulator("host");
+
+if (hostAttempt.fallbackRequested && !hostAttempt.error) {
+  console.log("[fallback] Retrying with -gpu software.");
+  const softwareAttempt = await startEmulator("software");
+  process.exitCode = softwareAttempt.error ? 1 : (softwareAttempt.code ?? 1);
+} else {
+  process.exitCode = hostAttempt.error ? 1 : (hostAttempt.code ?? 1);
+}

--- a/scripts/test-emulator-gpu-fallback.mjs
+++ b/scripts/test-emulator-gpu-fallback.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 // Usage: node scripts/test-emulator-gpu-fallback.mjs [AVD_NAME]
 const avdName = process.argv[2] ?? "Pixel_9";
@@ -8,6 +8,26 @@ const hardwareRenderingError =
 // The real server keeps Node alive. This timer plays that role while leaving
 // the emulator process and its pipes unreferenced, just like expo-device-hub.
 const serverKeepAlive = setInterval(() => {}, 60_000);
+
+function stopEmulatorAttempt(emulator) {
+  if (process.platform === "win32" && emulator.pid) {
+    const stopped = spawnSync(
+      "taskkill",
+      ["/PID", String(emulator.pid), "/T", "/F"],
+      { stdio: "ignore", windowsHide: true },
+    );
+    if (!stopped.error && stopped.status === 0) return;
+  } else if (emulator.pid) {
+    try {
+      process.kill(-emulator.pid, "SIGKILL");
+      return;
+    } catch {
+      // The process may have exited between emitting output and being signaled.
+    }
+  }
+
+  emulator.kill("SIGKILL");
+}
 
 function startEmulator(gpuMode) {
   return new Promise((resolve) => {
@@ -51,7 +71,7 @@ function startEmulator(gpuMode) {
         console.log(
           "[fallback] Hardware rendering is unavailable; stopping the host GPU attempt.",
         );
-        emulator.kill();
+        stopEmulatorAttempt(emulator);
       }
 
       return output.slice(-(hardwareRenderingError.length - 1));


### PR DESCRIPTION
## Summary

- monitor Android Emulator stderr while starting with `-gpu host`
- detect the hardware-rendering-unavailable error and retry once with `-gpu software`
- keep the retry silent except for the existing `expo-device-hub:android-utils` debug namespace
- make the returned process lifecycle and diagnostic command follow the software-rendered retry
- document the fallback behavior

## Why

Headless workers without a usable hardware GPU fail when the emulator is forced to use `-gpu host`. The launcher previously discarded stderr, so it could neither identify that specific failure nor recover from it.

## User impact

Hosts with working hardware rendering keep the existing fast path. In environments where hardware rendering is unavailable, emulator startup now recovers automatically using the current Android Emulator software-rendering mode.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- focused fake-emulator test verifies the launch sequence is `host` followed by `software`
