### PR TITLE
fix(hub-client): honor serve-sim WebRTC settings

### DIFF
--- a/.changeset/calm-sims-connect.md
+++ b/.changeset/calm-sims-connect.md
@@ -1,0 +1,6 @@
+---
+"@expo/hub-client": patch
+"expo-device-hub": patch
+---
+
+Honor serve-sim WebRTC codec and ICE settings in Expo Device Hub and expose viewer codec controls.

--- a/packages/@expo/hub-client/src/__tests__/ios-preview-config.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/ios-preview-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveIosPreviewConfig } from '../useIosDevice';
+
+describe('resolveIosPreviewConfig', () => {
+  test('preserves serve-sim WebRTC codec and ICE settings', () => {
+    const resolved = resolveIosPreviewConfig(
+      {
+        url: 'http://127.0.0.1:3101',
+        streamUrl: 'http://127.0.0.1:3101/stream.mjpeg',
+        wsUrl: 'ws://localhost/helper/DEVICE-A/ws',
+        device: 'DEVICE-A',
+        streamSettings: {
+          transport: 'webrtc',
+          codec: 'vp8',
+          iceServers: [
+            {
+              urls: ['turns:relay.example.test:443'],
+              username: 'viewer',
+              credential: 'secret',
+            },
+          ],
+        },
+      },
+      { protocol: 'https:', host: 'hub.example.test' },
+      'https://hub.example.test/vendor/serve-sim',
+    );
+
+    expect(resolved).toMatchObject({
+      webRtcCodec: 'vp8',
+      iceServers: [
+        {
+          urls: ['turns:relay.example.test:443'],
+          username: 'viewer',
+          credential: 'secret',
+        },
+      ],
+    });
+  });
+
+  test('falls back safely when advertised WebRTC settings are malformed', () => {
+    const resolved = resolveIosPreviewConfig(
+      {
+        url: 'http://127.0.0.1:3101',
+        wsUrl: 'ws://localhost/helper/DEVICE-A/ws',
+        device: 'DEVICE-A',
+        streamSettings: {
+          transport: 'webrtc',
+          codec: 'unknown',
+          iceServers: [{ urls: ['https://not-an-ice-server.example.test'] }],
+        },
+      },
+      { protocol: 'https:', host: 'hub.example.test' },
+      'https://hub.example.test/vendor/serve-sim',
+    );
+
+    expect(resolved.webRtcCodec).toBe('h264');
+    expect(resolved.iceServers).toBeUndefined();
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-fallback.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-fallback.test.ts
@@ -13,6 +13,12 @@ describe('WebRTC fallback', () => {
     expect(nextWebRtcFallbackCodec('h264', 'vp9')).toBe(null);
   });
 
+  test('keeps fallback ordering anchored to the configured codec', () => {
+    expect(nextWebRtcFallbackCodec('vp8', 'vp8')).toBe(null);
+    expect(nextWebRtcFallbackCodec('vp9', 'vp9')).toBe('vp8');
+    expect(nextWebRtcFallbackCodec('vp9', 'vp8')).toBe(null);
+  });
+
   test('switches to HTTP after codecs are exhausted or signaling is permanent', () => {
     expect(webRtcFallbackDecision('h264', 'h264', { kind: 'permanent' })).toEqual({
       type: 'switch-to-http',

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -24,6 +24,9 @@ export type DevicePlatform = 'ios' | 'android';
 /** Viewer-selected transport for serve-sim video. */
 export type DeviceStreamMode = 'mjpeg' | 'h264' | 'webrtc';
 
+/** Viewer-selected WebRTC codec preference for serve-sim video. */
+export type DeviceWebRtcCodec = 'h264' | 'vp8' | 'vp9';
+
 /**
  * Lifecycle of a single connection:
  *   idle       — nothing to connect to (no base URL / disabled)
@@ -172,6 +175,10 @@ export interface DeviceClient {
   screen: ScreenSize | null;
   /** Best-effort frames-per-second (0 when unavailable). */
   fps: number;
+  /** Requested WebRTC codec for iOS, or null on backends without WebRTC. */
+  webRtcCodec: DeviceWebRtcCodec | null;
+  /** Change the viewer-local WebRTC codec preference and renegotiate the stream. */
+  setWebRtcCodec: (codec: DeviceWebRtcCodec) => void;
   /** Running devices the server exposes (may be a placeholder list). */
   devices: RunningDevice[];
   /** Rolling buffer of recent log lines (best-effort; may be empty). */

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -661,6 +661,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     error,
     screen,
     fps,
+    webRtcCodec: null,
+    setWebRtcCodec: () => {},
     devices,
     logs,
     logsEnabled,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -43,6 +43,7 @@ import {
   type DeviceConnectionOptions,
   type DeviceLog,
   type DeviceOrientation,
+  type DeviceWebRtcCodec,
   type ForegroundApp,
   type HardwareButton,
   type KeyboardInput,
@@ -53,7 +54,7 @@ import {
 } from './types';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
 import { useAvccStream } from './useAvccStream';
-import { useWebRtcStream } from './useWebRtcStream';
+import { type WebRtcIceServer, useWebRtcStream } from './useWebRtcStream';
 import {
   type WebRtcCodec,
   webRtcFallbackDecision,
@@ -265,6 +266,8 @@ interface ResolvedConfig {
   /** Absolute URL of the foreground-app SSE stream. */
   appStateUrl: string | null;
   gridApiUrl: string | null;
+  webRtcCodec: WebRtcCodec;
+  iceServers?: WebRtcIceServer[];
 }
 
 /** Shape of the serve-sim middleware `/api` (and grid) responses we read. */
@@ -279,6 +282,83 @@ interface PreviewApi {
   appStateEndpoint?: string;
   gridApiEndpoint?: string;
   proxyHelpers?: boolean;
+  streamSettings?: {
+    transport?: unknown;
+    codec?: unknown;
+    iceServers?: unknown;
+  };
+}
+
+type BrowserLocation = Pick<Location, 'host' | 'protocol'>;
+
+function previewIceServers(value: unknown): WebRtcIceServer[] | undefined {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 16) return undefined;
+  const servers: WebRtcIceServer[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') return undefined;
+    const { urls, username, credential } = entry as {
+      urls?: unknown;
+      username?: unknown;
+      credential?: unknown;
+    };
+    if (
+      !Array.isArray(urls) ||
+      urls.length === 0 ||
+      urls.length > 16 ||
+      !urls.every(
+        (url) =>
+          typeof url === 'string' &&
+          url.length <= 2_048 &&
+          /^(stun|stuns|turn|turns):/i.test(url),
+      ) ||
+      (username !== undefined && typeof username !== 'string') ||
+      (credential !== undefined && typeof credential !== 'string')
+    ) {
+      return undefined;
+    }
+    servers.push({
+      urls,
+      ...(typeof username === 'string' ? { username } : {}),
+      ...(typeof credential === 'string' ? { credential } : {}),
+    });
+  }
+  return servers;
+}
+
+function previewWebRtcSettings(settings: PreviewApi['streamSettings']): {
+  webRtcCodec: WebRtcCodec;
+  iceServers?: WebRtcIceServer[];
+} {
+  if (settings?.transport !== 'webrtc') return { webRtcCodec: 'h264' };
+  const webRtcCodec =
+    settings.codec === 'vp8' || settings.codec === 'vp9' || settings.codec === 'h264'
+      ? settings.codec
+      : 'h264';
+  const iceServers = previewIceServers(settings.iceServers);
+  return { webRtcCodec, ...(iceServers ? { iceServers } : {}) };
+}
+
+/** Convert serve-sim's middleware response into the URLs consumed by the iOS client. */
+export function resolveIosPreviewConfig(
+  rawConfig: PreviewApi,
+  browserLocation: BrowserLocation,
+  baseUrl: string,
+): ResolvedConfig {
+  const c = proxyPreviewConfigForBrowser(rawConfig, browserLocation);
+  const basePath = c.basePath ?? '';
+  const webRtcSettings = previewWebRtcSettings(c.streamSettings);
+  return {
+    url: c.url!,
+    streamUrl: c.streamUrl ?? `${c.url}/stream.mjpeg`,
+    wsUrl: toQueryStyleHelperWsUrl(c.wsUrl ?? `${toWs(c.url!)}/ws`),
+    device: c.device ?? null,
+    execWsUrl: toWs(new URL(`${basePath}/exec-ws`, baseUrl).toString()),
+    execToken: c.execToken ?? null,
+    logsPath: c.logsEndpoint ?? null,
+    appStateUrl: c.appStateEndpoint ? new URL(c.appStateEndpoint, baseUrl).toString() : null,
+    gridApiUrl: new URL(c.gridApiEndpoint ?? '/grid/api', baseUrl).toString(),
+    ...webRtcSettings,
+  };
 }
 
 export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClient {
@@ -314,8 +394,10 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamUrlRef = useRef<string | null>(null);
   const [avccFallback, dispatchAvccFallback] = useReducer(avccFallbackReducer, initialAvccFallback);
+  const [requestedWebRtcCodec, setRequestedWebRtcCodec] = useState<WebRtcCodec>('h264');
   const [webRtcCodec, setWebRtcCodec] = useState<WebRtcCodec>('h264');
   const [webRtcHttpFallback, setWebRtcHttpFallback] = useState(false);
+  const handledWebRtcFailureRef = useRef<string | null>(null);
   const useWebRtc = streamMode === 'webrtc' && !webRtcHttpFallback;
   const wantsAvcc = streamMode === 'h264' || webRtcHttpFallback;
   const useAvcc = wantsAvcc && isAvccSupported() && !avccFallback.fellBack;
@@ -506,22 +588,6 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       targetDevice ? `?device=${encodeURIComponent(targetDevice)}` : ''
     }`;
 
-    const toMiddleware = (rawConfig: PreviewApi): ResolvedConfig => {
-      const c = proxyPreviewConfigForBrowser(rawConfig, window.location);
-      const basePath = c.basePath ?? '';
-      return {
-        url: c.url!,
-        streamUrl: c.streamUrl ?? `${c.url}/stream.mjpeg`,
-        wsUrl: toQueryStyleHelperWsUrl(c.wsUrl ?? `${toWs(c.url!)}/ws`),
-        device: c.device ?? null,
-        execWsUrl: toWs(new URL(`${basePath}/exec-ws`, baseUrl).toString()),
-        execToken: c.execToken ?? null,
-        logsPath: c.logsEndpoint ?? null,
-        appStateUrl: c.appStateEndpoint ? new URL(c.appStateEndpoint, baseUrl).toString() : null,
-        gridApiUrl: new URL(c.gridApiEndpoint ?? '/grid/api', baseUrl).toString(),
-      };
-    };
-
     // Ask the grid to attach a helper for this device at most once per effect
     // run (i.e. per device). Resets whenever `targetDevice`/`baseUrl` change.
     let startRequested = false;
@@ -536,7 +602,14 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
         }
         const c = (await res.json()) as PreviewApi | null;
         if (c && c.url && c.device) {
-          if (!cancelled) setConfig(toMiddleware(c));
+          if (!cancelled) {
+            const resolved = resolveIosPreviewConfig(c, window.location, baseUrl);
+            setRequestedWebRtcCodec(resolved.webRtcCodec);
+            setWebRtcCodec(resolved.webRtcCodec);
+            setWebRtcHttpFallback(false);
+            handledWebRtcFailureRef.current = null;
+            setConfig(resolved);
+          }
           return;
         }
         // Middleware reachable but no helper for this device yet. Ask the grid to
@@ -584,18 +657,25 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     closeUrl: config ? `${config.url}/webrtc/close` : '',
     enabled: active && useWebRtc && !!config,
     codec: webRtcCodec,
+    iceServers: config?.iceServers,
   });
-  const handledWebRtcFailureRef = useRef<string | null>(null);
+
+  const selectWebRtcCodec = useCallback((codec: DeviceWebRtcCodec) => {
+    handledWebRtcFailureRef.current = null;
+    setRequestedWebRtcCodec(codec);
+    setWebRtcCodec(codec);
+    setWebRtcHttpFallback(false);
+  }, []);
 
   useEffect(() => {
     if (!useWebRtc || !webRtcFailure) return;
     if (handledWebRtcFailureRef.current === webRtcFailure.sessionId) return;
     handledWebRtcFailureRef.current = webRtcFailure.sessionId;
-    const decision = webRtcFallbackDecision('h264', webRtcCodec, webRtcFailure);
+    const decision = webRtcFallbackDecision(requestedWebRtcCodec, webRtcCodec, webRtcFailure);
     if (!decision) return;
     if (decision.type === 'switch-to-http') setWebRtcHttpFallback(true);
     else setWebRtcCodec(decision.codec);
-  }, [useWebRtc, webRtcFailure, webRtcCodec]);
+  }, [useWebRtc, webRtcFailure, requestedWebRtcCodec, webRtcCodec]);
 
   useEffect(() => {
     if (!useWebRtc) return;
@@ -658,10 +738,12 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   // ── H.264 AVCC (WebCodecs) with serve-sim's MJPEG fallback policy. ──
   useEffect(() => {
     dispatchAvccFallback('reset');
-    setWebRtcCodec('h264');
+    handledWebRtcFailureRef.current = null;
+    setWebRtcCodec(requestedWebRtcCodec);
     setWebRtcHttpFallback(false);
+    fpsCounterRef.current = { frames: 0, startedAt: 0 };
     setFps(0);
-  }, [streamMode, config?.url]);
+  }, [streamMode, config?.url, requestedWebRtcCodec]);
 
   useEffect(() => {
     if (!useAvcc || !config?.url) return;
@@ -1028,6 +1110,8 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     error,
     screen,
     fps,
+    webRtcCodec: requestedWebRtcCodec,
+    setWebRtcCodec: selectWebRtcCodec,
     devices,
     logs,
     logsEnabled,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -8,6 +8,8 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   error: null,
   screen: null,
   fps: 0,
+  webRtcCodec: null,
+  setWebRtcCodec: () => {},
   devices: [],
   logs: [],
   logsEnabled: false,

--- a/packages/@expo/hub-client/src/webrtc-fallback.ts
+++ b/packages/@expo/hub-client/src/webrtc-fallback.ts
@@ -1,4 +1,6 @@
-export type WebRtcCodec = 'h264' | 'vp8' | 'vp9';
+import { type DeviceWebRtcCodec } from './types';
+
+export type WebRtcCodec = DeviceWebRtcCodec;
 
 export type WebRtcFailureReason =
   | { kind: 'permanent' }

--- a/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
@@ -39,6 +39,8 @@ export function DeviceOptionsSection({
             mode={streamMode}
             availability={streamModeAvailability}
             onChange={onStreamModeChange}
+            webRtcCodec={client.webRtcCodec}
+            onWebRtcCodecChange={client.setWebRtcCodec}
           />
         )}
       <OutputSection client={client} />

--- a/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamSection.tsx
@@ -1,4 +1,4 @@
-import { type DeviceStreamMode } from '@expo/hub-client';
+import { type DeviceStreamMode, type DeviceWebRtcCodec } from '@expo/hub-client';
 import { useId } from 'react';
 
 import { SegmentedControl } from '../components/SegmentedControl';
@@ -13,15 +13,25 @@ const STREAM_OPTIONS: Array<{ value: DeviceStreamMode; label: string }> = [
   { value: 'webrtc', label: 'WebRTC' },
 ];
 
+const WEBRTC_CODEC_OPTIONS: Array<{ value: DeviceWebRtcCodec; label: string }> = [
+  { value: 'h264', label: 'H.264' },
+  { value: 'vp9', label: 'VP9' },
+  { value: 'vp8', label: 'VP8' },
+];
+
 /** Viewer-local stream transport control for the right dashboard sidebar. */
 export function StreamSection({
   mode,
   availability,
   onChange,
+  webRtcCodec,
+  onWebRtcCodecChange,
 }: {
   mode: DeviceStreamMode;
   availability: StreamModeAvailability;
   onChange: (mode: DeviceStreamMode) => void;
+  webRtcCodec?: DeviceWebRtcCodec | null;
+  onWebRtcCodecChange?: (codec: DeviceWebRtcCodec) => void;
 }) {
   const helpId = useId();
   const restricted = !availability.h264 || !availability.webrtc;
@@ -41,6 +51,16 @@ export function StreamSection({
           onChange={onChange}
         />
       </SidebarRow>
+      {mode === 'webrtc' && webRtcCodec && onWebRtcCodecChange && (
+        <SidebarRow label="WebRTC codec">
+          <SegmentedControl
+            ariaLabel="WebRTC codec"
+            options={WEBRTC_CODEC_OPTIONS}
+            value={webRtcCodec}
+            onChange={onWebRtcCodecChange}
+          />
+        </SidebarRow>
+      )}
       {restricted && (
         <span
           id={helpId}

--- a/packages/expo-device-hub/src/dashboard/__tests__/streamSection.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/streamSection.test.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { StreamSection } from '../../../../@expo/hub-components/src/dashboard/StreamSection';
+
+test('shows the configured codec while WebRTC is selected', () => {
+  const html = renderToStaticMarkup(
+    <StreamSection
+      mode="webrtc"
+      availability={{ mjpeg: true, h264: true, webrtc: true }}
+      onChange={() => {}}
+      webRtcCodec="vp8"
+      onWebRtcCodecChange={() => {}}
+    />,
+  );
+
+  expect(html).toContain('aria-label="WebRTC codec"');
+  expect(html).toMatch(/aria-pressed="true"[^>]*>VP8<\/button>/);
+});


### PR DESCRIPTION
## Summary

- preserve serve-sim advertised WebRTC codec and validated ICE/TURN configuration in the Hub iOS client
- keep codec fallback anchored to the configured or viewer-selected codec
- expose H.264, VP9, and VP8 controls in the Device Hub sidebar and reset the FPS sample window on stream changes
- add patch changesets for @expo/hub-client and expo-device-hub

## Testing

- bun test in packages/@expo/hub-client (55 passed)
- bun test in packages/expo-device-hub (68 passed)
- turbo typecheck for @expo/hub-client and @expo/hub-components
- bun run build:web in packages/expo-device-hub