### PR TITLE
feat: show streamed device title

### DIFF
--- a/.changeset/device-stream-title.md
+++ b/.changeset/device-stream-title.md
@@ -1,0 +1,5 @@
+---
+"expo-device-hub": patch
+---
+
+Show the streamed device name above its frame and reveal its identifier on click.

--- a/.changeset/device-stream-title.md
+++ b/.changeset/device-stream-title.md
@@ -2,4 +2,4 @@
 "expo-device-hub": patch
 ---
 
-Show the streamed device name above its frame and reveal its identifier on click.
+Show a compact stream-status pill above the device frame and reveal its identifier on click.

--- a/packages/@expo/hub-components/src/__tests__/device-title.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/device-title.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DeviceTitle } from '../dashboard/DeviceTitle';
+
+describe('device title', () => {
+  test('caps long labels and truncates them with an ellipsis', () => {
+    const name = 'A very long simulator name that should not expand the stream layout';
+    const markup = renderToStaticMarkup(
+      <DeviceTitle
+        device={{ id: '00000000-0000-0000-0000-000000000000', name }}
+        status="streaming"
+      />
+    );
+
+    expect(markup).toContain('max-width:min(100%, 320px)');
+    expect(markup).toContain('box-sizing:border-box');
+    expect(markup).toContain('flex:1 1 auto');
+    expect(markup).toContain('min-width:0');
+    expect(markup).toContain('overflow:hidden');
+    expect(markup).toContain('text-overflow:ellipsis');
+    expect(markup).toContain('white-space:nowrap');
+    expect(markup).toContain(`title="${name}"`);
+  });
+});

