### PR TITLE
feat(cli): add `--stream-mode mjpeg|h264|webrtc`

### DIFF
--- a/.changeset/simulator-stream-modes.md
+++ b/.changeset/simulator-stream-modes.md
@@ -2,5 +2,4 @@
 "expo-device-hub": minor
 ---
 
-Add H.264 and WebRTC iOS simulator streaming, including a standalone CLI flag for choosing the
-preferred mode.
+Add H.264, and WebRTC iOS simulator streaming.

--- a/.changeset/simulator-stream-modes.md
+++ b/.changeset/simulator-stream-modes.md
@@ -2,4 +2,5 @@
 "expo-device-hub": minor
 ---
 
-Add H.264, and WebRTC iOS simulator streaming.
+Add H.264 and WebRTC iOS simulator streaming, including a standalone CLI flag for choosing the
+preferred mode.

--- a/.changeset/stream-mode-flag.md
+++ b/.changeset/stream-mode-flag.md
@@ -1,0 +1,5 @@
+---
+"expo-device-hub": minor
+---
+
+Add `--stream-mode mjpeg|h264|webrtc` to the standalone CLI.

--- a/README.md
+++ b/README.md
@@ -57,22 +57,6 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
-Pass `--platform` to focus the standalone dashboard on one platform:
-
-```sh
-npx expo-device-hub --platform ios
-npx expo-device-hub --platform android
-```
-
-Choose the preferred iOS simulator stream mode with `--stream-mode`:
-
-```sh
-npx expo-device-hub --stream-mode h264
-```
-
-The accepted modes are `mjpeg`, `h264`, and `webrtc`. MJPEG is the default and is used
-automatically when the browser cannot use the requested mode.
-
 ## Repository structure
 
 This is a [Bun](https://bun.sh) workspace orchestrated with [Turborepo](https://turbo.build).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ npx expo-device-hub --platform ios
 npx expo-device-hub --platform android
 ```
 
+Choose the preferred iOS simulator stream mode with `--stream-mode`:
+
+```sh
+npx expo-device-hub --stream-mode h264
+```
+
+The accepted modes are `mjpeg`, `h264`, and `webrtc`. MJPEG is the default and is used
+automatically when the browser cannot use the requested mode.
+
 ## Repository structure
 
 This is a [Bun](https://bun.sh) workspace orchestrated with [Turborepo](https://turbo.build).

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -64,6 +64,15 @@ npx expo-device-hub --platform ios
 npx expo-device-hub --platform android
 ```
 
+Choose the preferred iOS simulator stream mode with `--stream-mode`:
+
+```sh
+npx expo-device-hub --stream-mode h264
+```
+
+The accepted modes are `mjpeg`, `h264`, and `webrtc`. MJPEG is the default and is used
+automatically when the browser cannot use the requested mode.
+
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -57,22 +57,6 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
-Pass `--platform` to focus the standalone dashboard on one platform:
-
-```sh
-npx expo-device-hub --platform ios
-npx expo-device-hub --platform android
-```
-
-Choose the preferred iOS simulator stream mode with `--stream-mode`:
-
-```sh
-npx expo-device-hub --stream-mode h264
-```
-
-The accepted modes are `mjpeg`, `h264`, and `webrtc`. MJPEG is the default and is used
-automatically when the browser cannot use the requested mode.
-
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/public/index.html
+++ b/packages/expo-device-hub/public/index.html
@@ -18,6 +18,10 @@
         if (platform === 'ios' || platform === 'android') {
           window.__EXPO_DEVICE_HUB_PLATFORM__ = platform;
         }
+        var streamMode = '{{streamMode}}';
+        if (streamMode === 'mjpeg' || streamMode === 'h264' || streamMode === 'webrtc') {
+          window.__EXPO_DEVICE_HUB_STREAM_MODE__ = streamMode;
+        }
       })();
     </script>
     <!-- The `react-native-web` recommended style reset: https://necolas.github.io/react-native-web/docs/setup/#root-element -->

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -36,6 +36,7 @@ import {
   resolveStreamMode,
 } from './dashboard/streamMode';
 import { dashboardPlatformFilter } from './platform-filter';
