### PR TITLE
Add CLI option to hide the device sidebar

### DIFF
--- a/.changeset/hide-sidebar.md
+++ b/.changeset/hide-sidebar.md
@@ -1,0 +1,5 @@
+---
+"expo-device-hub": minor
+---
+
+Add `--hide-sidebar` to the standalone CLI.

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -57,6 +57,13 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
+Pass `--hide-sidebar` to start with the device list collapsed. The sidebar can still be
+opened from the toggle in the upper-left corner:
+
+```sh
+npx expo-device-hub --hide-sidebar
+```
+
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -57,13 +57,6 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
-Pass `--hide-sidebar` to start with the device list collapsed. The sidebar can still be
-opened from the toggle in the upper-left corner:
-
-```sh
-npx expo-device-hub --hide-sidebar
-```
-
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/public/index.html
+++ b/packages/expo-device-hub/public/index.html
@@ -22,6 +22,9 @@
         if (transport === 'mjpeg' || transport === 'h264' || transport === 'webrtc') {
           window.__EXPO_DEVICE_HUB_TRANSPORT__ = transport;
         }
+        if ('{{hideSidebar}}' === 'true') {
+          window.__EXPO_DEVICE_HUB_HIDE_SIDEBAR__ = true;
+        }
       })();
     </script>
     <!-- The `react-native-web` recommended style reset: https://necolas.github.io/react-native-web/docs/setup/#root-element -->

--- a/packages/expo-device-hub/src/dashboard/__tests__/dashboardStore.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/dashboardStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { type Device } from '@expo/hub-components';
 
@@ -13,6 +13,10 @@ const iosDevice: Device = {
   physical: false,
   supported: true,
 };
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
 
 describe('dashboard store', () => {
   test('tracks a replacement device and selects it', () => {
@@ -75,5 +79,13 @@ describe('dashboard store', () => {
 
     store.getState().closeSidebar('left');
     expect(store.getState().sidebarPreferences.left).toBe('hidden');
+  });
+
+  test('uses the standalone shell preference for the initial left sidebar state', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_HIDE_SIDEBAR__: true };
+
+    const store = createDashboardStore();
+
+    expect(store.getState().sidebarPreferences).toEqual({ left: 'hidden', right: 'auto' });
   });
 });

--- a/packages/expo-device-hub/src/dashboard/__tests__/sidebarPreference.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/sidebarPreference.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { dashboardHideSidebar } from '../../sidebar';
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('dashboardHideSidebar', () => {
+  test('uses the preference provided by the standalone shell', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_HIDE_SIDEBAR__: true };
+    expect(dashboardHideSidebar()).toBe(true);
+  });
+
+  test('keeps the sidebar visible by default', () => {
+    expect(dashboardHideSidebar()).toBe(false);
+  });
+});

--- a/packages/expo-device-hub/src/dashboard/dashboardStore.ts
+++ b/packages/expo-device-hub/src/dashboard/dashboardStore.ts
@@ -2,6 +2,7 @@ import { type DeviceStreamMode } from '@expo/hub-client';
 import { type Device, type StreamModeAvailability } from '@expo/hub-components';
 import { create } from 'zustand';
 
+import { dashboardHideSidebar } from '../sidebar';
 import { dashboardTransport } from '../transport';
 import { browserStreamModeAvailability, resolveStreamMode } from './streamMode';
 
@@ -72,7 +73,10 @@ function defaultDashboardStoreValues(): DashboardStoreValues {
     addedDevices: [],
     streamMode: resolveStreamMode(dashboardTransport(), availability),
     sidebarWidths: { left: DEFAULT_SIDEBAR_WIDTH, right: DEFAULT_SIDEBAR_WIDTH },
-    sidebarPreferences: { left: 'auto', right: 'auto' },
+    sidebarPreferences: {
+      left: dashboardHideSidebar() ? 'hidden' : 'auto',
+      right: 'auto',
+    },
     lastOpenedSidebar: 'right',
     hideUnsupportedDevices: initialHideUnsupportedDevices(),
   };

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -9,6 +9,7 @@ describe('parseCliOptions', () => {
       host: '127.0.0.1',
       platform: undefined,
       transport: undefined,
+      hideSidebar: false,
       help: false,
     });
   });
@@ -32,6 +33,11 @@ describe('parseCliOptions', () => {
     expect(() => parseCliOptions(['--transport', 'auto'])).toThrow('Invalid --transport: auto');
   });
 
