### PR TITLE
feat: add serve-sim compatible cli and endpoints

### DIFF
--- a/.changeset/standalone-serve-sim-flags.md
+++ b/.changeset/standalone-serve-sim-flags.md
@@ -1,0 +1,6 @@
+---
+"expo-device-hub": minor
+---
+
+Add standalone CLI flags for configuring serve-sim streaming, WebRTC ICE, and metrics CORS.
+Expose EAS-compatible readiness and temporary serve-sim-backed metrics endpoints.

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -53,7 +53,7 @@ import {
 } from './types';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
 import { useAvccStream } from './useAvccStream';
-import { useWebRtcStream } from './useWebRtcStream';
+import { useWebRtcStream, type WebRtcIceServer } from './useWebRtcStream';
 import {
   type WebRtcCodec,
   webRtcFallbackDecision,
@@ -265,6 +265,8 @@ interface ResolvedConfig {
   /** Absolute URL of the foreground-app SSE stream. */
   appStateUrl: string | null;
   gridApiUrl: string | null;
+  webRtcCodec: WebRtcCodec;
+  webRtcIceServers?: WebRtcIceServer[];
 }
 
 /** Shape of the serve-sim middleware `/api` (and grid) responses we read. */
@@ -279,6 +281,9 @@ interface PreviewApi {
   appStateEndpoint?: string;
   gridApiEndpoint?: string;
   proxyHelpers?: boolean;
+  streamSettings?:
+    | { transport: 'http'; codec?: 'auto' | 'h264' | 'mjpeg' }
+    | { transport: 'webrtc'; codec: WebRtcCodec; iceServers?: WebRtcIceServer[] };
 }
 
 export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClient {
@@ -519,6 +524,10 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
         logsPath: c.logsEndpoint ?? null,
         appStateUrl: c.appStateEndpoint ? new URL(c.appStateEndpoint, baseUrl).toString() : null,
         gridApiUrl: new URL(c.gridApiEndpoint ?? '/grid/api', baseUrl).toString(),
+        webRtcCodec: c.streamSettings?.transport === 'webrtc' ? c.streamSettings.codec : 'h264',
+        ...(c.streamSettings?.transport === 'webrtc' && c.streamSettings.iceServers
+          ? { webRtcIceServers: c.streamSettings.iceServers }
+          : {}),
       };
     };
 
@@ -536,7 +545,11 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
         }
         const c = (await res.json()) as PreviewApi | null;
         if (c && c.url && c.device) {
-          if (!cancelled) setConfig(toMiddleware(c));
+          if (!cancelled) {
+            const resolved = toMiddleware(c);
+            setWebRtcCodec(resolved.webRtcCodec);
+            setConfig(resolved);
+          }
           return;
         }
         // Middleware reachable but no helper for this device yet. Ask the grid to
@@ -584,6 +597,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     closeUrl: config ? `${config.url}/webrtc/close` : '',
     enabled: active && useWebRtc && !!config,
     codec: webRtcCodec,
+    iceServers: config?.webRtcIceServers,
   });
   const handledWebRtcFailureRef = useRef<string | null>(null);
 
@@ -591,11 +605,15 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     if (!useWebRtc || !webRtcFailure) return;
     if (handledWebRtcFailureRef.current === webRtcFailure.sessionId) return;
     handledWebRtcFailureRef.current = webRtcFailure.sessionId;
-    const decision = webRtcFallbackDecision('h264', webRtcCodec, webRtcFailure);
+    const decision = webRtcFallbackDecision(
+      config?.webRtcCodec ?? 'h264',
+      webRtcCodec,
+      webRtcFailure,
+    );
     if (!decision) return;
     if (decision.type === 'switch-to-http') setWebRtcHttpFallback(true);
     else setWebRtcCodec(decision.codec);