--- a/packages/@expo/hub-components/src/__tests__/device-title.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/device-title.test.tsx
@@ -4,15 +4,17 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { DeviceTitle } from '../dashboard/DeviceTitle';
 
 describe('device title', () => {
-  test('caps long labels and truncates them with an ellipsis', () => {
-    const name = 'A very long simulator name that should not expand the stream layout';
+  test('keeps the status visible when a long label needs truncating', () => {
+    const name = '868BF88E-084A-4E9D-9434-C2D3C0C567F3';
     const markup = renderToStaticMarkup(
       <DeviceTitle
         device={{ id: '00000000-0000-0000-0000-000000000000', name }}
         status="streaming"
       />
     );
+    const buttonContent = markup.slice(markup.indexOf('>') + 1, markup.lastIndexOf('</button>'));
 
+    expect(buttonContent).toStartWith(`<span title="${name}"`);
     expect(markup).toContain('max-width:min(100%, 320px)');
     expect(markup).toContain('box-sizing:border-box');
     expect(markup).toContain('flex:1 1 auto');

--- a/packages/@expo/hub-components/src/components/Button.tsx
+++ b/packages/@expo/hub-components/src/components/Button.tsx
@@ -140,11 +140,7 @@ export function Button({
   const content = (
     <>
       {leftSlot}
-      {children != null && (
-        <span style={{ display: 'flex', minWidth: 0, maxWidth: '100%', lineHeight: 1 }}>
-          {children}
-        </span>
-      )}
+      {children != null && <span style={{ display: 'flex', lineHeight: 1 }}>{children}</span>}
       {rightSlot}
     </>
   );

--- a/packages/@expo/hub-components/src/components/Button.tsx
+++ b/packages/@expo/hub-components/src/components/Button.tsx
@@ -140,7 +140,11 @@ export function Button({
   const content = (
     <>
       {leftSlot}
-      {children != null && <span style={{ display: 'flex', lineHeight: 1 }}>{children}</span>}
+      {children != null && (
+        <span style={{ display: 'flex', minWidth: 0, maxWidth: '100%', lineHeight: 1 }}>
+          {children}
+        </span>
+      )}
       {rightSlot}
     </>
   );

--- a/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
@@ -1,34 +1,65 @@
 import { useState } from 'react';
 
-import { Button, font, heading } from '../primitives';
+import { type ConnectionStatus } from '@expo/hub-client';
+import { Button, font, icon, radius, text } from '../primitives';
 import { type Device } from './data';
 
 export type DeviceTitleProps = {
   device: Pick<Device, 'id' | 'name'>;
+  status: ConnectionStatus;
 };
 
-/** Clickable stream title that toggles between a device's name and identifier. */
-export function DeviceTitle({ device }: DeviceTitleProps) {
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  idle: 'Offline',
+  connecting: 'Connecting',
+  streaming: 'Live',
+  error: 'Error',
+};
+
+/** Compact stream-status pill that toggles between a device's name and identifier. */
+export function DeviceTitle({ device, status }: DeviceTitleProps) {
   const [revealedId, setRevealedId] = useState<string | null>(null);
   const showingId = revealedId === device.id;
   const label = showingId ? device.id : device.name;
+  const live = status === 'streaming';
 
   return (
     <Button
-      theme="quaternary"
+      theme="secondary"
       size="2xs"
       onClick={() => setRevealedId(showingId ? null : device.id)}
-      style={{ ...heading.sm, maxWidth: '100%' }}>
+      style={{ maxWidth: '100%', borderRadius: radius.full }}>
       <span
-        title={label}
         style={{
-          display: 'block',
-          maxWidth: 'min(70vw, 480px)',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          fontFamily: showingId ? font.mono : font.sans,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          minWidth: 0,
         }}>
-        {label}
+        <span
+          title={label}
+          style={{
+            display: 'block',
+            maxWidth: 'min(65vw, 420px)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            fontFamily: showingId ? font.mono : font.sans,
+          }}>
+          {label}
+        </span>
+        <span
+          aria-hidden
+          style={{
+            width: 6,
+            height: 6,
+            flexShrink: 0,
+            borderRadius: radius.full,
+            backgroundColor: live ? icon.success : icon.danger,
+          }}
+        />
+        <span aria-live="polite" style={{ flexShrink: 0, color: text.secondary }}>
+          {STATUS_LABEL[status]}
+        </span>
       </span>
     </Button>
   );

--- a/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import { Button, font, heading } from '../primitives';
+import { type Device } from './data';
+
+export type DeviceTitleProps = {
+  device: Pick<Device, 'id' | 'name'>;
+};
+
+/** Clickable stream title that toggles between a device's name and identifier. */
+export function DeviceTitle({ device }: DeviceTitleProps) {
+  const [revealedId, setRevealedId] = useState<string | null>(null);
+  const showingId = revealedId === device.id;
+  const label = showingId ? device.id : device.name;
+
+  return (
+    <Button
+      theme="quaternary"
+      size="2xs"
+      onClick={() => setRevealedId(showingId ? null : device.id)}
+      style={{ ...heading.sm, maxWidth: '100%' }}>
+      <span
+        title={label}
+        style={{
+          display: 'block',
+          maxWidth: 'min(70vw, 480px)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          fontFamily: showingId ? font.mono : font.sans,
+        }}>
+        {label}
+      </span>
+    </Button>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { type ConnectionStatus } from '@expo/hub-client';
-import { Button, font, icon, radius, text } from '../primitives';
+import { border, Button, font, icon, radius, text } from '../primitives';
 import { type Device } from './data';
 
 export type DeviceTitleProps = {
@@ -9,11 +9,34 @@ export type DeviceTitleProps = {
   status: ConnectionStatus;
 };
 
-const STATUS_LABEL: Record<ConnectionStatus, string> = {
-  idle: 'Offline',
-  connecting: 'Connecting',
-  streaming: 'Live',
-  error: 'Error',
+const STATUS_APPEARANCE: Record<
+  ConnectionStatus,
+  { label: string; dotColor: string; ringColor: string; labelColor: string }
+> = {
+  idle: {
+    label: 'Offline',
+    dotColor: icon.danger,
+    ringColor: border.danger,
+    labelColor: text.secondary,
+  },
+  connecting: {
+    label: 'Starting',
+    dotColor: icon.warning,
+    ringColor: border.warning,
+    labelColor: text.secondary,
+  },
+  streaming: {
+    label: 'Live',
+    dotColor: text.success,
+    ringColor: border.success,
+    labelColor: text.success,
+  },
+  error: {
+    label: 'Error',
+    dotColor: icon.danger,
+    ringColor: border.danger,
+    labelColor: text.secondary,
+  },
 };
 
 /** Compact stream-status pill that toggles between a device's name and identifier. */
@@ -21,14 +44,21 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
   const [revealedId, setRevealedId] = useState<string | null>(null);
   const showingId = revealedId === device.id;
   const label = showingId ? device.id : device.name;
-  const live = status === 'streaming';
+  const appearance = STATUS_APPEARANCE[status];
 
   return (
     <Button
-      theme="secondary"
+      theme="tertiary"
       size="2xs"
       onClick={() => setRevealedId(showingId ? null : device.id)}
-      style={{ maxWidth: '100%', borderRadius: radius.full }}>
+      style={{
+        maxWidth: '100%',
+        flexShrink: 0,
+        paddingInline: 12,
+        borderWidth: 0.5,
+        borderColor: border.default,
+        borderRadius: radius.full,
+      }}>
       <span
         style={{
           display: 'flex',
@@ -53,12 +83,14 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
             width: 6,
             height: 6,
             flexShrink: 0,
+            boxSizing: 'content-box',
+            border: `2px solid ${appearance.ringColor}`,
             borderRadius: radius.full,
-            backgroundColor: live ? icon.success : icon.danger,
+            backgroundColor: appearance.dotColor,
           }}
         />
-        <span aria-live="polite" style={{ flexShrink: 0, color: text.secondary }}>
-          {STATUS_LABEL[status]}
+        <span aria-live="polite" style={{ flexShrink: 0, color: appearance.labelColor }}>
+          {appearance.label}
         </span>
       </span>
     </Button>

--- a/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
@@ -52,8 +52,10 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
       size="2xs"
       onClick={() => setRevealedId(showingId ? null : device.id)}
       style={{
-        maxWidth: '100%',
+        maxWidth: 'min(100%, 320px)',
+        minWidth: 0,
         flexShrink: 0,
+        boxSizing: 'border-box',
         paddingInline: 12,
         borderWidth: 0.5,
         borderColor: border.default,
@@ -64,15 +66,18 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
           display: 'flex',
           alignItems: 'center',
           gap: 6,
+          maxWidth: '100%',
           minWidth: 0,
         }}>
         <span
           title={label}
           style={{
             display: 'block',
-            maxWidth: 'min(65vw, 420px)',
+            flex: '1 1 auto',
+            minWidth: 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
             fontFamily: showingId ? font.mono : font.sans,
           }}>
           {label}

--- a/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceTitle.tsx
@@ -51,24 +51,7 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
       theme="tertiary"
       size="2xs"
       onClick={() => setRevealedId(showingId ? null : device.id)}
-      style={{
-        maxWidth: 'min(100%, 320px)',
-        minWidth: 0,
-        flexShrink: 0,
-        boxSizing: 'border-box',
-        paddingInline: 12,
-        borderWidth: 0.5,
-        borderColor: border.default,
-        borderRadius: radius.full,
-      }}>
-      <span
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          maxWidth: '100%',
-          minWidth: 0,
-        }}>
+      leftSlot={
         <span
           title={label}
           style={{
@@ -82,22 +65,37 @@ export function DeviceTitle({ device, status }: DeviceTitleProps) {
           }}>
           {label}
         </span>
-        <span
-          aria-hidden
-          style={{
-            width: 6,
-            height: 6,
-            flexShrink: 0,
-            boxSizing: 'content-box',
-            border: `2px solid ${appearance.ringColor}`,
-            borderRadius: radius.full,
-            backgroundColor: appearance.dotColor,
-          }}
-        />
-        <span aria-live="polite" style={{ flexShrink: 0, color: appearance.labelColor }}>
-          {appearance.label}
-        </span>
-      </span>
-    </Button>
+      }
+      rightSlot={
+        <>
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              flexShrink: 0,
+              boxSizing: 'content-box',
+              border: `2px solid ${appearance.ringColor}`,
+              borderRadius: radius.full,
+              backgroundColor: appearance.dotColor,
+            }}
+          />
+          <span aria-live="polite" style={{ flexShrink: 0, color: appearance.labelColor }}>
+            {appearance.label}
+          </span>
+        </>
+      }
+      style={{
+        maxWidth: 'min(100%, 320px)',
+        minWidth: 0,
+        flexShrink: 0,
+        boxSizing: 'border-box',
+        gap: 6,
+        paddingInline: 12,
+        borderWidth: 0.5,
+        borderColor: border.default,
+        borderRadius: radius.full,
+      }}
+    />
   );
 }

--- a/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
+++ b/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
@@ -13,8 +13,8 @@ import { deviceScreenClipPath } from './deviceScreenClipPath';
 
 const SHADOW = '0 40px 80px rgba(0, 0, 0, 0.4), 0 12px 28px rgba(0, 0, 0, 0.28)';
 
-// Room reserved for the controls + panel padding when sizing by height.
-const RESERVED_VERTICAL = 210;
+// Room reserved for the title, controls, gaps, and panel padding when sizing by height.
+const RESERVED_VERTICAL = 250;
 
 // Cap on the device's *short* side (portrait width / landscape height). Sizing
 // by the short side keeps the physical phone the same size across rotations:

--- a/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
+++ b/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
@@ -14,7 +14,7 @@ import { deviceScreenClipPath } from './deviceScreenClipPath';
 const SHADOW = '0 40px 80px rgba(0, 0, 0, 0.4), 0 12px 28px rgba(0, 0, 0, 0.28)';
 
 // Room reserved for the title, controls, gaps, and panel padding when sizing by height.
-const RESERVED_VERTICAL = 250;
+const RESERVED_VERTICAL = 258;
 
 // Cap on the device's *short* side (portrait width / landscape height). Sizing
 // by the short side keeps the physical phone the same size across rotations:

--- a/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
@@ -91,7 +91,7 @@ export function StreamPanel({
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: 12,
+          gap: 20,
           width: '100%',
           minHeight: 0,
         }}>

--- a/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from '@expo/hub-client';
 import { bg, border, radius, shadow } from '../primitives';
 import { type Device } from './data';
+import { DeviceTitle } from './DeviceTitle';
 import { PhoneFrame } from './PhoneFrame';
 import { StreamControls } from './StreamControls';
 
@@ -85,13 +86,24 @@ export function StreamPanel({
         boxShadow: framed ? shadow.sm : 'none',
         overflow: 'hidden',
       }}>
-      <PhoneFrame
-        platform={device.platform}
-        client={client}
-        agentInteraction={agentInteraction}
-        DeviceScreen={DeviceScreen}
-        displayScreen={displayScreen}
-      />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 12,
+          width: '100%',
+          minHeight: 0,
+        }}>
+        <DeviceTitle key={device.id} device={device} />
+        <PhoneFrame
+          platform={device.platform}
+          client={client}
+          agentInteraction={agentInteraction}
+          DeviceScreen={DeviceScreen}
+          displayScreen={displayScreen}
+        />
+      </div>
       <StreamControls
         platform={device.platform}
         physical={device.physical}

--- a/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
@@ -95,7 +95,7 @@ export function StreamPanel({
           width: '100%',
           minHeight: 0,
         }}>
-        <DeviceTitle key={device.id} device={device} />
+        <DeviceTitle key={device.id} device={device} status={client.status} />
         <PhoneFrame
           platform={device.platform}
           client={client}

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -53,6 +53,7 @@ export * from './theme/tokens';
 export { Sidebar } from './dashboard/Sidebar';
 export { LogSidebar, type LogSidebarProps } from './dashboard/LogSidebar';
 export { StreamPanel } from './dashboard/StreamPanel';
+export { DeviceTitle, type DeviceTitleProps } from './dashboard/DeviceTitle';
 export { EmptyState } from './dashboard/EmptyState';
 export { DeviceSection, type DeviceSectionProps } from './dashboard/DeviceSection';
 export { OutputSection } from './dashboard/OutputSection';


### PR DESCRIPTION
## Summary

- show the streamed device name in a compact pill above its frame
- match the supplied Figma tag geometry with a 28px outlined pill, 12px typography, semantic status ring, and 12px horizontal padding
- show green Live, orange Starting, and red Offline/Error states
- toggle the label to the iOS UDID or Android ADB serial on click
- cap the full pill at 320px and ellipsize long names or identifiers while keeping status visible
- keep 20px between the pill and device frame, preserve responsive frame sizing, and add a patch changeset

## Verification

- `bun run test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test packages/@expo/hub-components/src/__tests__/device-title.test.tsx packages/@expo/hub-components/src/__tests__/agent-device-status.test.tsx`
- agent-browser: measured the live pill at 28px high with 12px padding, a 6px center/2px ring, the Figma border color token, and a 20px frame gap on a real iPhone stream
- agent-browser: verified name-to-UDID click behavior after the design update; the Android serial flow remains covered