+  test('hides the device list sidebar on request', () => {
+    expect(parseCliOptions(['--hide-sidebar']).hideSidebar).toBe(true);
+    expect(HELP).toContain('--hide-sidebar');
+  });
+
   test('replaces the old stream-mode flag', () => {
     expect(HELP).toContain('--transport <transport>');
     expect(HELP).not.toContain('--stream-mode');
@@ -46,6 +52,7 @@ describe('parseCliOptions', () => {
       host: '0.0.0.0',
       platform: undefined,
       transport: undefined,
+      hideSidebar: false,
       help: false,
     });
     expect(parseCliOptions(['--help'])).toEqual({ host: '127.0.0.1', help: true });

--- a/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
@@ -4,17 +4,17 @@ import { configureClientShell } from '../client-shell';
 
 describe('configureClientShell', () => {
   const shell =
-    '<base href="{{mount}}/"> <script>var platform = "{{platform}}"; var transport = "{{transport}}"</script>';
+    '<base href="{{mount}}/"> <script>var platform = "{{platform}}"; var transport = "{{transport}}"; var hideSidebar = "{{hideSidebar}}"</script>';
 
   test('leaves CLI options empty when they are omitted', () => {
-    expect(configureClientShell(shell, '', undefined, undefined)).toBe(
-      '<base href="/"> <script>var platform = ""; var transport = ""</script>'
+    expect(configureClientShell(shell, '', undefined, undefined, false)).toBe(
+      '<base href="/"> <script>var platform = ""; var transport = ""; var hideSidebar = "false"</script>'
     );
   });
 
   test('injects the selected options and mount path', () => {
-    expect(configureClientShell(shell, '/hub', 'android', 'webrtc')).toBe(
-      '<base href="/hub/"> <script>var platform = "android"; var transport = "webrtc"</script>'
+    expect(configureClientShell(shell, '/hub', 'android', 'webrtc', true)).toBe(
+      '<base href="/hub/"> <script>var platform = "android"; var transport = "webrtc"; var hideSidebar = "true"</script>'
     );
   });
 });

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -72,6 +72,11 @@ async function main(): Promise<void> {
   } else {
     delete process.env.EXPO_DEVICE_HUB_TRANSPORT;
   }
+  if (options.hideSidebar) {
+    process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR = 'true';
+  } else {
+    delete process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR;
+  }
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time
   const hubServer = (await import('./index.mjs')) as HubServerModule;
   const handler = hubServer.default;

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -19,6 +19,7 @@ Options:
       --host <host>          Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on your local network)
       --platform <platform>  Show only iOS simulators or Android emulators (ios or android)
       --transport <transport> Preferred transport: ${TRANSPORTS.join(', ')} (default: ${DEFAULT_TRANSPORT})
+      --hide-sidebar         Hide the device list sidebar by default
   -h, --help                 Show this help
 `;
 
@@ -27,6 +28,7 @@ export type CliOptions = {
   host: string;
   platform?: PlatformFilter;
   transport?: Transport;
+  hideSidebar: boolean;
   help: boolean;
 };
 
@@ -36,6 +38,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     host: string;
     platform?: string;
     transport?: string;
+    'hide-sidebar': boolean;
     help: boolean;
   };
   try {
@@ -49,6 +52,7 @@ export function parseCliOptions(args: string[]): CliOptions {
         host: { type: 'string', default: '127.0.0.1' },
         platform: { type: 'string' },
         transport: { type: 'string' },
+        'hide-sidebar': { type: 'boolean', default: false },
         help: { type: 'boolean', short: 'h', default: false },
       },
     }));
@@ -73,5 +77,12 @@ export function parseCliOptions(args: string[]): CliOptions {
     throw new Error(`Invalid --transport: ${values.transport}\n\n${HELP}`);
   }
 
-  return { port, host: values.host, platform, transport, help: false };
+  return {
+    port,
+    host: values.host,
+    platform,
+    transport,
+    hideSidebar: values['hide-sidebar'],
+    help: false,
+  };
 }

--- a/packages/expo-device-hub/src/server/client-shell.ts
+++ b/packages/expo-device-hub/src/server/client-shell.ts
@@ -6,10 +6,12 @@ export function configureClientShell(
   html: string,
   mountPath: string,
   platform: PlatformFilter | undefined,
-  transport: Transport | undefined
+  transport: Transport | undefined,
+  hideSidebar: boolean
 ): string {
   return html
     .replaceAll('{{mount}}', mountPath)
     .replaceAll('{{platform}}', platform ?? '')
-    .replaceAll('{{transport}}', transport ?? '');
+    .replaceAll('{{transport}}', transport ?? '')
+    .replaceAll('{{hideSidebar}}', String(hideSidebar));
 }

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -27,6 +27,7 @@ import { MOUNT_PATH } from './mount';
 import { SERVER_PLATFORM_FILTER } from './platform-filter';
 import { EMU_PREFIX, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
 import { SIM_PREFIX, handleSimRequest, simWebSocketHandler } from './serve-sim';
+import { SERVER_HIDE_SIDEBAR } from './sidebar';
 import { listNewDeviceOptions } from './sim-options';
 import { SERVER_TRANSPORT } from './transport';
 
@@ -58,7 +59,13 @@ async function serveClientIndexHtml(): Promise<Response | null> {
     }
   }
   return new Response(
-    configureClientShell(clientIndexHtml, MOUNT_PATH, SERVER_PLATFORM_FILTER, SERVER_TRANSPORT),
+    configureClientShell(
+      clientIndexHtml,
+      MOUNT_PATH,
+      SERVER_PLATFORM_FILTER,
+      SERVER_TRANSPORT,
+      SERVER_HIDE_SIDEBAR
+    ),
     {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',

--- a/packages/expo-device-hub/src/server/sidebar.ts
+++ b/packages/expo-device-hub/src/server/sidebar.ts
@@ -1,0 +1,4 @@
+/** Set only by the standalone CLI before it imports the server bundle. */
+export const SERVER_HIDE_SIDEBAR =
+  process.env.EXPO_DEVICE_HUB_BASE_PATH === '' &&
+  process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR === 'true';

--- a/packages/expo-device-hub/src/sidebar.ts
+++ b/packages/expo-device-hub/src/sidebar.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    __EXPO_DEVICE_HUB_HIDE_SIDEBAR__?: boolean;
+  }
+}
+
+/** Whether the standalone CLI asked the dashboard to start with its device list hidden. */
+export function dashboardHideSidebar(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.__EXPO_DEVICE_HUB_HIDE_SIDEBAR__ === true;
+}


### PR DESCRIPTION
Add `--hide-sidebar` option to the CLI, which let's hosted version, intended for one simulator, start with UI focused on the running device.