-  }, [useWebRtc, webRtcFailure, webRtcCodec]);
+  }, [useWebRtc, webRtcFailure, webRtcCodec, config?.webRtcCodec]);
 
   useEffect(() => {
     if (!useWebRtc) return;
@@ -658,10 +676,10 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   // ── H.264 AVCC (WebCodecs) with serve-sim's MJPEG fallback policy. ──
   useEffect(() => {
     dispatchAvccFallback('reset');
-    setWebRtcCodec('h264');
+    setWebRtcCodec(config?.webRtcCodec ?? 'h264');
     setWebRtcHttpFallback(false);
     setFps(0);
-  }, [streamMode, config?.url]);
+  }, [streamMode, config?.url, config?.webRtcCodec]);
 
   useEffect(() => {
     if (!useAvcc || !config?.url) return;

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -9,6 +9,16 @@ describe('parseCliOptions', () => {
       host: '127.0.0.1',
       platform: undefined,
       transport: undefined,
+      webrtcCodec: undefined,
+      maxDimension: undefined,
+      mjpegQuality: undefined,
+      videoBitrate: undefined,
+      videoFps: undefined,
+      stunUrls: undefined,
+      turnUrls: undefined,
+      turnUsername: undefined,
+      turnCredential: undefined,
+      metricsCorsOrigins: [],
       hideSidebar: false,
       help: false,
     });
@@ -33,6 +43,118 @@ describe('parseCliOptions', () => {
     expect(() => parseCliOptions(['--transport', 'auto'])).toThrow('Invalid --transport: auto');
   });
 
+  test('parses serve-sim WebRTC options', () => {
+    expect(
+      parseCliOptions([
+        '--transport',
+        'webrtc',
+        '--webrtc-codec',
+        'VP8',
+        '--stun-url',
+        'stun:one.test,stuns:two.test',
+        '--turn-url=turn:relay.test,turns:secure-relay.test',
+        '--turn-username',
+        'alice',
+        '--turn-credential',
+        'secret',
+      ])
+    ).toMatchObject({
+      transport: 'webrtc',
+      webrtcCodec: 'vp8',
+      stunUrls: ['stun:one.test', 'stuns:two.test'],
+      turnUrls: ['turn:relay.test', 'turns:secure-relay.test'],
+      turnUsername: 'alice',
+      turnCredential: 'secret',
+    });
+  });
+
+  test('parses serve-sim encoder and metrics options', () => {
+    expect(
+      parseCliOptions([
+        '--max-dimension=1920',
+        '--mjpeg-quality',
+        '0.8',
+        '--video-bitrate',
+        '8000000',
+        '--video-fps',
+        '30',
+        '--metrics-cors-origin',
+        'https://one.test',
+        '--metrics-cors-origin=https://two.test',
+      ])
+    ).toMatchObject({
+      maxDimension: 1920,
+      mjpegQuality: 0.8,
+      videoBitrate: 8_000_000,
+      videoFps: 30,
+      metricsCorsOrigins: ['https://one.test', 'https://two.test'],
+    });
+  });
+
+  test('validates serve-sim option ranges and values', () => {
+    expect(() => parseCliOptions(['--webrtc-codec', 'av1'])).toThrow(
+      'Invalid --webrtc-codec: av1'
+    );
+    expect(() => parseCliOptions(['--max-dimension', '4097'])).toThrow(
+      'Invalid --max-dimension: 4097'
+    );
+    expect(() => parseCliOptions(['--mjpeg-quality', '0'])).toThrow(
+      'Invalid --mjpeg-quality: 0'
+    );
+    expect(() => parseCliOptions(['--video-bitrate', '99999'])).toThrow(
+      'Invalid --video-bitrate: 99999'
+    );
+    expect(() => parseCliOptions(['--video-fps', '29.97'])).toThrow(
+      'Invalid --video-fps: 29.97'
+    );
+    expect(() =>
+      parseCliOptions(['--transport', 'webrtc', '--stun-url', 'https://bad.test'])
+    ).toThrow('Invalid --stun-url');
+  });
+
+  test('requires a WebRTC transport and complete TURN credentials', () => {
+    expect(() => parseCliOptions(['--webrtc-codec', 'vp8'])).toThrow(
+      'WebRTC options require --transport webrtc'
+    );
+    expect(() =>
+      parseCliOptions([
+        '--transport',
+        'webrtc',
+        '--turn-url',
+        'turn:relay.test',
+        '--turn-username',
+        'alice',
+      ])
+    ).toThrow('--turn-username and --turn-credential must be provided together');
+    expect(() =>
+      parseCliOptions([
+        '--transport',
+        'webrtc',
+        '--turn-username',
+        'alice',
+        '--turn-credential',
+        'secret',
+      ])
+    ).toThrow('--turn-username and --turn-credential require --turn-url');
+  });
+
+  test('documents every serve-sim flag', () => {
+    for (const flag of [
+      '--webrtc-codec',
+      '--max-dimension',
+      '--mjpeg-quality',
+      '--video-bitrate',
+      '--video-fps',
+      '--stun-url',
+      '--turn-url',
+      '--turn-username',
+      '--turn-credential',
+      '--metrics-cors-origin',
+    ]) {
+      expect(HELP).toContain(flag);
+    }
+  });
+
   test('hides the device list sidebar on request', () => {
     expect(parseCliOptions(['--hide-sidebar']).hideSidebar).toBe(true);
     expect(HELP).toContain('--hide-sidebar');
@@ -52,6 +174,16 @@ describe('parseCliOptions', () => {
       host: '0.0.0.0',
       platform: undefined,
       transport: undefined,
+      webrtcCodec: undefined,
+      maxDimension: undefined,
+      mjpegQuality: undefined,
+      videoBitrate: undefined,
+      videoFps: undefined,
+      stunUrls: undefined,
+      turnUrls: undefined,
+      turnUsername: undefined,
+      turnCredential: undefined,
+      metricsCorsOrigins: [],
       hideSidebar: false,
       help: false,
     });

--- a/packages/expo-device-hub/src/server/__tests__/eas-endpoints.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/eas-endpoints.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import { handleEasEndpoint } from '../eas-endpoints';
+
+const options = {
+  mountPath: '/_expo/plugins/expo-device-hub',
+  serveSimPrefix: '/vendor/serve-sim',
+};
+
+describe('EAS endpoints', () => {
+  test('always reports ready with the interface placeholder device ID', async () => {
+    const response = handleEasEndpoint(new Request('http://localhost/readyz'), options);
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get('cache-control')).toBe('no-store');
+    expect(await response?.json()).toEqual({ status: 'ready', device: 'no-device-id' });
+  });
+
+  test('redirects metrics to the mounted serve-sim endpoint', () => {
+    const response = handleEasEndpoint(
+      new Request('http://localhost/metrics?device=simulator-id'),
+      options
+    );
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get('location')).toBe(
+      '/_expo/plugins/expo-device-hub/vendor/serve-sim/metrics?device=simulator-id'
+    );
+  });
+
+  test('leaves unrelated routes unhandled', () => {
+    expect(handleEasEndpoint(new Request('http://localhost/other'), options)).toBeNull();
+  });
+});

--- a/packages/expo-device-hub/src/server/__tests__/serve-sim-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/serve-sim-options.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseCliOptions } from '../cli/options';
+import {
+  encodeStandaloneServeSimOptions,
+  readStandaloneServeSimOptions,
+  standaloneServeSimOptions,
+} from '../serve-sim-options';
+
+describe('standaloneServeSimOptions', () => {
+  test('maps Hub HTTP transports to serve-sim codecs', () => {
+    expect(standaloneServeSimOptions(parseCliOptions(['--transport', 'mjpeg']))).toEqual({
+      streamSettings: { transport: 'http', codec: 'mjpeg' },
+    });
+    expect(standaloneServeSimOptions(parseCliOptions(['--transport', 'h264']))).toEqual({
+      streamSettings: { transport: 'http', codec: 'h264' },
+    });
+  });
+
+  test('maps WebRTC codec and ICE servers', () => {
+    expect(
+      standaloneServeSimOptions(
+        parseCliOptions([
+          '--transport',
+          'webrtc',
+          '--webrtc-codec',
+          'vp9',
+          '--stun-url',
+          'stun:one.test,stun:two.test',
+          '--turn-url',
+          'turn:relay.test',
+          '--turn-username',
+          'alice',
+          '--turn-credential',
+          'secret',
+        ]),
+      ),
+    ).toEqual({
+      streamSettings: {
+        transport: 'webrtc',
+        codec: 'vp9',
+        iceServers: [
+          { urls: ['stun:one.test', 'stun:two.test'] },
+          {
+            urls: ['turn:relay.test'],
+            username: 'alice',
+            credential: 'secret',
+          },
+        ],
+      },
+    });
+  });
+
+  test('uses the serve-sim WebRTC codec default', () => {
+    expect(standaloneServeSimOptions(parseCliOptions(['--transport', 'webrtc']))).toEqual({
+      streamSettings: { transport: 'webrtc', codec: 'h264' },
+    });
+  });
+
+  test('maps encoder settings and metrics CORS origins', () => {
+    expect(
+      standaloneServeSimOptions(
+        parseCliOptions([
+          '--max-dimension',
+          '1280',
+          '--mjpeg-quality',
+          '0.75',
+          '--video-bitrate',
+          '4000000',
+          '--video-fps',
+          '24',
+          '--metrics-cors-origin',
+          'https://metrics.test',
+        ]),
+      ),
+    ).toEqual({
+      streamSettings: {
+        transport: 'http',
+        maxDimension: 1280,
+        mjpegQuality: 0.75,
+        h264Bitrate: 4_000_000,
+        h264Fps: 24,
+      },
+      metricsCorsOrigins: ['https://metrics.test'],
+    });
+  });
+
+  test('round-trips through the server environment payload', () => {
+    const options = parseCliOptions(['--transport', 'webrtc', '--webrtc-codec', 'vp8']);
+    expect(readStandaloneServeSimOptions(encodeStandaloneServeSimOptions(options))).toEqual(
+      standaloneServeSimOptions(options),
+    );
+    expect(readStandaloneServeSimOptions('not json')).toEqual({});
+  });
+});

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -7,6 +7,10 @@ import { URL } from 'node:url';
 import { requestOrigin, toFetchRequest, toUpgradeRequest, writeFetchResponse } from './cli/node-fetch-server';
 import { DEFAULT_PORT, HELP, parseCliOptions, type CliOptions } from './cli/options';
 import { staticFileHandler } from './cli/static-files';
+import {
+  encodeStandaloneServeSimOptions,
+  SERVE_SIM_OPTIONS_ENV,
+} from './serve-sim-options';
 
 type HubServerModule = typeof import('./index');
 type WebSocketRouteHandler = (socket: unknown, request: Request, server: WebSocketServer) => void;
@@ -77,6 +81,7 @@ async function main(): Promise<void> {
   } else {
     delete process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR;
   }
+  process.env[SERVE_SIM_OPTIONS_ENV] = encodeStandaloneServeSimOptions(options);
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time
   const hubServer = (await import('./index.mjs')) as HubServerModule;
   const handler = hubServer.default;

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -1,5 +1,7 @@
 import { parseArgs } from 'node:util';
 
+import { type WebRtcStreamCodec } from '@expo/serve-sim/state';
+
 import { parsePlatformFilter, type PlatformFilter } from '../../platform-filter';
 import {
   DEFAULT_TRANSPORT,
@@ -9,6 +11,8 @@ import {
 } from '../../transport';
 
 export const DEFAULT_PORT = 3400;
+export const DEFAULT_WEBRTC_CODEC: WebRtcStreamCodec = 'h264';
+export const WEBRTC_CODECS = ['vp8', 'vp9', 'h264'] as const satisfies readonly WebRtcStreamCodec[];
 
 export const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
 
@@ -19,6 +23,16 @@ Options:
       --host <host>          Host to bind (default: 127.0.0.1; use 0.0.0.0 to expose on your local network)
       --platform <platform>  Show only iOS simulators or Android emulators (ios or android)
       --transport <transport> Preferred transport: ${TRANSPORTS.join(', ')} (default: ${DEFAULT_TRANSPORT})
+      --webrtc-codec <codec> WebRTC video codec: ${WEBRTC_CODECS.join(', ')} (default: ${DEFAULT_WEBRTC_CODEC})
+      --max-dimension <pixels> Maximum captured width or height; 0 keeps native resolution (0-4096)
+      --mjpeg-quality <quality> MJPEG quality (0.05-1)
+      --video-bitrate <bps>  H.264/WebRTC target bitrate (100000-50000000)
+      --video-fps <fps>      H.264/WebRTC frame rate (1-120)
+      --stun-url <urls>      Comma-separated STUN URL(s) for WebRTC ICE
+      --turn-url <urls>      Comma-separated TURN URL(s) for WebRTC ICE
+      --turn-username <name> TURN username (requires --turn-credential and --turn-url)
+      --turn-credential <credential> TURN credential (requires --turn-username and --turn-url)
+      --metrics-cors-origin <origin> Allow an origin to read serve-sim metrics (repeatable)
       --hide-sidebar         Hide the device list sidebar by default
   -h, --help                 Show this help
 `;
@@ -28,9 +42,64 @@ export type CliOptions = {
   host: string;
   platform?: PlatformFilter;
   transport?: Transport;
-  hideSidebar: boolean;
+  webrtcCodec?: WebRtcStreamCodec;
+  maxDimension?: number;
+  mjpegQuality?: number;
+  videoBitrate?: number;
+  videoFps?: number;
+  stunUrls?: string[];
+  turnUrls?: string[];
+  turnUsername?: string;
+  turnCredential?: string;
+  metricsCorsOrigins?: string[];
+  hideSidebar?: boolean;
   help: boolean;
 };
+
+function parseNumberOption(
+  value: string | undefined,
+  option: string,
+  min: number,
+  max: number,
+  integer = false
+): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (
+    !Number.isFinite(parsed) ||
+    (integer && !Number.isInteger(parsed)) ||
+    parsed < min ||
+    parsed > max
+  ) {
+    const kind = integer ? 'integer' : 'number';
+    throw new Error(
+      `Invalid ${option}: ${value} (expected a ${kind} from ${min} to ${max})\n\n${HELP}`
+    );
+  }
+  return parsed;
+}
+
+function parseIceUrls(
+  value: string | undefined,
+  kind: 'stun' | 'turn'
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  const urls = value
+    .split(',')
+    .map((url) => url.trim())
+    .filter(Boolean);
+  const scheme = kind === 'stun' ? /^stuns?:/i : /^turns?:/i;
+  if (
+    urls.length === 0 ||
+    urls.length > 16 ||
+    urls.some((url) => url.length > 2_048 || !scheme.test(url))
+  ) {
+    throw new Error(
+      `Invalid --${kind}-url: ${value} (expected one or more comma-separated ${kind.toUpperCase()} URLs)\n\n${HELP}`
+    );
+  }
+  return urls;
+}
 
 export function parseCliOptions(args: string[]): CliOptions {
   let values: {
@@ -38,6 +107,16 @@ export function parseCliOptions(args: string[]): CliOptions {
     host: string;
     platform?: string;
     transport?: string;
+    'webrtc-codec'?: string;
+    'max-dimension'?: string;
+    'mjpeg-quality'?: string;
+    'video-bitrate'?: string;
+    'video-fps'?: string;
+    'stun-url'?: string;
+    'turn-url'?: string;
+    'turn-username'?: string;
+    'turn-credential'?: string;
+    'metrics-cors-origin': string[];
     'hide-sidebar': boolean;
     help: boolean;
   };
@@ -52,6 +131,16 @@ export function parseCliOptions(args: string[]): CliOptions {
         host: { type: 'string', default: '127.0.0.1' },
         platform: { type: 'string' },
         transport: { type: 'string' },
+        'webrtc-codec': { type: 'string' },
+        'max-dimension': { type: 'string' },
+        'mjpeg-quality': { type: 'string' },
+        'video-bitrate': { type: 'string' },
+        'video-fps': { type: 'string' },
+        'stun-url': { type: 'string' },
+        'turn-url': { type: 'string' },
+        'turn-username': { type: 'string' },
+        'turn-credential': { type: 'string' },
+        'metrics-cors-origin': { type: 'string', multiple: true, default: [] },
         'hide-sidebar': { type: 'boolean', default: false },
         help: { type: 'boolean', short: 'h', default: false },
       },
@@ -77,11 +166,66 @@ export function parseCliOptions(args: string[]): CliOptions {
     throw new Error(`Invalid --transport: ${values.transport}\n\n${HELP}`);
   }
 
+  const normalizedWebRtcCodec = values['webrtc-codec']?.toLowerCase();
+  const webrtcCodec = WEBRTC_CODECS.includes(normalizedWebRtcCodec as WebRtcStreamCodec)
+    ? (normalizedWebRtcCodec as WebRtcStreamCodec)
+    : undefined;
+  if (values['webrtc-codec'] !== undefined && webrtcCodec === undefined) {
+    throw new Error(`Invalid --webrtc-codec: ${values['webrtc-codec']}\n\n${HELP}`);
+  }
+
+  const maxDimension = parseNumberOption(
+    values['max-dimension'],
+    '--max-dimension',
+    0,
+    4096,
+    true
+  );
+  const mjpegQuality = parseNumberOption(values['mjpeg-quality'], '--mjpeg-quality', 0.05, 1);
+  const videoBitrate = parseNumberOption(
+    values['video-bitrate'],
+    '--video-bitrate',
+    100_000,
+    50_000_000,
+    true
+  );
+  const videoFps = parseNumberOption(values['video-fps'], '--video-fps', 1, 120, true);
+  const stunUrls = parseIceUrls(values['stun-url'], 'stun');
+  const turnUrls = parseIceUrls(values['turn-url'], 'turn');
+  const turnUsername = values['turn-username'];
+  const turnCredential = values['turn-credential'];
+
+  const webRtcOptionProvided =
+    values['webrtc-codec'] !== undefined ||
+    stunUrls !== undefined ||
+    turnUrls !== undefined ||
+    turnUsername !== undefined ||
+    turnCredential !== undefined;
+  if (webRtcOptionProvided && transport !== 'webrtc') {
+    throw new Error(`WebRTC options require --transport webrtc.\n\n${HELP}`);
+  }
+  if ((turnUsername === undefined) !== (turnCredential === undefined)) {
+    throw new Error(`--turn-username and --turn-credential must be provided together.\n\n${HELP}`);
+  }
+  if ((turnUsername !== undefined || turnCredential !== undefined) && turnUrls === undefined) {
+    throw new Error(`--turn-username and --turn-credential require --turn-url.\n\n${HELP}`);
+  }
+
   return {
     port,
     host: values.host,
     platform,
     transport,
+    webrtcCodec,
+    maxDimension,
+    mjpegQuality,
+    videoBitrate,
+    videoFps,
+    stunUrls,
+    turnUrls,
+    turnUsername,
+    turnCredential,
+    metricsCorsOrigins: values['metrics-cors-origin'],
     hideSidebar: values['hide-sidebar'],
     help: false,
   };

--- a/packages/expo-device-hub/src/server/eas-endpoints.ts
+++ b/packages/expo-device-hub/src/server/eas-endpoints.ts
@@ -1,0 +1,40 @@
+export const READY_ROUTE = '/readyz';
+export const METRICS_ROUTE = '/metrics';
+
+interface EasEndpointOptions {
+  mountPath: string;
+  serveSimPrefix: string;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export function handleEasEndpoint(
+  request: Request,
+  { mountPath, serveSimPrefix }: EasEndpointOptions
+): Response | null {
+  const { pathname, search } = new URL(request.url);
+
+  if (pathname === READY_ROUTE) {
+    // EAS does not currently use the device ID. A Hub can have zero to many devices
+    // connected, so there is no single device ID for this interface to report.
+    return jsonResponse({ status: 'ready', device: 'no-device-id' });
+  }
+
+  if (pathname === METRICS_ROUTE) {
+    // TODO: This redirect is only a temporary stopgap. Implement Hub metrics properly,
+    // including metrics for Android devices, instead of relying on serve-sim.
+    return new Response(null, {
+      status: 307,
+      headers: { Location: `${mountPath}${serveSimPrefix}/metrics${search}` },
+    });
+  }
+
+  return null;
+}

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -23,6 +23,7 @@ import {
 import { configureClientShell } from './client-shell';
 import { deviceListWebSocketHandler, refreshDeviceList } from './device-list-websocket';
 import { type HubDeviceList, listDevices } from './devices';
+import { handleEasEndpoint } from './eas-endpoints';
 import { MOUNT_PATH } from './mount';
 import { SERVER_PLATFORM_FILTER } from './platform-filter';
 import { EMU_PREFIX, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
@@ -87,6 +88,12 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 export default async function handler(request: Request): Promise<Response | null> {
   const { pathname, searchParams } = new URL(request.url);
+
+  const easResponse = handleEasEndpoint(request, {
+    mountPath: MOUNT_PATH,
+    serveSimPrefix: SIM_PREFIX,
+  });
+  if (easResponse) return easResponse;
 
   if (request.method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
     return serveClientIndexHtml();

--- a/packages/expo-device-hub/src/server/serve-sim-options.ts
+++ b/packages/expo-device-hub/src/server/serve-sim-options.ts
@@ -1,0 +1,72 @@
+import { type StreamSettings, type WebRtcIceServer } from '@expo/serve-sim/state';
+
+import { DEFAULT_WEBRTC_CODEC, type CliOptions } from './cli/options';
+
+export const SERVE_SIM_OPTIONS_ENV = 'EXPO_DEVICE_HUB_SERVE_SIM_OPTIONS';
+
+export type StandaloneServeSimOptions = {
+  streamSettings?: StreamSettings;
+  metricsCorsOrigins?: string[];
+};
+
+function streamSettingsFor(options: CliOptions): StreamSettings | undefined {
+  const encoderSettings = {
+    ...(options.maxDimension !== undefined ? { maxDimension: options.maxDimension } : {}),
+    ...(options.mjpegQuality !== undefined ? { mjpegQuality: options.mjpegQuality } : {}),
+    ...(options.videoBitrate !== undefined ? { h264Bitrate: options.videoBitrate } : {}),
+    ...(options.videoFps !== undefined ? { h264Fps: options.videoFps } : {}),
+  };
+  const hasEncoderSettings = Object.keys(encoderSettings).length > 0;
+
+  if (options.transport === 'webrtc') {
+    const iceServers: WebRtcIceServer[] = [];
+    if (options.stunUrls) iceServers.push({ urls: options.stunUrls });
+    if (options.turnUrls) {
+      iceServers.push({
+        urls: options.turnUrls,
+        ...(options.turnUsername !== undefined ? { username: options.turnUsername } : {}),
+        ...(options.turnCredential !== undefined ? { credential: options.turnCredential } : {}),
+      });
+    }
+    return {
+      transport: 'webrtc',
+      codec: options.webrtcCodec ?? DEFAULT_WEBRTC_CODEC,
+      ...(iceServers.length > 0 ? { iceServers } : {}),
+      ...encoderSettings,
+    };
+  }
+
+  if (options.transport === 'mjpeg' || options.transport === 'h264') {
+    return { transport: 'http', codec: options.transport, ...encoderSettings };
+  }
+
+  return hasEncoderSettings ? { transport: 'http', ...encoderSettings } : undefined;
+}
+
+export function standaloneServeSimOptions(options: CliOptions): StandaloneServeSimOptions {
+  const streamSettings = streamSettingsFor(options);
+  return {
+    ...(streamSettings ? { streamSettings } : {}),
+    ...(options.metricsCorsOrigins && options.metricsCorsOrigins.length > 0
+      ? { metricsCorsOrigins: options.metricsCorsOrigins }
+      : {}),
+  };
+}
+
+export function encodeStandaloneServeSimOptions(options: CliOptions): string {
+  return JSON.stringify(standaloneServeSimOptions(options));
+}
+
+export function readStandaloneServeSimOptions(
+  value: string | undefined,
+): StandaloneServeSimOptions {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as StandaloneServeSimOptions)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/expo-device-hub/src/server/serve-sim.ts
+++ b/packages/expo-device-hub/src/server/serve-sim.ts
@@ -8,13 +8,22 @@ import { fileURLToPath } from 'node:url';
 import { simMiddleware } from '../../vendor/serve-sim/dist/middleware.js';
 
 import { MOUNT_PATH } from './mount';
+import {
+  readStandaloneServeSimOptions,
+  SERVE_SIM_OPTIONS_ENV,
+} from './serve-sim-options';
 
 export const SIM_PREFIX = '/vendor/serve-sim';
 // Must be the full mount path: serve-sim bakes basePath into the client-facing URLs it returns
 // (grid / exec-ws / stream), so a shorter value silently breaks the iOS client.
 const SIM_BASE_PATH = `${MOUNT_PATH}${SIM_PREFIX}`;
 
-const middleware = simMiddleware({ basePath: SIM_BASE_PATH, proxyHelpers: true });
+const standaloneOptions = readStandaloneServeSimOptions(process.env[SERVE_SIM_OPTIONS_ENV]);
+const middleware = simMiddleware({
+  basePath: SIM_BASE_PATH,
+  proxyHelpers: true,
+  ...standaloneOptions,
+});
 
 const SERVE_SIM_STATE_DIR = join(tmpdir(), 'serve-sim');
 const SPAWN_RETRY_COOLDOWN_MS = 30_000;


### PR DESCRIPTION
Add serve-sim compatible cli and readyz and metrics endpoints to make is easier to switch back and forth. And also the define the surface of what to implement on the android side.