+import { dashboardStreamMode } from './stream-mode';
 
 /** Append `extra` devices not already present in `base` (deduped by id). */
 function mergeById(base: Device[], extra: Device[]): Device[] {
@@ -59,7 +60,6 @@ const DEFAULT_SIDEBAR_WIDTH = 400;
 const MIN_SIDEBAR_WIDTH = 280;
 const MAX_SIDEBAR_WIDTH = 560;
 const MIN_STREAM_WIDTH = 320;
-const DEFAULT_STREAM_MODE: DeviceStreamMode = 'mjpeg';
 
 /**
  * Clamp a dragged sidebar width to `[MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH]`, and
@@ -103,7 +103,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
     []
   );
   const [streamMode, setStreamMode] = useState<DeviceStreamMode>(() =>
-    resolveStreamMode(DEFAULT_STREAM_MODE, streamModeAvailability)
+    resolveStreamMode(dashboardStreamMode(), streamModeAvailability)
   );
   const handleStreamModeChange = (mode: DeviceStreamMode) => {
     setStreamMode(resolveStreamMode(mode, streamModeAvailability));

--- a/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { resolveStreamMode, streamModeAvailability } from '../streamMode';
+import { dashboardStreamMode, parseStreamMode } from '../../stream-mode';
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
 
 describe('stream mode availability', () => {
   test('enables all modes in a capable secure context such as localhost', () => {
@@ -28,5 +33,35 @@ describe('stream mode availability', () => {
     });
     expect(resolveStreamMode('mjpeg', availability)).toBe('mjpeg');
     expect(resolveStreamMode('h264', availability)).toBe('mjpeg');
+  });
+
+  test('uses the standalone host preference when it is available', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_STREAM_MODE__: 'webrtc' };
+    const availability = streamModeAvailability({
+      secureContext: true,
+      h264Decoder: true,
+      webRtc: true,
+    });
+    expect(resolveStreamMode(dashboardStreamMode(), availability)).toBe('webrtc');
+  });
+
+  test('falls back to MJPEG when the standalone preference is unavailable', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_STREAM_MODE__: 'h264' };
+    const availability = streamModeAvailability({
+      secureContext: false,
+      h264Decoder: true,
+      webRtc: true,
+    });
+    expect(resolveStreamMode(dashboardStreamMode(), availability)).toBe('mjpeg');
+  });
+});
+
+describe('parseStreamMode', () => {
+  test('accepts only supported stream modes', () => {
+    expect(parseStreamMode('mjpeg')).toBe('mjpeg');
+    expect(parseStreamMode('h264')).toBe('h264');
+    expect(parseStreamMode('webrtc')).toBe('webrtc');
+    expect(parseStreamMode('auto')).toBeUndefined();
+    expect(parseStreamMode(undefined)).toBeUndefined();
   });
 });

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -8,6 +8,7 @@ describe('parseCliOptions', () => {
       port: undefined,
       host: '127.0.0.1',
       platform: undefined,
+      streamMode: undefined,
       help: false,
     });
   });
@@ -21,11 +22,24 @@ describe('parseCliOptions', () => {
     expect(() => parseCliOptions(['--platform', 'web'])).toThrow('Invalid --platform: web');
   });
 
+  test('accepts each supported stream mode', () => {
+    expect(parseCliOptions(['--stream-mode', 'mjpeg']).streamMode).toBe('mjpeg');
+    expect(parseCliOptions(['--stream-mode=h264']).streamMode).toBe('h264');
+    expect(parseCliOptions(['--stream-mode', 'webrtc']).streamMode).toBe('webrtc');
+  });
+
+  test('rejects unsupported stream modes', () => {
+    expect(() => parseCliOptions(['--stream-mode', 'auto'])).toThrow(
+      'Invalid --stream-mode: auto'
+    );
+  });
+
   test('parses the existing host, port, and help options', () => {
     expect(parseCliOptions(['--host', '0.0.0.0', '-p', '4300'])).toEqual({
       port: 4300,
       host: '0.0.0.0',
       platform: undefined,
+      streamMode: undefined,
       help: false,
     });
     expect(parseCliOptions(['--help'])).toEqual({ host: '127.0.0.1', help: true });

--- a/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
@@ -3,17 +3,18 @@ import { describe, expect, test } from 'bun:test';
 import { configureClientShell } from '../client-shell';
 
 describe('configureClientShell', () => {
-  const shell = '<base href="{{mount}}/"> <script>var platform = "{{platform}}"</script>';
+  const shell =
+    '<base href="{{mount}}/"> <script>var platform = "{{platform}}"; var streamMode = "{{streamMode}}"</script>';
 
-  test('leaves the platform empty when the CLI option is omitted', () => {
-    expect(configureClientShell(shell, '', undefined)).toBe(
-      '<base href="/"> <script>var platform = ""</script>'
+  test('leaves CLI options empty when they are omitted', () => {
+    expect(configureClientShell(shell, '', undefined, undefined)).toBe(
+      '<base href="/"> <script>var platform = ""; var streamMode = ""</script>'
     );
   });
 
-  test('injects the selected platform and mount path', () => {
-    expect(configureClientShell(shell, '/hub', 'android')).toBe(
-      '<base href="/hub/"> <script>var platform = "android"</script>'
+  test('injects the selected options and mount path', () => {
+    expect(configureClientShell(shell, '/hub', 'android', 'webrtc')).toBe(
+      '<base href="/hub/"> <script>var platform = "android"; var streamMode = "webrtc"</script>'
     );
   });
 });

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -67,6 +67,11 @@ async function main(): Promise<void> {
   } else {
     delete process.env.EXPO_DEVICE_HUB_PLATFORM;
   }
+  if (options.streamMode) {
+    process.env.EXPO_DEVICE_HUB_STREAM_MODE = options.streamMode;
+  } else {
+    delete process.env.EXPO_DEVICE_HUB_STREAM_MODE;
+  }
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time
   const hubServer = (await import('./index.mjs')) as HubServerModule;
   const handler = hubServer.default;

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -1,6 +1,12 @@
 import { parseArgs } from 'node:util';
 
 import { parsePlatformFilter, type PlatformFilter } from '../../platform-filter';
+import {
+  DEFAULT_STREAM_MODE,
+  parseStreamMode,
+  STREAM_MODES,
+  type StreamMode,
+} from '../../stream-mode';
 
 export const DEFAULT_PORT = 3400;
 
@@ -12,6 +18,7 @@ Options:
   -p, --port <port>          Port to listen on (default: ${DEFAULT_PORT}, or the next available port)
       --host <host>          Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on your local network)
       --platform <platform>  Show only iOS simulators or Android emulators (ios or android)
+      --stream-mode <mode>   Preferred stream mode: ${STREAM_MODES.join(', ')} (default: ${DEFAULT_STREAM_MODE})
   -h, --help                 Show this help
 `;
 
@@ -19,11 +26,18 @@ export type CliOptions = {
   port?: number;
   host: string;
   platform?: PlatformFilter;
+  streamMode?: StreamMode;
   help: boolean;
 };
 
 export function parseCliOptions(args: string[]): CliOptions {
-  let values: { port?: string; host: string; platform?: string; help: boolean };
+  let values: {
+    port?: string;
+    host: string;
+    platform?: string;
+    'stream-mode'?: string;
+    help: boolean;
+  };
   try {
     ({ values } = parseArgs({
       args,
@@ -34,6 +48,7 @@ export function parseCliOptions(args: string[]): CliOptions {
         // v6-only listener leaves the advertised stream/ws endpoints unreachable.
         host: { type: 'string', default: '127.0.0.1' },
         platform: { type: 'string' },
+        'stream-mode': { type: 'string' },
         help: { type: 'boolean', short: 'h', default: false },
       },
     }));
@@ -53,5 +68,10 @@ export function parseCliOptions(args: string[]): CliOptions {
     throw new Error(`Invalid --platform: ${values.platform}\n\n${HELP}`);
   }
 
-  return { port, host: values.host, platform, help: false };
+  const streamMode = parseStreamMode(values['stream-mode']);
+  if (values['stream-mode'] !== undefined && streamMode === undefined) {
+    throw new Error(`Invalid --stream-mode: ${values['stream-mode']}\n\n${HELP}`);
+  }
+
+  return { port, host: values.host, platform, streamMode, help: false };
 }

--- a/packages/expo-device-hub/src/server/client-shell.ts
+++ b/packages/expo-device-hub/src/server/client-shell.ts
@@ -1,10 +1,15 @@
 import { type PlatformFilter } from '../platform-filter';
+import { type StreamMode } from '../stream-mode';
 
 /** Fill the runtime values consumed by the exported dashboard shell. */
 export function configureClientShell(
   html: string,
   mountPath: string,
-  platform: PlatformFilter | undefined
+  platform: PlatformFilter | undefined,
+  streamMode: StreamMode | undefined
 ): string {
-  return html.replaceAll('{{mount}}', mountPath).replaceAll('{{platform}}', platform ?? '');
+  return html
+    .replaceAll('{{mount}}', mountPath)
+    .replaceAll('{{platform}}', platform ?? '')
+    .replaceAll('{{streamMode}}', streamMode ?? '');
 }

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -28,6 +28,7 @@ import { SERVER_PLATFORM_FILTER } from './platform-filter';
 import { EMU_PREFIX, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
 import { SIM_PREFIX, handleSimRequest, simWebSocketHandler } from './serve-sim';
 import { listNewDeviceOptions } from './sim-options';
+import { SERVER_STREAM_MODE } from './stream-mode';
 
 const DEVICES_ROUTE = '/api/devices';
 const SHUTDOWN_DEVICE_ROUTE = '/api/devices/shutdown';
@@ -56,12 +57,15 @@ async function serveClientIndexHtml(): Promise<Response | null> {
       return null;
     }
   }
-  return new Response(configureClientShell(clientIndexHtml, MOUNT_PATH, SERVER_PLATFORM_FILTER), {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'no-store',
-    },
-  });
+  return new Response(
+    configureClientShell(clientIndexHtml, MOUNT_PATH, SERVER_PLATFORM_FILTER, SERVER_STREAM_MODE),
+    {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    }
+  );
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/packages/expo-device-hub/src/server/stream-mode.ts
+++ b/packages/expo-device-hub/src/server/stream-mode.ts
@@ -1,0 +1,7 @@
+import { parseStreamMode } from '../stream-mode';
+
+/** Set only by the standalone CLI before it imports the server bundle. */
+export const SERVER_STREAM_MODE =
+  process.env.EXPO_DEVICE_HUB_BASE_PATH === ''
+    ? parseStreamMode(process.env.EXPO_DEVICE_HUB_STREAM_MODE)
+    : undefined;

