### PR TITLE
Add Android WebRTC streaming

### DIFF
--- a/.changeset/android-webrtc-streaming.md
+++ b/.changeset/android-webrtc-streaming.md
@@ -1,0 +1,6 @@
+---
+'@expo/hub-client': minor
+'expo-device-hub': minor
+---
+
+Add Android WebRTC streaming, platform-aware stream controls, and standalone serve-emu stream option forwarding.

--- a/.changeset/android-webrtc-streaming.md
+++ b/.changeset/android-webrtc-streaming.md
@@ -1,6 +1,5 @@
 ---
-'@expo/hub-client': minor
 'expo-device-hub': minor
 ---
 
-Add Android WebRTC streaming, platform-aware stream controls, and standalone serve-emu stream option forwarding.
+Add Android WebRTC streaming

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
         "expo-device-hub": "dist/server/cli.mjs",
       },
       "dependencies": {
+        "node-datachannel": "^0.32.3",
         "ws": "^8.21.0",
         "zustand": "^5.0.15",
       },

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+
+import { androidWsUrlFor, parseServeEmuStreamSettings } from '../useAndroidDevice';
+
+describe('serve-emu stream contract', () => {
+  test('uses a metadata video socket for H.264 and an input-only socket for WebRTC', () => {
+    expect(androidWsUrlFor('http://localhost:3400/vendor/serve-emu', 'emulator-5554', true)).toBe(
+      'ws://localhost:3400/vendor/serve-emu/ws?frame-meta=1&device=emulator-5554',
+    );
+    expect(androidWsUrlFor('https://hub.test/vendor/serve-emu/', 'pixel 9', false)).toBe(
+      'wss://hub.test/vendor/serve-emu/ws?video=0&device=pixel+9',
+    );
+  });
+
+  test('accepts the host-owned H.264 WebRTC configuration', () => {
+    expect(
+      parseServeEmuStreamSettings({
+        transport: 'webrtc',
+        codec: 'h264',
+        iceServers: [
+          { urls: ['stun:stun.example.test:3478'] },
+          {
+            urls: ['turn:turn.example.test:3478'],
+            username: 'hub',
+            credential: 'secret',
+          },
+        ],
+        iceTransportPolicy: 'relay',
+      }),
+    ).toEqual({
+      transport: 'webrtc',
+      codec: 'h264',
+      iceServers: [
+        { urls: ['stun:stun.example.test:3478'] },
+        {
+          urls: ['turn:turn.example.test:3478'],
+          username: 'hub',
+          credential: 'secret',
+        },
+      ],
+      iceTransportPolicy: 'relay',
+    });
+  });
+
+  test('rejects unsupported codecs and malformed ICE settings', () => {
+    expect(parseServeEmuStreamSettings({ transport: 'websocket' })).toEqual({
+      transport: 'websocket',
+    });
+    expect(
+      parseServeEmuStreamSettings({
+        transport: 'webrtc',
+        codec: 'vp8',
+        iceServers: [],
+        iceTransportPolicy: 'all',
+      }),
+    ).toBeNull();
+    expect(
+      parseServeEmuStreamSettings({
+        transport: 'webrtc',
+        codec: 'h264',
+        iceServers: [{ urls: ['stun:ok.test'], credential: 123 }],
+        iceTransportPolicy: 'all',
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-stream-options.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-stream-options.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildWebRtcOfferPayload,
+  isRetryableWebRtcOfferStatus,
+  preferredVideoCodecs,
+  shouldFallbackCodecAfterFirstFrameTimeout,
+  type WebRtcIceServer,
+  type WebRtcVideoCodecCapability,
+} from '../useWebRtcStream';
+
+describe('WebRTC stream options', () => {
+  test('prefers H.264 packetization-mode=1 before other H.264 formats', () => {
+    const vp8 = { mimeType: 'video/VP8' };
+    const h264Mode0 = {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'profile-level-id=42e01f;packetization-mode=0',
+    };
+    const h264Mode1 = {
+      mimeType: 'video/H264',
+      sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f',
+    };
+    const codecs: WebRtcVideoCodecCapability[] = [vp8, h264Mode0, h264Mode1];
+
+    expect(preferredVideoCodecs(codecs, 'h264')).toEqual([h264Mode1, h264Mode0, vp8]);
+  });
+
+  test('keeps the requested non-H.264 codec first', () => {
+    const h264 = { mimeType: 'video/H264', sdpFmtpLine: 'packetization-mode=1' };
+    const vp8 = { mimeType: 'video/VP8' };
+    const vp9 = { mimeType: 'video/VP9' };
+
+    expect(preferredVideoCodecs([h264, vp8, vp9], 'vp9')).toEqual([vp9, h264, vp8]);
+  });
+
+  test('includes ICE servers in offers by default for serve-sim', () => {
+    const iceServers: WebRtcIceServer[] = [{ urls: ['stun:example.test'] }];
+
+    expect(
+      buildWebRtcOfferPayload({
+        description: { type: 'offer', sdp: 'v=0' },
+        sessionId: 'session-1',
+        codec: 'vp8',
+        iceServers,
+      }),
+    ).toEqual({
+      type: 'offer',
+      sdp: 'v=0',
+      sessionId: 'session-1',
+      codec: 'vp8',
+      iceServers,
+    });
+  });
+
+  test('omits ICE servers from offers for host-configured serve-emu signaling', () => {
+    expect(
+      buildWebRtcOfferPayload({
+        description: { type: 'offer', sdp: 'v=0' },
+        sessionId: 'session-1',
+        codec: 'h264',
+        iceServers: [{ urls: ['stun:example.test'] }],
+        sendIceServersInOffer: false,
+      }),
+    ).toEqual({
+      type: 'offer',
+      sdp: 'v=0',
+      sessionId: 'session-1',
+      codec: 'h264',
+    });
+  });
+
+  test('retries transient offer responses but not permanent client errors', () => {
+    for (const status of [408, 425, 429, 500, 503]) {
+      expect(isRetryableWebRtcOfferStatus(status)).toBe(true);
+    }
+    for (const status of [400, 401, 403, 404, 409, 422]) {
+      expect(isRetryableWebRtcOfferStatus(status)).toBe(false);
+    }
+  });
+
+  test('can disable codec fallback for an established connection', () => {
+    expect(shouldFallbackCodecAfterFirstFrameTimeout(true, 'connected')).toBe(true);
+    expect(shouldFallbackCodecAfterFirstFrameTimeout(false, 'connected')).toBe(false);
+    expect(shouldFallbackCodecAfterFirstFrameTimeout(true, 'failed')).toBe(false);
+  });
+});

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -21,7 +21,7 @@ import { type CSSProperties } from 'react';
 
 export type DevicePlatform = 'ios' | 'android';
 
-/** Viewer-selected transport for serve-sim video. */
+/** Viewer-selected transport for the active device stream. */
 export type DeviceStreamMode = 'mjpeg' | 'h264' | 'webrtc';
 
 /**
@@ -129,6 +129,13 @@ export type DeviceHttpCodec = 'auto' | 'mjpeg' | 'h264';
 /** Viewer-local WebRTC codec selection. */
 export type DeviceWebRtcCodec = 'h264' | 'vp9' | 'vp8';
 
+/** Stream transports and codecs supported by the active backend. */
+export interface DeviceStreamCapabilities {
+  modeAvailability: Record<DeviceStreamMode, boolean>;
+  httpCodecs: readonly DeviceHttpCodec[];
+  webRtcCodecs: readonly DeviceWebRtcCodec[];
+}
+
 /** Runtime encoder settings supported by serve-sim's `/stream-settings` endpoint. */
 export interface DeviceStreamEncoderSettings {
   mjpegFps: number;
@@ -138,11 +145,12 @@ export interface DeviceStreamEncoderSettings {
   h264Fps: number;
 }
 
-/** Explicit backend feature flags used to omit unsupported inspector sections. */
+/** Explicit backend feature flags used to omit unsupported inspector sections and controls. */
 export interface DeviceCapabilities {
   deviceSettings: boolean;
   activity: boolean;
   events: boolean;
+  /** Runtime encoder settings can be read and patched. */
   streamSettings: boolean;
 }
 
@@ -259,7 +267,7 @@ export interface DeviceConnectionOptions {
   /**
    * Stream transport selected by the consumer. There is intentionally no
    * client-level default; products embedding Hub own their default choice.
-   * serve-emu currently ignores this because its wire protocol is always H.264.
+   * Each backend adapter maps unavailable choices to one of its supported modes.
    */
   streamMode: DeviceStreamMode;
 }
@@ -317,7 +325,9 @@ export interface DeviceClient {
   /** Change one simulator/device option. Unsupported keys are ignored by each backend. */
   setDeviceSetting: (key: DeviceSettingKey, value: string) => void;
 
-  /** Runtime encoder settings, available on serve-sim only. */
+  /** Backend-supported viewer transport and codec choices; null hides stream controls. */
+  streamCapabilities: DeviceStreamCapabilities | null;
+  /** Runtime encoder settings, available only when `capabilities.streamSettings` is true. */
   streamSettings: DeviceStreamEncoderSettings | null;
   streamSettingsPending: boolean;
   /** Patch one or more runtime encoder values. */

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -2,9 +2,10 @@
  * serve-emu (Android) implementation of the {@link DeviceClient} interface.
  *
  * Wire protocol (see serve-emu `src/middleware.ts` / `src/input.ts`):
- *   - Video + input share one WebSocket at `<base>/ws?frame-meta=1`. serve-emu is
- *     multi-device: a `&device=<serial>` query selects which device to stream
- *     (omitted → first available). `/api/logcat` takes the same `?device=`.
+ *   - H.264 video + input share one WebSocket at `<base>/ws?frame-meta=1`.
+ *     With WebRTC video, input stays on `<base>/ws?video=0`; signaling uses
+ *     `<base>/webrtc/{offer,close}`. serve-emu is multi-device: `?device=<serial>`
+ *     selects the target (omitted → first available).
  *   - Binary inbound messages are H.264 access units, each prefixed with a
  *     16-byte "SEMU" header (keyframe flag + PTS); decoded with WebCodecs into a
  *     `<canvas>`.
@@ -27,6 +28,7 @@ import {
 } from './android-events';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
+import { type WebRtcIceServer, useWebRtcStream } from './useWebRtcStream';
 import {
   type ConnectionStatus,
   type DeviceAppearance,
@@ -48,6 +50,7 @@ const SOFT_DECODE_QUEUE_SIZE = 4;
 const KEYFRAME_REQUEST_COOLDOWN_MS = 1500;
 const FOREGROUND_POLL_MS = 5000;
 const EVENTS_POLL_MS = 1000;
+const STREAM_METADATA_POLL_MS = 1500;
 
 const KEYCODE_R = 46;
 
@@ -90,17 +93,76 @@ function apiUrl(baseUrl: string, path: string): string {
   return `${baseUrl.replace(/\/$/, '')}${path}`;
 }
 
-function wsUrlFor(baseUrl: string, device: string | null): string {
+function deviceApiUrl(baseUrl: string, path: string, device: string | null): string {
+  const url = new URL(apiUrl(baseUrl, path));
+  if (device) url.searchParams.set('device', device);
+  return url.toString();
+}
+
+export function androidWsUrlFor(
+  baseUrl: string,
+  device: string | null,
+  video: boolean,
+): string {
   const u = new URL(apiUrl(baseUrl, '/ws'));
   u.protocol = u.protocol === 'https:' ? 'wss:' : 'ws:';
-  u.searchParams.set('frame-meta', '1');
+  if (video) u.searchParams.set('frame-meta', '1');
+  else u.searchParams.set('video', '0');
   // serve-emu routes the stream to this device; omitted → first available.
   if (device) u.searchParams.set('device', device);
   return u.toString();
 }
 
+type ServeEmuStreamSettings =
+  | { transport: 'websocket' }
+  | {
+      transport: 'webrtc';
+      codec: 'h264';
+      iceServers: WebRtcIceServer[];
+      iceTransportPolicy: RTCIceTransportPolicy;
+    };
+
+type ServeEmuApiInfo = {
+  size?: { width?: unknown; height?: unknown };
+  stream?: unknown;
+};
+
+function isIceServer(value: unknown): value is WebRtcIceServer {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    Array.isArray(candidate.urls) &&
+    candidate.urls.length > 0 &&
+    candidate.urls.every((url) => typeof url === 'string') &&
+    (candidate.username === undefined || typeof candidate.username === 'string') &&
+    (candidate.credential === undefined || typeof candidate.credential === 'string')
+  );
+}
+
+/** Validate the stream contract returned by serve-emu's device-scoped `/api`. */
+export function parseServeEmuStreamSettings(value: unknown): ServeEmuStreamSettings | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.transport === 'websocket') return { transport: 'websocket' };
+  if (
+    candidate.transport !== 'webrtc' ||
+    candidate.codec !== 'h264' ||
+    !Array.isArray(candidate.iceServers) ||
+    !candidate.iceServers.every(isIceServer) ||
+    (candidate.iceTransportPolicy !== 'all' && candidate.iceTransportPolicy !== 'relay')
+  ) {
+    return null;
+  }
+  return {
+    transport: 'webrtc',
+    codec: 'h264',
+    iceServers: candidate.iceServers,
+    iceTransportPolicy: candidate.iceTransportPolicy,
+  };
+}
+
 export function useAndroidDeviceClient(options: DeviceConnectionOptions): DeviceClient {
-  const { baseUrl, enabled = true, device: targetDevice = null } = options;
+  const { baseUrl, enabled = true, device: targetDevice = null, streamMode } = options;
   const active = enabled && !!baseUrl;
 
   const [status, setStatus] = useState<ConnectionStatus>('idle');
@@ -120,6 +182,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   >(() => new Set());
   // The foreground app, polled from `/api/foreground`. null until the first read.
   const [foregroundApp, setForegroundApp] = useState<ForegroundApp | null>(null);
+  const [serverStreamSettings, setServerStreamSettings] =
+    useState<ServeEmuStreamSettings | null>(null);
+  const [webRtcVideoElement, setWebRtcVideoElement] = useState<HTMLVideoElement | null>(null);
+  const [webRtcVideoReady, setWebRtcVideoReady] = useState(false);
+  const [webRtcInputReady, setWebRtcInputReady] = useState(false);
+  const [webRtcInputError, setWebRtcInputError] = useState<string | null>(null);
 
   const wsRef = useRef<WebSocket | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -133,7 +201,9 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
   const attachVideo = useCallback(
     (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
-      canvasRef.current = (el as HTMLCanvasElement) ?? null;
+      canvasRef.current = el?.tagName === 'CANVAS' ? (el as HTMLCanvasElement) : null;
+      const video = el?.tagName === 'VIDEO' ? (el as HTMLVideoElement) : null;
+      setWebRtcVideoElement((current) => (current === video ? current : video));
     },
     [],
   );
@@ -281,12 +351,187 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     [setAppearance],
   );
 
-  // ── Video + input WebSocket (with reconnect) ──
+  // ── Stream metadata ──
+  // serve-emu locks its host transport at launch. Poll the device-scoped API so
+  // the viewer only offers WebRTC when that transport is actually configured,
+  // and so the peer uses the host's ICE servers/policy rather than client input.
+  useEffect(() => {
+    setServerStreamSettings(null);
+    if (!active || !baseUrl) return;
+
+    let cancelled = false;
+    let polling = false;
+    let controller: AbortController | null = null;
+    const url = deviceApiUrl(baseUrl, '/api', targetDevice);
+
+    const refresh = async () => {
+      if (cancelled || polling) return;
+      polling = true;
+      controller = new AbortController();
+      try {
+        const response = await fetch(url, { cache: 'no-store', signal: controller.signal });
+        if (!response.ok) return;
+        const info = (await response.json()) as ServeEmuApiInfo;
+        if (cancelled) return;
+        const next = parseServeEmuStreamSettings(info.stream) ?? { transport: 'websocket' };
+        setServerStreamSettings((current) =>
+          JSON.stringify(current) === JSON.stringify(next) ? current : next,
+        );
+        const width = Number(info.size?.width);
+        const height = Number(info.size?.height);
+        if (width > 0 && height > 0) {
+          setScreen((current) =>
+            current?.width === width && current.height === height ? current : { width, height },
+          );
+        }
+      } catch {
+        // Device startup and temporary disconnects are expected; keep polling.
+      } finally {
+        polling = false;
+        controller = null;
+      }
+    };
+
+    void refresh();
+    const timer = setInterval(refresh, STREAM_METADATA_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      controller?.abort();
+    };
+  }, [active, baseUrl, targetDevice]);
+
+  const webRtcRequested = streamMode === 'webrtc';
+  const waitingForWebRtcMetadata = webRtcRequested && serverStreamSettings === null;
+  const useWebRtc =
+    webRtcRequested && serverStreamSettings?.transport === 'webrtc';
+  const requestWebRtcKeyframe = useCallback(() => {
+    send({ type: 'reset-video' });
+  }, [send]);
+  const {
+    stream: webRtcStream,
+    error: webRtcError,
+    markFrameDecoded: markWebRtcFrameDecoded,
+  } = useWebRtcStream({
+    offerUrl: baseUrl ? deviceApiUrl(baseUrl, '/webrtc/offer', targetDevice) : '',
+    closeUrl: baseUrl ? deviceApiUrl(baseUrl, '/webrtc/close', targetDevice) : '',
+    enabled: active && useWebRtc,
+    codec: 'h264',
+    iceServers:
+      serverStreamSettings?.transport === 'webrtc'
+        ? serverStreamSettings.iceServers
+        : undefined,
+    iceTransportPolicy:
+      serverStreamSettings?.transport === 'webrtc'
+        ? serverStreamSettings.iceTransportPolicy
+        : 'all',
+    sendIceServersInOffer: false,
+    allowCodecFallback: false,
+    onKeyframeNeeded: requestWebRtcKeyframe,
+  });
+
+  useEffect(() => {
+    if (!useWebRtc) {
+      setWebRtcVideoReady(false);
+      setWebRtcInputReady(false);
+      setWebRtcInputError(null);
+      return;
+    }
+    if (webRtcError) {
+      setStatus('error');
+      setError(webRtcError);
+    } else if (webRtcInputError) {
+      setStatus('error');
+      setError(webRtcInputError);
+    } else if (!webRtcStream || !webRtcVideoReady || !webRtcInputReady) {
+      setStatus('connecting');
+      setError(null);
+    } else {
+      setStatus('streaming');
+      setError(null);
+    }
+  }, [useWebRtc, webRtcError, webRtcInputError, webRtcInputReady, webRtcStream, webRtcVideoReady]);
+
+  // Attach the negotiated MediaStream to DeviceScreen's current <video> node.
+  // The node is stateful (rather than only a ref) so a remount reattaches the
+  // stream and frame observer even when the MediaStream itself is unchanged.
+  useEffect(() => {
+    if (!useWebRtc) return;
+    const video = webRtcVideoElement;
+    if (!video) return;
+
+    let stopped = false;
+    let firstFrame = true;
+    let frameCallback = 0;
+    let fpsCount = 0;
+    let fpsStartedAt = performance.now();
+
+    const markFrame = () => {
+      if (stopped) return;
+      if (video.videoWidth > 0 && video.videoHeight > 0) {
+        const width = video.videoWidth;
+        const height = video.videoHeight;
+        setScreen((current) =>
+          current?.width === width && current.height === height ? current : { width, height },
+        );
+      }
+      if (firstFrame) {
+        firstFrame = false;
+        markWebRtcFrameDecoded();
+        setWebRtcVideoReady(true);
+      }
+      fpsCount++;
+      const now = performance.now();
+      if (now - fpsStartedAt >= 1000) {
+        const next = Math.round((fpsCount * 1000) / (now - fpsStartedAt));
+        fpsCount = 0;
+        fpsStartedAt = now;
+        setFps((current) => (current === next ? current : next));
+      }
+    };
+    const onVideoFrame = () => {
+      markFrame();
+      frameCallback = video.requestVideoFrameCallback(onVideoFrame);
+    };
+    const onTimeUpdate = () => markFrame();
+
+    video.srcObject = webRtcStream;
+    setWebRtcVideoReady(false);
+    if (webRtcStream) {
+      if (typeof video.requestVideoFrameCallback === 'function') {
+        frameCallback = video.requestVideoFrameCallback(onVideoFrame);
+      } else {
+        video.addEventListener('timeupdate', onTimeUpdate);
+      }
+      video.addEventListener('loadeddata', markFrame, { once: true });
+      void video.play().catch(() => {});
+    }
+
+    return () => {
+      stopped = true;
+      video.removeEventListener('loadeddata', markFrame);
+      video.removeEventListener('timeupdate', onTimeUpdate);
+      if (frameCallback && typeof video.cancelVideoFrameCallback === 'function') {
+        video.cancelVideoFrameCallback(frameCallback);
+      }
+      video.srcObject = null;
+      setWebRtcVideoReady(false);
+      setFps(0);
+    };
+  }, [useWebRtc, webRtcStream, webRtcVideoElement, markWebRtcFrameDecoded]);
+
+  // ── H.264 video + input WebSocket (with reconnect) ──
   useEffect(() => {
     if (!active || !baseUrl) {
       setStatus('idle');
       return;
     }
+    if (waitingForWebRtcMetadata) {
+      setStatus('connecting');
+      setError(null);
+      return;
+    }
+    if (useWebRtc) return;
     // WebCodecs (`VideoDecoder`) is a secure-context-only API, so it's absent
     // over a plain-HTTP LAN origin (`http://192.168.x.x:8081`). Fall back to
     // Media Source Extensions — not secure-context gated — which decodes the same
@@ -497,7 +742,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       if (cancelled) return;
       let ws: WebSocket;
       try {
-        ws = new WebSocket(wsUrlFor(baseUrl, targetDevice));
+        ws = new WebSocket(androidWsUrlFor(baseUrl, targetDevice, true));
       } catch (err) {
         setStatus('error');
         setError(err instanceof Error ? err.message : 'Invalid server URL');
@@ -588,7 +833,79 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     // Reconnect only when the target device or server changes — not on every
     // status/fps/screen state update this effect writes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, baseUrl, targetDevice]);
+  }, [active, baseUrl, targetDevice, waitingForWebRtcMetadata, useWebRtc]);
+
+  // ── WebRTC input WebSocket ──
+  // Video travels over the peer connection, but low-latency JSON input and
+  // keyframe requests retain serve-emu's scrcpy control WebSocket.
+  useEffect(() => {
+    if (!active || !baseUrl || !useWebRtc) {
+      setWebRtcInputReady(false);
+      setWebRtcInputError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let reconnectDelay = 500;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    const inputUrl = androidWsUrlFor(baseUrl, targetDevice, false);
+    setWebRtcInputReady(false);
+    setWebRtcInputError(null);
+
+    const scheduleReconnect = (message: string) => {
+      if (cancelled) return;
+      setWebRtcInputReady(false);
+      setWebRtcInputError(message);
+      const retryIn = reconnectDelay;
+      reconnectDelay = Math.min(Math.round(reconnectDelay * 1.6), 5000);
+      retryTimer = setTimeout(connect, retryIn);
+    };
+
+    function connect() {
+      if (cancelled) return;
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(inputUrl);
+      } catch {
+        scheduleReconnect('WebRTC input connection failed. Retrying...');
+        return;
+      }
+      wsRef.current = ws;
+      ws.onopen = () => {
+        if (cancelled) return;
+        reconnectDelay = 500;
+        setWebRtcInputReady(true);
+        setWebRtcInputError(null);
+        ws.send(JSON.stringify({ type: 'reset-video', ack: false }));
+      };
+      ws.onerror = () => {
+        // onclose owns retry scheduling.
+      };
+      ws.onclose = () => {
+        if (wsRef.current === ws) wsRef.current = null;
+        scheduleReconnect('WebRTC input disconnected. Retrying...');
+      };
+      ws.onmessage = (event) => {
+        if (cancelled || typeof event.data !== 'string') return;
+        try {
+          const message = JSON.parse(event.data) as { ok?: boolean; error?: string };
+          if (message.ok === false && message.error) setError(message.error);
+        } catch {}
+      };
+    }
+
+    connect();
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      const ws = wsRef.current;
+      try {
+        ws?.close();
+      } catch {}
+      if (wsRef.current === ws) wsRef.current = null;
+      setWebRtcInputReady(false);
+    };
+  }, [active, baseUrl, targetDevice, useWebRtc]);
 
   // ── Logcat (SSE, best-effort) — off by default; opt-in via attach ──
   useEffect(() => {
@@ -809,6 +1126,15 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     updateStreamSettings: () => {},
     webRtcCodec: 'h264',
     setWebRtcCodec: () => {},
+    streamCapabilities: {
+      modeAvailability: {
+        mjpeg: false,
+        h264: true,
+        webrtc: serverStreamSettings?.transport === 'webrtc',
+      },
+      httpCodecs: ['h264'],
+      webRtcCodecs: ['h264'],
+    },
     capabilities: {
       deviceSettings: true,
       activity: false,
@@ -816,7 +1142,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       streamSettings: false,
     },
     foregroundApp,
-    videoKind: 'canvas',
+    videoKind: useWebRtc ? 'video' : 'canvas',
     attachVideo,
     sendTouch,
     sendKey,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -56,6 +56,7 @@ import {
   type DeviceLog,
   type DeviceSettingKey,
   type DeviceSettings,
+  type DeviceStreamCapabilities,
   type DeviceStreamEncoderSettings,
   type DeviceWebRtcCodec,
   type DeviceOrientation,
@@ -130,6 +131,12 @@ const HID_USAGE_R = 0x15; // 'r'
 const PLACEHOLDER_DEVICES: RunningDevice[] = [
   { id: 'ios', name: 'iPhone Simulator', platform: 'ios', current: true },
 ];
+
+const IOS_STREAM_CAPABILITIES = {
+  modeAvailability: { mjpeg: true, h264: true, webrtc: true },
+  httpCodecs: ['auto', 'h264', 'mjpeg'],
+  webRtcCodecs: ['h264', 'vp9', 'vp8'],
+} as const satisfies DeviceStreamCapabilities;
 
 // The counterclockwise rotation order (matches Simulator's "Rotate Left"): each
 // press advances one step, so four presses come back around to portrait.
@@ -773,7 +780,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       cancelled = true;
       if (pollTimer) clearTimeout(pollTimer);
     };
-  }, [active, baseUrl, targetDevice]);
+  }, [active, baseUrl, targetDevice, setWebRtcCodec]);
 
   const fpsCounterRef = useRef({ frames: 0, startedAt: 0 });
   const onAvccFrame = useCallback(() => {
@@ -1401,6 +1408,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    streamCapabilities: IOS_STREAM_CAPABILITIES,
     streamSettings,
     streamSettingsPending,
     updateStreamSettings,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -23,6 +23,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   deviceSettings: null,
   deviceSettingsPending: new Set(),
   setDeviceSetting: () => {},
+  streamCapabilities: null,
   streamSettings: null,
   streamSettingsPending: false,
   updateStreamSettings: () => {},

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -29,6 +29,72 @@ const BUSY_RETRY_INTERVAL_MS = 500;
 const BUSY_RETRY_COUNT = 30;
 const TRANSPORT_RETRY_BASE_MS = 500;
 const TRANSPORT_RETRY_MAX_MS = 5_000;
+const DISCONNECTED_GRACE_MS = 10_000;
+
+export type WebRtcVideoCodecCapability = {
+  mimeType: string;
+  sdpFmtpLine?: string;
+};
+
+/** Keep serve-emu's packetization-mode=1 H.264 formats ahead of incompatible formats. */
+export function preferredVideoCodecs<Capability extends WebRtcVideoCodecCapability>(
+  codecs: readonly Capability[],
+  codec: WebRtcCodec,
+): Capability[] {
+  const preferredMimeType =
+    codec === 'h264' ? 'video/h264' : codec === 'vp9' ? 'video/vp9' : 'video/vp8';
+  if (codec !== 'h264') {
+    return [
+      ...codecs.filter((candidate) => candidate.mimeType.toLowerCase() === preferredMimeType),
+      ...codecs.filter((candidate) => candidate.mimeType.toLowerCase() !== preferredMimeType),
+    ];
+  }
+
+  const isH264 = (candidate: Capability) => candidate.mimeType.toLowerCase() === preferredMimeType;
+  const hasPacketizationMode1 = (candidate: Capability) =>
+    /(?:^|;)\s*packetization-mode=1(?:\s*;|$)/i.test(candidate.sdpFmtpLine ?? '');
+  return [
+    ...codecs.filter((candidate) => isH264(candidate) && hasPacketizationMode1(candidate)),
+    ...codecs.filter((candidate) => isH264(candidate) && !hasPacketizationMode1(candidate)),
+    ...codecs.filter((candidate) => !isH264(candidate)),
+  ];
+}
+
+export function buildWebRtcOfferPayload({
+  description,
+  sessionId,
+  codec,
+  iceServers,
+  sendIceServersInOffer = true,
+}: {
+  description: RTCSessionDescriptionInit;
+  sessionId: string;
+  codec: WebRtcCodec;
+  iceServers: WebRtcIceServer[];
+  sendIceServersInOffer?: boolean;
+}): Record<string, unknown> {
+  return {
+    type: description.type,
+    sdp: description.sdp,
+    sessionId,
+    codec,
+    ...(sendIceServersInOffer ? { iceServers } : {}),
+  };
+}
+
+export function isRetryableWebRtcOfferStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+export function shouldFallbackCodecAfterFirstFrameTimeout(
+  allowCodecFallback: boolean,
+  connectionState: RTCPeerConnectionState,
+): boolean {
+  return (
+    allowCodecFallback &&
+    webRtcFailureDisposition('first-frame-timeout', connectionState) === 'codec'
+  );
+}
 
 function createSessionId(): string {
   if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
@@ -39,19 +105,27 @@ function createSessionId(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-/** Negotiate and maintain serve-sim's recv-only WebRTC stream. */
+/** Negotiate and maintain a recv-only serve-sim / serve-emu WebRTC stream. */
 export function useWebRtcStream({
   offerUrl,
   closeUrl,
   enabled,
   codec,
   iceServers,
+  iceTransportPolicy = 'all',
+  sendIceServersInOffer = true,
+  allowCodecFallback = true,
+  onKeyframeNeeded,
 }: {
   offerUrl: string;
   closeUrl: string;
   enabled: boolean;
   codec: WebRtcCodec;
   iceServers?: WebRtcIceServer[];
+  iceTransportPolicy?: RTCIceTransportPolicy;
+  sendIceServersInOffer?: boolean;
+  allowCodecFallback?: boolean;
+  onKeyframeNeeded?: () => void;
 }) {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [failure, setFailure] = useState<WebRtcStreamFailure | null>(null);
@@ -74,7 +148,16 @@ export function useWebRtcStream({
 
   useEffect(() => {
     transportRetryAttemptRef.current = 0;
-  }, [enabled, offerUrl, closeUrl, codec, iceServers]);
+  }, [
+    enabled,
+    offerUrl,
+    closeUrl,
+    codec,
+    iceServers,
+    iceTransportPolicy,
+    sendIceServersInOffer,
+    allowCodecFallback,
+  ]);
 
   useEffect(() => {
     if (!enabled || !offerUrl) return;
@@ -89,8 +172,11 @@ export function useWebRtcStream({
     let stopped = false;
     let peer: RTCPeerConnection | null = null;
     let retryTimer: number | undefined;
+    let disconnectedTimer: number | undefined;
     let closePromise: Promise<void> | null = null;
     let failing = false;
+    let trackReceived = false;
+    let connectionReady = false;
     const lifecycleController = new AbortController();
     const sessionId = createSessionId();
     const servers = iceServers?.length ? iceServers : DEFAULT_ICE_SERVERS;
@@ -112,9 +198,29 @@ export function useWebRtcStream({
     window.addEventListener('pagehide', releaseOnPageHide);
     window.addEventListener('beforeunload', releaseOnPageHide);
 
+    const clearFirstFrameTimeout = () => {
+      if (firstFrameTimeoutRef.current === undefined) return;
+      window.clearTimeout(firstFrameTimeoutRef.current);
+      firstFrameTimeoutRef.current = undefined;
+    };
+
+    const clearDisconnectedTimer = () => {
+      if (disconnectedTimer === undefined) return;
+      window.clearTimeout(disconnectedTimer);
+      disconnectedTimer = undefined;
+    };
+
     const closePeer = () => {
+      clearFirstFrameTimeout();
+      clearDisconnectedTimer();
       setStream(null);
       peer?.close();
+    };
+
+    const requestKeyframe = () => {
+      try {
+        onKeyframeNeeded?.();
+      } catch {}
     };
 
     const failPermanently = (message: string) => {
@@ -144,14 +250,36 @@ export function useWebRtcStream({
         TRANSPORT_RETRY_BASE_MS * 2 ** Math.min(attempt, 4),
         TRANSPORT_RETRY_MAX_MS,
       );
+      requestKeyframe();
       setError(`${message} Retrying...`);
       closePeer();
-      void closeRemoteSession().finally(() => {
-        if (stopped) return;
-        retryTimer = window.setTimeout(() => {
-          if (!stopped) setRetryGeneration((generation) => generation + 1);
-        }, delay);
-      });
+      void closeRemoteSession();
+      retryTimer = window.setTimeout(() => {
+        if (!stopped) setRetryGeneration((generation) => generation + 1);
+      }, delay);
+    };
+
+    const armFirstFrameTimeout = () => {
+      if (
+        stopped ||
+        firstFrameDecodedRef.current ||
+        !trackReceived ||
+        !connectionReady ||
+        firstFrameTimeoutRef.current !== undefined
+      ) {
+        return;
+      }
+      firstFrameTimeoutRef.current = window.setTimeout(() => {
+        firstFrameTimeoutRef.current = undefined;
+        if (stopped || firstFrameDecodedRef.current) return;
+        const state = peer?.connectionState ?? 'closed';
+        if (shouldFallbackCodecAfterFirstFrameTimeout(allowCodecFallback, state)) {
+          requestKeyframe();
+          failCodec();
+        } else {
+          retryTransport('WebRTC did not establish a video path.');
+        }
+      }, FIRST_FRAME_TIMEOUT_MS);
     };
 
     const waitForIce = (connection: RTCPeerConnection) =>
@@ -180,40 +308,41 @@ export function useWebRtcStream({
       try {
         peer = new RTCPeerConnection({
           iceServers: servers,
-          iceTransportPolicy: 'all',
+          iceTransportPolicy,
         });
 
         const transceiver = peer.addTransceiver('video', { direction: 'recvonly' });
         const capabilities = RTCRtpReceiver.getCapabilities('video');
-        const preferredMimeType =
-          codec === 'h264' ? 'video/H264' : codec === 'vp9' ? 'video/VP9' : 'video/VP8';
         if (capabilities?.codecs.length && 'setCodecPreferences' in transceiver) {
-          const preferred = preferredMimeType.toLowerCase();
-          transceiver.setCodecPreferences([
-            ...capabilities.codecs.filter((candidate) => candidate.mimeType.toLowerCase() === preferred),
-            ...capabilities.codecs.filter((candidate) => candidate.mimeType.toLowerCase() !== preferred),
-          ]);
+          transceiver.setCodecPreferences(preferredVideoCodecs(capabilities.codecs, codec));
         }
 
         peer.ontrack = (event) => {
           if (stopped) return;
+          trackReceived = true;
           firstFrameDecodedRef.current = false;
           event.track.onended = () => retryTransport('WebRTC video track ended.');
           setStream(event.streams[0] ?? new MediaStream([event.track]));
-          if (firstFrameTimeoutRef.current !== undefined) {
-            window.clearTimeout(firstFrameTimeoutRef.current);
-          }
-          firstFrameTimeoutRef.current = window.setTimeout(() => {
-            firstFrameTimeoutRef.current = undefined;
-            if (stopped || firstFrameDecodedRef.current) return;
-            const state = peer?.connectionState ?? 'closed';
-            if (webRtcFailureDisposition('first-frame-timeout', state) === 'codec') failCodec();
-            else retryTransport('WebRTC did not establish a video path.');
-          }, FIRST_FRAME_TIMEOUT_MS);
+          clearFirstFrameTimeout();
+          armFirstFrameTimeout();
         };
         peer.onconnectionstatechange = () => {
-          if (stopped || !peer || peer.connectionState !== 'failed') return;
-          if (webRtcFailureDisposition('connection-failed', peer.connectionState) === 'transport') {
+          if (stopped || !peer) return;
+          if (peer.connectionState === 'connected') {
+            connectionReady = true;
+            clearDisconnectedTimer();
+            armFirstFrameTimeout();
+          } else if (peer.connectionState === 'disconnected') {
+            connectionReady = false;
+            clearFirstFrameTimeout();
+            if (disconnectedTimer === undefined) {
+              disconnectedTimer = window.setTimeout(() => {
+                disconnectedTimer = undefined;
+                if (stopped || !peer || peer.connectionState === 'connected') return;
+                retryTransport('WebRTC remained disconnected.');
+              }, DISCONNECTED_GRACE_MS);
+            }
+          } else if (peer.connectionState === 'failed' || peer.connectionState === 'closed') {
             retryTransport('WebRTC connection failed.');
           }
         };
@@ -229,17 +358,22 @@ export function useWebRtcStream({
           requestTimeoutMs: SIGNALING_REQUEST_TIMEOUT_MS,
           busyRetryIntervalMs: BUSY_RETRY_INTERVAL_MS,
           busyRetryCount: BUSY_RETRY_COUNT,
-          body: JSON.stringify({
-            type: local.type,
-            sdp: local.sdp,
-            sessionId,
-            codec,
-            iceServers: servers,
-          }),
+          body: JSON.stringify(
+            buildWebRtcOfferPayload({
+              description: local,
+              sessionId,
+              codec,
+              iceServers: servers,
+              sendIceServersInOffer,
+            }),
+          ),
         });
         if (!response.ok) {
+          const status = response.status;
           await response.body?.cancel();
-          failPermanently(`WebRTC offer failed: HTTP ${response.status}`);
+          const message = `WebRTC offer failed: HTTP ${status}.`;
+          if (isRetryableWebRtcOfferStatus(status)) retryTransport(message);
+          else failPermanently(message);
           return;
         }
         const answer = (await response.json()) as RTCSessionDescriptionInit;
@@ -255,16 +389,14 @@ export function useWebRtcStream({
       } catch (caught) {
         if (stopped || lifecycleController.signal.aborted) return;
         if (caught instanceof WebRtcSignalingBusyError) {
-          failPermanently(caught.message);
+          retryTransport('WebRTC signaling stayed busy for too long.');
           return;
         }
         const message =
           caught instanceof WebRtcSignalingTimeoutError
             ? 'WebRTC signaling timed out.'
             : 'WebRTC signaling failed.';
-        if (webRtcFailureDisposition('signaling-failed', peer?.connectionState ?? 'closed') === 'transport') {
-          retryTransport(message);
-        }
+        retryTransport(message);
       }
     })();
 
@@ -274,15 +406,24 @@ export function useWebRtcStream({
       window.removeEventListener('beforeunload', releaseOnPageHide);
       lifecycleController.abort();
       if (retryTimer !== undefined) window.clearTimeout(retryTimer);
-      if (firstFrameTimeoutRef.current !== undefined) {
-        window.clearTimeout(firstFrameTimeoutRef.current);
-        firstFrameTimeoutRef.current = undefined;
-      }
+      clearFirstFrameTimeout();
+      clearDisconnectedTimer();
       void closeRemoteSession(true);
       setStream(null);
       peer?.close();
     };
-  }, [enabled, offerUrl, closeUrl, codec, iceServers, retryGeneration]);
+  }, [
+    enabled,
+    offerUrl,
+    closeUrl,
+    codec,
+    iceServers,
+    iceTransportPolicy,
+    sendIceServersInOffer,
+    allowCodecFallback,
+    onKeyframeNeeded,
+    retryGeneration,
+  ]);
 
   return { stream, failure, error, markFrameDecoded };
 }

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -76,7 +76,7 @@ export function LogSidebar({
         {client?.capabilities.deviceSettings && <DeviceOptionsSection client={client} />}
         {client?.capabilities.activity && <ActivitySection client={client} />}
         {client?.capabilities.events && <EventsSection client={client} />}
-        {client?.capabilities.streamSettings && (
+        {client?.streamCapabilities && (
           <StreamOptionsSection
             client={client}
             streamMode={streamMode}

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import {
   type DeviceClient,
   type DeviceHttpCodec,
+  type DeviceStreamCapabilities,
   type DeviceStreamEncoderSettings,
   type DeviceStreamMode,
   type DeviceWebRtcCodec,
@@ -12,10 +13,12 @@ import { CollapsibleSection } from './CollapsibleSection';
 import { SidebarRow } from './SidebarRow';
 import { type StreamModeAvailability } from './StreamSection';
 
-type StreamTransport = 'http' | 'webrtc';
+type StreamTransport = 'http' | 'websocket' | 'webrtc';
 
 export type StreamOptionsSectionProps = {
   client: DeviceClient;
+  /** Whether the section is initially expanded. */
+  defaultOpen?: boolean;
   streamMode?: DeviceStreamMode;
   httpCodec?: DeviceHttpCodec;
   streamModeAvailability?: StreamModeAvailability;
@@ -37,10 +40,13 @@ const DEFAULT_AVAILABILITY: StreamModeAvailability = {
   webrtc: true,
 };
 
-const TRANSPORT_OPTIONS = [
-  { value: 'http', label: 'HTTP' },
-  { value: 'webrtc', label: 'WebRTC' },
-] as const;
+const DEFAULT_STREAM_CAPABILITIES = {
+  modeAvailability: DEFAULT_AVAILABILITY,
+  httpCodecs: ['auto', 'h264', 'mjpeg'],
+  webRtcCodecs: ['h264', 'vp9', 'vp8'],
+} as const satisfies DeviceStreamCapabilities;
+
+const STREAM_MODE_ORDER: readonly DeviceStreamMode[] = ['mjpeg', 'h264', 'webrtc'];
 
 const HTTP_CODEC_OPTIONS = [
   { value: 'auto', label: 'Auto' },
@@ -95,31 +101,79 @@ function withCurrentValue(
     : [{ value: current, label: label(value) }, ...options];
 }
 
-/** Viewer transport, codec, and serve-sim runtime encoder controls. */
+/** Viewer transport, backend-supported codecs, and optional runtime encoder controls. */
 export function StreamOptionsSection({
   client,
+  defaultOpen = false,
   streamMode = 'mjpeg',
   httpCodec,
   streamModeAvailability = DEFAULT_AVAILABILITY,
   onStreamModeChange,
   onHttpCodecChange,
 }: StreamOptionsSectionProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
+  const backend: DeviceStreamCapabilities =
+    client.streamCapabilities ?? DEFAULT_STREAM_CAPABILITIES;
+  const availability: StreamModeAvailability = {
+    mjpeg: streamModeAvailability.mjpeg && backend.modeAvailability.mjpeg,
+    h264: streamModeAvailability.h264 && backend.modeAvailability.h264,
+    webrtc: streamModeAvailability.webrtc && backend.modeAvailability.webrtc,
+  };
+  const activeStreamMode = availability[streamMode]
+    ? streamMode
+    : (STREAM_MODE_ORDER.find((mode) => availability[mode]) ?? streamMode);
+  const primaryTransport: Exclude<StreamTransport, 'webrtc'> =
+    client.platform === 'android' ? 'websocket' : 'http';
+  const primaryTransportLabel = client.platform === 'android' ? 'WebSocket' : 'HTTP';
+  const transportOptions: ReadonlyArray<{ value: StreamTransport; label: string }> = [
+    { value: primaryTransport, label: primaryTransportLabel },
+    { value: 'webrtc', label: 'WebRTC' },
+  ];
+  const httpCodecOptions = HTTP_CODEC_OPTIONS.filter((option) =>
+    backend.httpCodecs.includes(option.value),
+  );
+  const webRtcCodecOptions = WEBRTC_CODEC_OPTIONS.filter((option) =>
+    backend.webRtcCodecs.includes(option.value),
+  );
   const settings = client.streamSettings ?? DEFAULT_SETTINGS;
   const settingsReady = client.streamSettings !== null;
   const settingsDisabled = !settingsReady || client.streamSettingsPending;
-  const transport: StreamTransport = streamMode === 'webrtc' ? 'webrtc' : 'http';
+  const transport: StreamTransport =
+    activeStreamMode === 'webrtc' ? 'webrtc' : primaryTransport;
+  const httpAvailable = availability.mjpeg || availability.h264;
+
+  function httpCodecAvailable(codec: DeviceHttpCodec): boolean {
+    if (codec === 'h264') return availability.h264;
+    if (codec === 'mjpeg') return availability.mjpeg;
+    return httpAvailable;
+  }
+
+  const requestedHttpCodec: DeviceHttpCodec =
+    httpCodec ??
+    (activeStreamMode === 'mjpeg' ? 'mjpeg' : activeStreamMode === 'h264' ? 'h264' : 'auto');
+  const modeHttpCodec =
+    activeStreamMode === 'mjpeg' || activeStreamMode === 'h264' ? activeStreamMode : null;
+  const fallbackHttpCodec =
+    (modeHttpCodec &&
+    backend.httpCodecs.includes(modeHttpCodec) &&
+    httpCodecAvailable(modeHttpCodec)
+      ? modeHttpCodec
+      : undefined) ?? httpCodecOptions.find((option) => httpCodecAvailable(option.value))?.value;
   const selectedHttpCodec: DeviceHttpCodec =
-    httpCodec ?? (streamMode === 'mjpeg' ? 'mjpeg' : streamMode === 'h264' ? 'h264' : 'auto');
-  const httpAvailable = streamModeAvailability.mjpeg || streamModeAvailability.h264;
+    backend.httpCodecs.includes(requestedHttpCodec) && httpCodecAvailable(requestedHttpCodec)
+      ? requestedHttpCodec
+      : (fallbackHttpCodec ?? requestedHttpCodec);
+  const selectedWebRtcCodec = backend.webRtcCodecs.includes(client.webRtcCodec)
+    ? client.webRtcCodec
+    : (webRtcCodecOptions[0]?.value ?? client.webRtcCodec);
   const h264Active =
     transport === 'webrtc' ||
-    (transport === 'http' && streamModeAvailability.h264 && selectedHttpCodec !== 'mjpeg');
+    (availability.h264 && selectedHttpCodec !== 'mjpeg');
 
   function httpMode(codec: DeviceHttpCodec): DeviceStreamMode {
     if (codec === 'mjpeg') return 'mjpeg';
-    if (codec === 'h264') return streamModeAvailability.h264 ? 'h264' : 'mjpeg';
-    return streamModeAvailability.h264 ? 'h264' : 'mjpeg';
+    if (codec === 'h264') return availability.h264 ? 'h264' : 'mjpeg';
+    return availability.h264 ? 'h264' : 'mjpeg';
   }
 
   function changeTransport(nextTransport: StreamTransport) {
@@ -128,7 +182,7 @@ export function StreamOptionsSection({
 
   function changeHttpCodec(codec: DeviceHttpCodec) {
     onHttpCodecChange?.(codec);
-    if (transport === 'http') onStreamModeChange?.(httpMode(codec));
+    if (transport !== 'webrtc') onStreamModeChange?.(httpMode(codec));
   }
 
   function patchSetting<Key extends keyof DeviceStreamEncoderSettings>(
@@ -138,111 +192,129 @@ export function StreamOptionsSection({
     if (!settingsDisabled) client.updateStreamSettings({ [key]: value });
   }
 
-  const restricted = !streamModeAvailability.h264 || !streamModeAvailability.webrtc;
+  const restricted =
+    (backend.modeAvailability.h264 && !streamModeAvailability.h264) ||
+    (backend.modeAvailability.webrtc && !streamModeAvailability.webrtc);
+  const hostWebRtcDisabled =
+    client.platform === 'android' && !backend.modeAvailability.webrtc;
 
   return (
     <CollapsibleSection title="Stream options" open={open} onOpenChange={setOpen}>
       <SidebarRow label="Transport">
         <SegmentedControl
           ariaLabel="Stream transport"
-          options={TRANSPORT_OPTIONS.map((option) => ({
+          options={transportOptions.map((option) => ({
             ...option,
             disabled:
               !onStreamModeChange ||
-              (option.value === 'http' ? !httpAvailable : !streamModeAvailability.webrtc),
+              (option.value === 'webrtc' ? !availability.webrtc : !httpAvailable),
           }))}
           value={transport}
           onChange={changeTransport}
         />
       </SidebarRow>
-      <SidebarRow label="HTTP codec">
-        <SegmentedControl
-          ariaLabel="HTTP codec"
-          options={HTTP_CODEC_OPTIONS.map((option) => ({
-            ...option,
-            disabled:
-              transport !== 'http' ||
-              !onHttpCodecChange ||
-              (option.value === 'h264' && !streamModeAvailability.h264) ||
-              (option.value === 'mjpeg' && !streamModeAvailability.mjpeg),
-          }))}
-          value={selectedHttpCodec}
-          onChange={changeHttpCodec}
-        />
-      </SidebarRow>
-      <SidebarRow label="WebRTC codec">
-        <SegmentedControl
-          ariaLabel="WebRTC codec"
-          options={WEBRTC_CODEC_OPTIONS.map((option) => ({
-            ...option,
-            disabled: transport !== 'webrtc' || !streamModeAvailability.webrtc,
-          }))}
-          value={client.webRtcCodec}
-          onChange={(codec: DeviceWebRtcCodec) => client.setWebRtcCodec(codec)}
-        />
-      </SidebarRow>
+      {httpCodecOptions.length > 0 && (
+        <SidebarRow label={`${primaryTransportLabel} codec`}>
+          <SegmentedControl
+            ariaLabel={`${primaryTransportLabel} codec`}
+            options={httpCodecOptions.map((option) => ({
+              ...option,
+              disabled:
+                transport === 'webrtc' || !onHttpCodecChange || !httpCodecAvailable(option.value),
+            }))}
+            value={selectedHttpCodec}
+            onChange={changeHttpCodec}
+          />
+        </SidebarRow>
+      )}
+      {webRtcCodecOptions.length > 0 && (
+        <SidebarRow label="WebRTC codec" borderBottom={client.capabilities.streamSettings}>
+          <SegmentedControl
+            ariaLabel="WebRTC codec"
+            options={webRtcCodecOptions.map((option) => ({
+              ...option,
+              disabled: transport !== 'webrtc' || !availability.webrtc,
+            }))}
+            value={selectedWebRtcCodec}
+            onChange={(codec: DeviceWebRtcCodec) => client.setWebRtcCodec(codec)}
+          />
+        </SidebarRow>
+      )}
       {restricted && (
         <span
           style={{ ...textSize.xs, display: 'block', padding: '0 0 8px', color: text.tertiary }}
         >
-          H.264 and WebRTC require localhost or HTTPS. MJPEG remains available on insecure HTTP.
+          {client.platform === 'android'
+            ? 'WebRTC requires localhost or HTTPS.'
+            : 'H.264 and WebRTC require localhost or HTTPS. MJPEG remains available on insecure HTTP.'}
         </span>
       )}
-      <SidebarRow label="Max size">
-        <Select
-          ariaLabel="Max size"
-          value={String(settings.maxDimension)}
-          options={withCurrentValue(settings.maxDimension, MAX_DIMENSION_OPTIONS, (value) =>
-            value === 0 ? 'Full' : `${value} px`,
-          )}
-          disabled={settingsDisabled}
-          onChange={(value) => patchSetting('maxDimension', Number(value))}
-        />
-      </SidebarRow>
-      <SidebarRow label="MJPEG FPS">
-        <Select
-          ariaLabel="MJPEG FPS"
-          value={String(settings.mjpegFps)}
-          options={withCurrentValue(settings.mjpegFps, FPS_OPTIONS, (value) => `${value} FPS`)}
-          disabled={settingsDisabled || transport !== 'http'}
-          onChange={(value) => patchSetting('mjpegFps', Number(value))}
-        />
-      </SidebarRow>
-      <SidebarRow label="MJPEG quality">
-        <Select
-          ariaLabel="MJPEG quality"
-          value={String(settings.mjpegQuality)}
-          options={withCurrentValue(
-            settings.mjpegQuality,
-            QUALITY_OPTIONS,
-            (value) => `${Math.round(value * 100)}%`,
-          )}
-          disabled={settingsDisabled || transport !== 'http'}
-          onChange={(value) => patchSetting('mjpegQuality', Number(value))}
-        />
-      </SidebarRow>
-      <SidebarRow label="Video FPS">
-        <Select
-          ariaLabel="Video FPS"
-          value={String(settings.h264Fps)}
-          options={withCurrentValue(settings.h264Fps, FPS_OPTIONS, (value) => `${value} FPS`)}
-          disabled={settingsDisabled || !h264Active}
-          onChange={(value) => patchSetting('h264Fps', Number(value))}
-        />
-      </SidebarRow>
-      <SidebarRow label="Video bitrate" borderBottom={false}>
-        <Select
-          ariaLabel="Video bitrate"
-          value={String(settings.h264Bitrate)}
-          options={withCurrentValue(
-            settings.h264Bitrate,
-            BITRATE_OPTIONS,
-            (value) => `${value / 1_000_000} Mbps`,
-          )}
-          disabled={settingsDisabled || !h264Active}
-          onChange={(value) => patchSetting('h264Bitrate', Number(value))}
-        />
-      </SidebarRow>
+      {hostWebRtcDisabled && (
+        <span
+          style={{ ...textSize.xs, display: 'block', padding: '0 0 8px', color: text.tertiary }}
+        >
+          Start the standalone server with --transport webrtc to enable WebRTC.
+        </span>
+      )}
+      {client.capabilities.streamSettings && (
+        <>
+          <SidebarRow label="Max size">
+            <Select
+              ariaLabel="Max size"
+              value={String(settings.maxDimension)}
+              options={withCurrentValue(settings.maxDimension, MAX_DIMENSION_OPTIONS, (value) =>
+                value === 0 ? 'Full' : `${value} px`,
+              )}
+              disabled={settingsDisabled}
+              onChange={(value) => patchSetting('maxDimension', Number(value))}
+            />
+          </SidebarRow>
+          <SidebarRow label="MJPEG FPS">
+            <Select
+              ariaLabel="MJPEG FPS"
+              value={String(settings.mjpegFps)}
+              options={withCurrentValue(settings.mjpegFps, FPS_OPTIONS, (value) => `${value} FPS`)}
+              disabled={settingsDisabled || transport !== 'http'}
+              onChange={(value) => patchSetting('mjpegFps', Number(value))}
+            />
+          </SidebarRow>
+          <SidebarRow label="MJPEG quality">
+            <Select
+              ariaLabel="MJPEG quality"
+              value={String(settings.mjpegQuality)}
+              options={withCurrentValue(
+                settings.mjpegQuality,
+                QUALITY_OPTIONS,
+                (value) => `${Math.round(value * 100)}%`,
+              )}
+              disabled={settingsDisabled || transport !== 'http'}
+              onChange={(value) => patchSetting('mjpegQuality', Number(value))}
+            />
+          </SidebarRow>
+          <SidebarRow label="Video FPS">
+            <Select
+              ariaLabel="Video FPS"
+              value={String(settings.h264Fps)}
+              options={withCurrentValue(settings.h264Fps, FPS_OPTIONS, (value) => `${value} FPS`)}
+              disabled={settingsDisabled || !h264Active}
+              onChange={(value) => patchSetting('h264Fps', Number(value))}
+            />
+          </SidebarRow>
+          <SidebarRow label="Video bitrate" borderBottom={false}>
+            <Select
+              ariaLabel="Video bitrate"
+              value={String(settings.h264Bitrate)}
+              options={withCurrentValue(
+                settings.h264Bitrate,
+                BITRATE_OPTIONS,
+                (value) => `${value / 1_000_000} Mbps`,
+              )}
+              disabled={settingsDisabled || !h264Active}
+              onChange={(value) => patchSetting('h264Bitrate', Number(value))}
+            />
+          </SidebarRow>
+        </>
+      )}
     </CollapsibleSection>
   );
 }

--- a/packages/expo-device-hub/package.json
+++ b/packages/expo-device-hub/package.json
@@ -43,9 +43,13 @@
     "/expo-module.config.json"
   ],
   "dependencies": {
+    "node-datachannel": "^0.32.3",
     "ws": "^8.21.0",
     "zustand": "^5.0.15"
   },
+  "trustedDependencies": [
+    "node-datachannel"
+  ],
   "devDependencies": {
     "@expo/hub-android-utils": "workspace:*",
     "@expo/hub-apple-utils": "workspace:*",

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -43,7 +43,10 @@ import { useArgentInteractions } from './dashboard/useArgentInteraction';
 import { useNewDeviceOptions } from './dashboard/useNewDeviceOptions';
 import { SidebarOverlay } from './dashboard/SidebarOverlay';
 import { useSidebarLayout } from './dashboard/useSidebarLayout';
-import { browserStreamModeAvailability } from './dashboard/streamMode';
+import {
+  androidStreamModeAvailability,
+  browserStreamModeAvailability,
+} from './dashboard/streamMode';
 import { dashboardPlatformFilter } from './platform-filter';
 
 /** Append `extra` devices not already present in `base` (deduped by id). */
@@ -106,9 +109,6 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   const [httpCodec, setHttpCodec] = useState<DeviceHttpCodec>(() =>
     streamMode === 'mjpeg' ? 'mjpeg' : streamMode === 'h264' ? 'h264' : 'auto'
   );
-  const handleStreamModeChange = (mode: DeviceStreamMode) => {
-    chooseStreamMode(mode, streamModeAvailability);
-  };
   // Draggable widths for each inline sidebar. The `*Start` refs snapshot the
   // width when a drag begins so each move re-derives width from the start point
   // (delta-from-start), which clamps cleanly without drifting.
@@ -233,6 +233,16 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
 
   const devices = [...simulators, ...emulators];
   const selected = devices.find((device) => device.id === selectedId) ?? devices[0];
+  const selectedStreamModeAvailability =
+    selected?.platform === 'android'
+      ? androidStreamModeAvailability(
+          streamModeAvailability,
+          typeof window.MediaSource !== 'undefined'
+        )
+      : streamModeAvailability;
+  const handleStreamModeChange = (mode: DeviceStreamMode) => {
+    chooseStreamMode(mode, selectedStreamModeAvailability);
+  };
 
   // One shared connection to the serve-sim/serve-emu server, wired to the
   // selected device. Null until the user picks one, so nothing connects (or
@@ -344,7 +354,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           client={client}
           streamMode={streamMode}
           httpCodec={httpCodec}
-          streamModeAvailability={streamModeAvailability}
+          streamModeAvailability={selectedStreamModeAvailability}
           onStreamModeChange={handleStreamModeChange}
           onHttpCodecChange={setHttpCodec}
           onToggle={sidebars.closeRight}
@@ -385,7 +395,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           client={client}
           streamMode={streamMode}
           httpCodec={httpCodec}
-          streamModeAvailability={streamModeAvailability}
+          streamModeAvailability={selectedStreamModeAvailability}
           onStreamModeChange={handleStreamModeChange}
           onHttpCodecChange={setHttpCodec}
           onToggle={sidebars.closeRight}

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -3,6 +3,9 @@ import { type DeviceClient, type DevicePlatform } from '@expo/hub-client';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { LogSidebar } from '../../../../@expo/hub-components/src/dashboard/LogSidebar';
+import {
+  StreamOptionsSection,
+} from '../../../../@expo/hub-components/src/dashboard/StreamOptionsSection';
 
 function inspectorClient(platform: DevicePlatform): DeviceClient {
   const ios = platform === 'ios';
@@ -41,6 +44,17 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       : { appearance: 'light' },
     deviceSettingsPending: new Set(),
     setDeviceSetting: () => {},
+    streamCapabilities: ios
+      ? {
+          modeAvailability: { mjpeg: true, h264: true, webrtc: true },
+          httpCodecs: ['auto', 'h264', 'mjpeg'],
+          webRtcCodecs: ['h264', 'vp9', 'vp8'],
+        }
+      : {
+          modeAvailability: { mjpeg: false, h264: true, webrtc: true },
+          httpCodecs: ['h264'],
+          webRtcCodecs: ['h264'],
+        },
     streamSettings: ios
       ? {
           mjpegFps: 60,
@@ -135,17 +149,66 @@ test('renders every supported iOS inspector section and option', () => {
   expect(html.match(/aria-expanded="false"/g)?.length).toBe(4);
 });
 
-test('omits unsupported Android activity, stream, and iOS-only options', () => {
+test('renders Android stream options while omitting unsupported and iOS-only sections', () => {
   const html = renderToStaticMarkup(<LogSidebar client={inspectorClient('android')} />);
 
-  for (const label of ['Device options', 'Events', 'Logs', 'Appearance']) {
+  for (const label of ['Device options', 'Events', 'Stream options', 'Logs', 'Appearance']) {
     expect(html).toContain(label);
   }
-  for (const label of ['Activity', 'Stream options', 'Liquid glass', 'VoiceOver']) {
+  for (const label of ['Activity', 'Liquid glass', 'VoiceOver']) {
     expect(html).not.toContain(`>${label}<`);
   }
   expect(html.match(/aria-expanded="true"/g)?.length).toBe(1);
-  expect(html.match(/aria-expanded="false"/g)?.length).toBe(2);
+  expect(html.match(/aria-expanded="false"/g)?.length).toBe(3);
+});
+
+test('limits Android stream controls to the transports and H.264 codecs serve-emu supports', () => {
+  const html = renderToStaticMarkup(
+    <StreamOptionsSection
+      client={inspectorClient('android')}
+      defaultOpen
+      streamMode="webrtc"
+      httpCodec="h264"
+      streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
+      onStreamModeChange={() => {}}
+      onHttpCodecChange={() => {}}
+    />,
+  );
+
+  expect(segmentedControlMarkup(html, 'Stream transport')).toContain('>WebSocket</button>');
+  expect(segmentedControlMarkup(html, 'Stream transport')).toContain('>WebRTC</button>');
+  expect(segmentedControlMarkup(html, 'WebSocket codec')).toContain('>H.264</button>');
+  expect(segmentedControlMarkup(html, 'WebRTC codec')).toContain('>H.264</button>');
+  expect(html).not.toContain('>HTTP</button>');
+  expect(html).not.toContain('>MJPEG</button>');
+  expect(html).not.toContain('>VP8</button>');
+  expect(html).not.toContain('>VP9</button>');
+  expect(html).not.toContain('>Max size</span>');
+});
+
+test('explains when the Android host was not launched with WebRTC', () => {
+  const client = {
+    ...inspectorClient('android'),
+    streamCapabilities: {
+      modeAvailability: { mjpeg: false, h264: true, webrtc: false },
+      httpCodecs: ['h264'],
+      webRtcCodecs: ['h264'],
+    },
+  } satisfies DeviceClient;
+  const html = renderToStaticMarkup(
+    <StreamOptionsSection
+      client={client}
+      defaultOpen
+      streamMode="h264"
+      httpCodec="h264"
+      streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
+      onStreamModeChange={() => {}}
+      onHttpCodecChange={() => {}}
+    />,
+  );
+
+  expect(segmentedControlMarkup(html, 'Stream transport')).toContain('disabled=""');
+  expect(html).toContain('Start the standalone server with --transport webrtc');
 });
 
 test('uses the shared stream-pill spacing for every device option', () => {

--- a/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/streamMode.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { resolveStreamMode, streamModeAvailability } from '../streamMode';
+import {
+  androidStreamModeAvailability,
+  resolveStreamMode,
+  streamModeAvailability,
+} from '../streamMode';
 import { dashboardTransport, parseTransport } from '../../transport';
 
 afterEach(() => {
@@ -33,6 +37,21 @@ describe('stream mode availability', () => {
     });
     expect(resolveStreamMode('mjpeg', availability)).toBe('mjpeg');
     expect(resolveStreamMode('h264', availability)).toBe('mjpeg');
+  });
+
+  test('keeps Android WebSocket H.264 available through MSE on insecure HTTP', () => {
+    const browserAvailability = streamModeAvailability({
+      secureContext: false,
+      h264Decoder: false,
+      webRtc: true,
+    });
+
+    expect(androidStreamModeAvailability(browserAvailability, true)).toEqual({
+      mjpeg: true,
+      h264: true,
+      webrtc: false,
+    });
+    expect(androidStreamModeAvailability(browserAvailability, false).h264).toBe(false);
   });
 
   test('uses the standalone host preference when it is available', () => {

--- a/packages/expo-device-hub/src/dashboard/streamMode.ts
+++ b/packages/expo-device-hub/src/dashboard/streamMode.ts
@@ -31,6 +31,17 @@ export function browserStreamModeAvailability(): StreamModeAvailability {
   });
 }
 
+/** Android can decode serve-emu's WebSocket H.264 stream through MSE on LAN HTTP. */
+export function androidStreamModeAvailability(
+  availability: StreamModeAvailability,
+  mediaSourceSupported: boolean,
+): StreamModeAvailability {
+  return {
+    ...availability,
+    h264: availability.h264 || mediaSourceSupported,
+  };
+}
+
 /** Keep the requested mode when available, otherwise use the universal MJPEG path. */
 export function resolveStreamMode(
   requested: DeviceStreamMode,

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -18,6 +18,7 @@ describe('parseCliOptions', () => {
       turnUrls: undefined,
       turnUsername: undefined,
       turnCredential: undefined,
+      webrtcIcePolicy: undefined,
       metricsCorsOrigins: [],
       hideSidebar: false,
       help: false,
@@ -57,6 +58,8 @@ describe('parseCliOptions', () => {
         'alice',
         '--turn-credential',
         'secret',
+        '--webrtc-ice-policy',
+        'relay',
       ])
     ).toMatchObject({
       transport: 'webrtc',
@@ -65,6 +68,7 @@ describe('parseCliOptions', () => {
       turnUrls: ['turn:relay.test', 'turns:secure-relay.test'],
       turnUsername: 'alice',
       turnCredential: 'secret',
+      webrtcIcePolicy: 'relay',
     });
   });
 
@@ -136,6 +140,25 @@ describe('parseCliOptions', () => {
         'secret',
       ])
     ).toThrow('--turn-username and --turn-credential require --turn-url');
+    expect(() => parseCliOptions(['--webrtc-ice-policy', 'all'])).toThrow(
+      'WebRTC options require --transport webrtc'
+    );
+    expect(() =>
+      parseCliOptions(['--transport', 'webrtc', '--webrtc-ice-policy', 'relay'])
+    ).toThrow('--webrtc-ice-policy relay requires --turn-url');
+    expect(() =>
+      parseCliOptions(['--transport', 'webrtc', '--webrtc-ice-policy', 'host'])
+    ).toThrow('Invalid --webrtc-ice-policy: host');
+    expect(() =>
+      parseCliOptions([
+        '--platform',
+        'ios',
+        '--transport',
+        'webrtc',
+        '--webrtc-ice-policy',
+        'all',
+      ])
+    ).toThrow('--webrtc-ice-policy is supported only for Android');
   });
 
   test('documents every serve-sim flag', () => {
@@ -149,6 +172,7 @@ describe('parseCliOptions', () => {
       '--turn-url',
       '--turn-username',
       '--turn-credential',
+      '--webrtc-ice-policy',
       '--metrics-cors-origin',
     ]) {
       expect(HELP).toContain(flag);
@@ -183,6 +207,7 @@ describe('parseCliOptions', () => {
       turnUrls: undefined,
       turnUsername: undefined,
       turnCredential: undefined,
+      webrtcIcePolicy: undefined,
       metricsCorsOrigins: [],
       hideSidebar: false,
       help: false,

--- a/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseCliOptions } from '../cli/options';
+import {
+  DEFAULT_SERVE_EMU_ICE_SERVERS,
+  encodeStandaloneServeEmuOptions,
+  readStandaloneServeEmuOptions,
+  serveEmuWebSocketOptions,
+  standaloneServeEmuOptions,
+} from '../serve-emu-options';
+
+describe('standaloneServeEmuOptions', () => {
+  test('uses serve-emu WebSocket defaults without Hub stream flags', () => {
+    expect(standaloneServeEmuOptions(parseCliOptions([]))).toEqual({
+      streamSettings: { transport: 'websocket' },
+    });
+    expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'mjpeg']))).toEqual({
+      streamSettings: { transport: 'websocket' },
+    });
+    expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'h264']))).toEqual({
+      streamSettings: { transport: 'websocket' },
+    });
+  });
+
+  test('maps shared encoder flags onto scrcpy startup options', () => {
+    expect(
+      standaloneServeEmuOptions(
+        parseCliOptions([
+          '--max-dimension',
+          '1280',
+          '--video-bitrate',
+          '4000000',
+          '--video-fps',
+          '24',
+          '--mjpeg-quality',
+          '0.75',
+        ]),
+      ),
+    ).toEqual({
+      maxSize: 1280,
+      bitRate: 4_000_000,
+      maxFps: 24,
+      streamSettings: { transport: 'websocket' },
+    });
+  });
+
+  test('maps host WebRTC settings while keeping Android on H.264', () => {
+    expect(
+      standaloneServeEmuOptions(
+        parseCliOptions([
+          '--transport',
+          'webrtc',
+          '--webrtc-codec',
+          'vp9',
+          '--stun-url',
+          'stun:one.test,stun:two.test',
+          '--turn-url',
+          'turn:relay.test',
+          '--turn-username',
+          'alice',
+          '--turn-credential',
+          'secret',
+          '--webrtc-ice-policy',
+          'relay',
+        ]),
+      ),
+    ).toEqual({
+      streamSettings: {
+        transport: 'webrtc',
+        codec: 'h264',
+        iceServers: [
+          { urls: ['stun:one.test', 'stun:two.test'] },
+          {
+            urls: ['turn:relay.test'],
+            username: 'alice',
+            credential: 'secret',
+          },
+        ],
+        iceTransportPolicy: 'relay',
+      },
+    });
+  });
+
+  test('uses serve-emu WebRTC ICE defaults', () => {
+    expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'webrtc']))).toEqual({
+      streamSettings: {
+        transport: 'webrtc',
+        codec: 'h264',
+        iceServers: DEFAULT_SERVE_EMU_ICE_SERVERS,
+        iceTransportPolicy: 'all',
+      },
+    });
+  });
+
+  test('keeps the default STUN servers when only TURN is configured', () => {
+    expect(
+      standaloneServeEmuOptions(
+        parseCliOptions([
+          '--transport',
+          'webrtc',
+          '--turn-url',
+          'turn:relay.test',
+          '--webrtc-ice-policy',
+          'relay',
+        ]),
+      ).streamSettings,
+    ).toEqual({
+      transport: 'webrtc',
+      codec: 'h264',
+      iceServers: [...DEFAULT_SERVE_EMU_ICE_SERVERS, { urls: ['turn:relay.test'] }],
+      iceTransportPolicy: 'relay',
+    });
+  });
+
+  test('round-trips through the server environment payload', () => {
+    const options = parseCliOptions(['--transport', 'webrtc', '--video-fps', '30']);
+    expect(readStandaloneServeEmuOptions(encodeStandaloneServeEmuOptions(options))).toEqual(
+      standaloneServeEmuOptions(options),
+    );
+    expect(readStandaloneServeEmuOptions('not json')).toEqual({
+      streamSettings: { transport: 'websocket' },
+    });
+  });
+});
+
+describe('serveEmuWebSocketOptions', () => {
+  test('keeps WebRTC input sockets video-free', () => {
+    expect(
+      serveEmuWebSocketOptions(
+        new URL('http://localhost/vendor/serve-emu/ws?video=0&frame-meta=1'),
+      ),
+    ).toEqual({ video: false, frameMeta: false });
+  });
+
+  test('requests metadata only for video sockets', () => {
+    expect(
+      serveEmuWebSocketOptions(new URL('http://localhost/vendor/serve-emu/ws?frame-meta=1')),
+    ).toEqual({ video: true, frameMeta: true });
+  });
+});

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -8,6 +8,10 @@ import { requestOrigin, toFetchRequest, toUpgradeRequest, writeFetchResponse } f
 import { DEFAULT_PORT, HELP, parseCliOptions, type CliOptions } from './cli/options';
 import { staticFileHandler } from './cli/static-files';
 import {
+  encodeStandaloneServeEmuOptions,
+  SERVE_EMU_OPTIONS_ENV,
+} from './serve-emu-options';
+import {
   encodeStandaloneServeSimOptions,
   SERVE_SIM_OPTIONS_ENV,
 } from './serve-sim-options';
@@ -81,6 +85,7 @@ async function main(): Promise<void> {
   } else {
     delete process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR;
   }
+  process.env[SERVE_EMU_OPTIONS_ENV] = encodeStandaloneServeEmuOptions(options);
   process.env[SERVE_SIM_OPTIONS_ENV] = encodeStandaloneServeSimOptions(options);
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time
   const hubServer = (await import('./index.mjs')) as HubServerModule;

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -13,6 +13,9 @@ import {
 export const DEFAULT_PORT = 3400;
 export const DEFAULT_WEBRTC_CODEC: WebRtcStreamCodec = 'h264';
 export const WEBRTC_CODECS = ['vp8', 'vp9', 'h264'] as const satisfies readonly WebRtcStreamCodec[];
+export const DEFAULT_WEBRTC_ICE_POLICY = 'all';
+export const WEBRTC_ICE_POLICIES = ['all', 'relay'] as const;
+export type WebRtcIcePolicy = (typeof WEBRTC_ICE_POLICIES)[number];
 
 export const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
 
@@ -32,6 +35,7 @@ Options:
       --turn-url <urls>      Comma-separated TURN URL(s) for WebRTC ICE
       --turn-username <name> TURN username (requires --turn-credential and --turn-url)
       --turn-credential <credential> TURN credential (requires --turn-username and --turn-url)
+      --webrtc-ice-policy <policy> Android ICE policy: ${WEBRTC_ICE_POLICIES.join(', ')} (default: ${DEFAULT_WEBRTC_ICE_POLICY})
       --metrics-cors-origin <origin> Allow an origin to read serve-sim metrics (repeatable)
       --hide-sidebar         Hide the device list sidebar by default
   -h, --help                 Show this help
@@ -51,6 +55,7 @@ export type CliOptions = {
   turnUrls?: string[];
   turnUsername?: string;
   turnCredential?: string;
+  webrtcIcePolicy?: WebRtcIcePolicy;
   metricsCorsOrigins?: string[];
   hideSidebar?: boolean;
   help: boolean;
@@ -116,6 +121,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     'turn-url'?: string;
     'turn-username'?: string;
     'turn-credential'?: string;
+    'webrtc-ice-policy'?: string;
     'metrics-cors-origin': string[];
     'hide-sidebar': boolean;
     help: boolean;
@@ -140,6 +146,7 @@ export function parseCliOptions(args: string[]): CliOptions {
         'turn-url': { type: 'string' },
         'turn-username': { type: 'string' },
         'turn-credential': { type: 'string' },
+        'webrtc-ice-policy': { type: 'string' },
         'metrics-cors-origin': { type: 'string', multiple: true, default: [] },
         'hide-sidebar': { type: 'boolean', default: false },
         help: { type: 'boolean', short: 'h', default: false },
@@ -194,13 +201,26 @@ export function parseCliOptions(args: string[]): CliOptions {
   const turnUrls = parseIceUrls(values['turn-url'], 'turn');
   const turnUsername = values['turn-username'];
   const turnCredential = values['turn-credential'];
+  const normalizedWebRtcIcePolicy = values['webrtc-ice-policy']?.toLowerCase();
+  const webrtcIcePolicy = WEBRTC_ICE_POLICIES.includes(
+    normalizedWebRtcIcePolicy as WebRtcIcePolicy
+  )
+    ? (normalizedWebRtcIcePolicy as WebRtcIcePolicy)
+    : undefined;
+  if (values['webrtc-ice-policy'] !== undefined && webrtcIcePolicy === undefined) {
+    throw new Error(`Invalid --webrtc-ice-policy: ${values['webrtc-ice-policy']}\n\n${HELP}`);
+  }
+  if (values['webrtc-ice-policy'] !== undefined && platform === 'ios') {
+    throw new Error(`--webrtc-ice-policy is supported only for Android.\n\n${HELP}`);
+  }
 
   const webRtcOptionProvided =
     values['webrtc-codec'] !== undefined ||
     stunUrls !== undefined ||
     turnUrls !== undefined ||
     turnUsername !== undefined ||
-    turnCredential !== undefined;
+    turnCredential !== undefined ||
+    values['webrtc-ice-policy'] !== undefined;
   if (webRtcOptionProvided && transport !== 'webrtc') {
     throw new Error(`WebRTC options require --transport webrtc.\n\n${HELP}`);
   }
@@ -209,6 +229,9 @@ export function parseCliOptions(args: string[]): CliOptions {
   }
   if ((turnUsername !== undefined || turnCredential !== undefined) && turnUrls === undefined) {
     throw new Error(`--turn-username and --turn-credential require --turn-url.\n\n${HELP}`);
+  }
+  if (webrtcIcePolicy === 'relay' && turnUrls === undefined) {
+    throw new Error(`--webrtc-ice-policy relay requires --turn-url.\n\n${HELP}`);
   }
 
   return {
@@ -225,6 +248,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     turnUrls,
     turnUsername,
     turnCredential,
+    webrtcIcePolicy,
     metricsCorsOrigins: values['metrics-cors-origin'],
     hideSidebar: values['hide-sidebar'],
     help: false,

--- a/packages/expo-device-hub/src/server/serve-emu-options.ts
+++ b/packages/expo-device-hub/src/server/serve-emu-options.ts
@@ -1,0 +1,95 @@
+import { DEFAULT_WEBRTC_ICE_POLICY, type CliOptions, type WebRtcIcePolicy } from './cli/options';
+
+export const SERVE_EMU_OPTIONS_ENV = 'EXPO_DEVICE_HUB_SERVE_EMU_OPTIONS';
+
+export type StandaloneServeEmuIceServer = {
+  urls: string[];
+  username?: string;
+  credential?: string;
+};
+
+export type StandaloneServeEmuStreamSettings =
+  | { transport: 'websocket' }
+  | {
+      transport: 'webrtc';
+      codec: 'h264';
+      iceServers: StandaloneServeEmuIceServer[];
+      iceTransportPolicy: WebRtcIcePolicy;
+    };
+
+/** The public STUN defaults used by serve-emu's own standalone CLI. */
+export const DEFAULT_SERVE_EMU_ICE_SERVERS: StandaloneServeEmuIceServer[] = [
+  { urls: ['stun:stun.l.google.com:19302'] },
+  { urls: ['stun:stun1.l.google.com:19302'] },
+];
+
+export type StandaloneServeEmuOptions = {
+  maxFps?: number;
+  bitRate?: number;
+  maxSize?: number;
+  streamSettings: StandaloneServeEmuStreamSettings;
+};
+
+function webRtcIceServers(options: CliOptions): StandaloneServeEmuIceServer[] {
+  const iceServers: StandaloneServeEmuIceServer[] = options.stunUrls
+    ? [{ urls: options.stunUrls }]
+    : DEFAULT_SERVE_EMU_ICE_SERVERS.map((server) => ({
+        ...server,
+        urls: [...server.urls],
+      }));
+  if (options.turnUrls) {
+    iceServers.push({
+      urls: options.turnUrls,
+      ...(options.turnUsername !== undefined ? { username: options.turnUsername } : {}),
+      ...(options.turnCredential !== undefined ? { credential: options.turnCredential } : {}),
+    });
+  }
+  return iceServers;
+}
+
+/** Map the Hub's cross-platform CLI flags onto serve-emu's router defaults. */
+export function standaloneServeEmuOptions(options: CliOptions): StandaloneServeEmuOptions {
+  return {
+    ...(options.videoFps !== undefined ? { maxFps: options.videoFps } : {}),
+    ...(options.videoBitrate !== undefined ? { bitRate: options.videoBitrate } : {}),
+    ...(options.maxDimension !== undefined ? { maxSize: options.maxDimension } : {}),
+    streamSettings:
+      options.transport === 'webrtc'
+        ? {
+            transport: 'webrtc',
+            // serve-emu publishes the scrcpy H.264 encoder over RTP. The Hub's
+            // VP8/VP9 preference remains valid for iOS but cannot be forwarded here.
+            codec: 'h264',
+            iceServers: webRtcIceServers(options),
+            iceTransportPolicy: options.webrtcIcePolicy ?? DEFAULT_WEBRTC_ICE_POLICY,
+          }
+        : { transport: 'websocket' },
+  };
+}
+
+export function encodeStandaloneServeEmuOptions(options: CliOptions): string {
+  return JSON.stringify(standaloneServeEmuOptions(options));
+}
+
+export function readStandaloneServeEmuOptions(
+  value: string | undefined,
+): StandaloneServeEmuOptions {
+  if (!value) return { streamSettings: { transport: 'websocket' } };
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as StandaloneServeEmuOptions)
+      : { streamSettings: { transport: 'websocket' } };
+  } catch {
+    return { streamSettings: { transport: 'websocket' } };
+  }
+}
+
+/** Parse the video-channel flags that the serve-emu router expects at upgrade time. */
+export function serveEmuWebSocketOptions(url: URL): { video: boolean; frameMeta: boolean } {
+  const video = url.searchParams.get('video') !== '0';
+  return {
+    video,
+    frameMeta: video && url.searchParams.get('frame-meta') === '1',
+  };
+}

--- a/packages/expo-device-hub/src/server/serve-emu.ts
+++ b/packages/expo-device-hub/src/server/serve-emu.ts
@@ -1,9 +1,15 @@
 // @ts-ignore vendored module, absent until `bun run build:vendor`
 import { createRouter, fromWsSocket, type WsWebSocketLike } from '../../vendor/serve-emu/dist/middleware.js';
 
+import {
+  readStandaloneServeEmuOptions,
+  SERVE_EMU_OPTIONS_ENV,
+  serveEmuWebSocketOptions,
+} from './serve-emu-options';
+
 export const EMU_PREFIX = '/vendor/serve-emu';
 
-const router = createRouter();
+const router = createRouter(readStandaloneServeEmuOptions(process.env[SERVE_EMU_OPTIONS_ENV]));
 
 function stopAll(): void {
   try {
@@ -31,8 +37,8 @@ async function attachEmuSocket(socket: WsWebSocketLike, request: Request): Promi
     } catch {}
     return;
   }
-  const frameMeta = url.searchParams.get('frame-meta') === '1';
-  router.attachWebSocket(fromWsSocket(socket), { serial, frameMeta });
+  const { video, frameMeta } = serveEmuWebSocketOptions(url);
+  router.attachWebSocket(fromWsSocket(socket), { serial, video, frameMeta });
 }
 
 export const emuWebSocketHandler = (socket: WsWebSocketLike, request: Request): void => {


### PR DESCRIPTION
## Summary

- port serve-emu's stabilized H.264 WebRTC negotiation and recovery behavior into the shared Hub client
- keep Android input on an input-only WebSocket while video uses WebRTC, and expose only backend/browser-supported stream choices in the inspector
- forward standalone transport, ICE, max-size, bitrate, and FPS options into serve-emu and ship its `node-datachannel` runtime dependency
- retain iOS WebRTC behavior while sharing the hardened negotiation path

`upstream/main` currently pins an unavailable serve-sim revision, so the first commit includes the submodule/lockfile update from #28 needed to initialize and build the monorepo.

## Verification

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- built standalone CLI launched with `--transport webrtc --webrtc-codec h264 --max-dimension 1280 --video-bitrate 4000000 --video-fps 24`
- `agent-browser` observed successful WebRTC offer requests for both iOS and Android
- Android health reported `transport: webrtc`, one active connected peer, an open track, and increasing `sentFrames`
- Android's scrcpy process received `max_size=1280`, `video_bit_rate=4000000`, and `max_fps=24`
- a browser-driven touch was recorded through the input-only WebSocket and opened Chrome (`com.android.chrome`)

## Screenshot

![Android WebRTC stream with Chrome open and stream options visible](https://raw.githubusercontent.com/krystofwoldrich-agent/expo-device-hub/ce6c7bdd3f513fa1f3448bc54911cbb11eae3801/assets/pr/serve-emu-webrtc/android-webrtc-chrome-open.png)