--- a/packages/expo-device-hub/src/stream-mode.ts
+++ b/packages/expo-device-hub/src/stream-mode.ts
@@ -1,0 +1,22 @@
+import { type DeviceStreamMode } from '@expo/hub-client';
+
+export type StreamMode = DeviceStreamMode;
+
+export const DEFAULT_STREAM_MODE: StreamMode = 'mjpeg';
+export const STREAM_MODES = ['mjpeg', 'h264', 'webrtc'] as const satisfies readonly StreamMode[];
+
+export function parseStreamMode(value: unknown): StreamMode | undefined {
+  return STREAM_MODES.includes(value as StreamMode) ? (value as StreamMode) : undefined;
+}
+
+declare global {
+  interface Window {
+    __EXPO_DEVICE_HUB_STREAM_MODE__?: StreamMode;
+  }
+}
+
+/** Stream mode selected by the standalone CLI, or MJPEG when none was provided. */
+export function dashboardStreamMode(): StreamMode {
+  if (typeof window === 'undefined') return DEFAULT_STREAM_MODE;
+  return parseStreamMode(window.__EXPO_DEVICE_HUB_STREAM_MODE__) ?? DEFAULT_STREAM_MODE;
+}


### PR DESCRIPTION
Add `--stream-mode mjpeg|h264|webrtc` to enabled defaulting to webrtc when hosting `expo-device-hub`.
