### PR TITLE
Add hide boot device CLI option

### DIFF
--- a/.changeset/calm-spoons-hide.md
+++ b/.changeset/calm-spoons-hide.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add a `--hide-boot-device` CLI option that hides controls for booting and creating devices.

--- a/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar({
   selectedId: string;
   onSelect: (id: string) => void;
   /** Starts the existing or new device chosen in either add-device picker. */
-  onAddDevice: (target: AddDeviceTarget) => Promise<AddDeviceOutcome>;
+  onAddDevice?: (target: AddDeviceTarget) => Promise<AddDeviceOutcome>;
   /** When set, a sidebar toggle is shown right-aligned in the logo row. */
   onToggle?: () => void;
   /** Restrict the sidebar to one platform. Both sections render by default. */
@@ -72,7 +72,11 @@ export function Sidebar({
           title="Simulators"
           addLabel="Add simulator"
           kind="simulator"
-          emptyLabel="No booted simulators. Use the + button to add one."
+          emptyLabel={
+            onAddDevice
+              ? 'No booted simulators. Use the + button to add one.'
+              : 'No booted simulators.'
+          }
           devices={simulators}
           recent={recentSimulators}
           options={simulatorOptions}
@@ -87,7 +91,11 @@ export function Sidebar({
           title="Emulators"
           addLabel="Add emulator"
           kind="emulator"
-          emptyLabel="No booted emulators or devices. Use the + button to add one."
+          emptyLabel={
+            onAddDevice
+              ? 'No booted emulators or devices. Use the + button to add one.'
+              : 'No booted emulators or devices.'
+          }
           devices={emulators}
           recent={recentEmulators}
           options={emulatorOptions}

--- a/packages/expo-device-hub/public/index.html
+++ b/packages/expo-device-hub/public/index.html
@@ -25,6 +25,9 @@
         if ('{{hideSidebar}}' === 'true') {
           window.__EXPO_DEVICE_HUB_HIDE_SIDEBAR__ = true;
         }
+        if ('{{hideBootDevice}}' === 'true') {
+          window.__EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE__ = true;
+        }
       })();
     </script>
     <!-- The `react-native-web` recommended style reset: https://necolas.github.io/react-native-web/docs/setup/#root-element -->

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { AnimatedDockedSidebar } from './dashboard/AnimatedDockedSidebar';
+import { dashboardHideBootDevice } from './boot-device';
 import { basePath } from './dashboard/basePath';
 import { bootDevice, createDevice, removeDevice, shutdownDevice } from './dashboard/deviceActions';
 import { DEFAULT_SIDEBAR_WIDTH, useDashboardStore } from './dashboard/dashboardStore';
@@ -86,6 +87,7 @@ function clampSidebarWidth(width: number, otherWidth: number): number {
  */
 export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps }) {
   const scheme = useColorScheme();
+  const hideBootDevice = dashboardHideBootDevice();
   const platform = dashboardPlatformFilter();
   const { booted, recent } = useDeviceLists();
   // Installed runtimes/system images and models for the new-device forms.
@@ -287,7 +289,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           agentDeviceIds={agentDeviceIds}
           selectedId={selectedId}
           onSelect={selectDevice}
-          onAddDevice={handleAddDevice}
+          onAddDevice={hideBootDevice ? undefined : handleAddDevice}
           onToggle={sidebars.closeLeft}
           platform={platform}
           width={sidebarWidth}
@@ -378,7 +380,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           agentDeviceIds={agentDeviceIds}
           selectedId={selectedId}
           onSelect={selectDevice}
-          onAddDevice={handleAddDevice}
+          onAddDevice={hideBootDevice ? undefined : handleAddDevice}
           onToggle={sidebars.closeLeft}
           platform={platform}
           width={sidebarWidth}

--- a/packages/expo-device-hub/src/boot-device.ts
+++ b/packages/expo-device-hub/src/boot-device.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    __EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE__?: boolean;
+  }
+}
+
+/** Whether the standalone CLI disabled controls for booting or creating devices. */
+export function dashboardHideBootDevice(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.__EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE__ === true;
+}

--- a/packages/expo-device-hub/src/dashboard/__tests__/bootDeviceVisibility.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/bootDeviceVisibility.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Sidebar } from '@expo/hub-components';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { dashboardHideBootDevice } from '../../boot-device';
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('dashboardHideBootDevice', () => {
+  test('uses the preference provided by the standalone shell', () => {
+    (globalThis as any).window = { __EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE__: true };
+    expect(dashboardHideBootDevice()).toBe(true);
+  });
+
+  test('keeps boot-device controls visible by default', () => {
+    expect(dashboardHideBootDevice()).toBe(false);
+  });
+});
+
+test('omits add-device buttons and their empty-state instructions without a handler', () => {
+  const html = renderToStaticMarkup(
+    <Sidebar
+      simulators={[]}
+      emulators={[]}
+      recentSimulators={[]}
+      recentEmulators={[]}
+      simulatorOptions={{ runtimes: [] }}
+      emulatorOptions={{ runtimes: [] }}
+      selectedId=""
+      onSelect={() => {}}
+    />
+  );
+
+  expect(html).not.toContain('aria-label="Add simulator"');
+  expect(html).not.toContain('aria-label="Add emulator"');
+  expect(html).not.toContain('Use the + button');
+});

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -21,6 +21,7 @@ describe('parseCliOptions', () => {
       webrtcIcePolicy: undefined,
       metricsCorsOrigins: [],
       hideSidebar: false,
+      hideBootDevice: false,
       help: false,
     });
   });
@@ -184,6 +185,11 @@ describe('parseCliOptions', () => {
     expect(HELP).toContain('--hide-sidebar');
   });
 
+  test('hides controls for booting or creating devices on request', () => {
+    expect(parseCliOptions(['--hide-boot-device']).hideBootDevice).toBe(true);
+    expect(HELP).toContain('--hide-boot-device');
+  });
+
   test('replaces the old stream-mode flag', () => {
     expect(HELP).toContain('--transport <transport>');
     expect(HELP).not.toContain('--stream-mode');
@@ -210,6 +216,7 @@ describe('parseCliOptions', () => {
       webrtcIcePolicy: undefined,
       metricsCorsOrigins: [],
       hideSidebar: false,
+      hideBootDevice: false,
       help: false,
     });
     expect(parseCliOptions(['--help'])).toEqual({ host: '127.0.0.1', help: true });

--- a/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
@@ -4,17 +4,17 @@ import { configureClientShell } from '../client-shell';
 
 describe('configureClientShell', () => {
   const shell =
-    '<base href="{{mount}}/"> <script>var platform = "{{platform}}"; var transport = "{{transport}}"; var hideSidebar = "{{hideSidebar}}"</script>';
+    '<base href="{{mount}}/"> <script>var platform = "{{platform}}"; var transport = "{{transport}}"; var hideSidebar = "{{hideSidebar}}"; var hideBootDevice = "{{hideBootDevice}}"</script>';
 
   test('leaves CLI options empty when they are omitted', () => {
-    expect(configureClientShell(shell, '', undefined, undefined, false)).toBe(
-      '<base href="/"> <script>var platform = ""; var transport = ""; var hideSidebar = "false"</script>'
+    expect(configureClientShell(shell, '', undefined, undefined, false, false)).toBe(
+      '<base href="/"> <script>var platform = ""; var transport = ""; var hideSidebar = "false"; var hideBootDevice = "false"</script>'
     );
   });
 
   test('injects the selected options and mount path', () => {
-    expect(configureClientShell(shell, '/hub', 'android', 'webrtc', true)).toBe(
-      '<base href="/hub/"> <script>var platform = "android"; var transport = "webrtc"; var hideSidebar = "true"</script>'
+    expect(configureClientShell(shell, '/hub', 'android', 'webrtc', true, true)).toBe(
+      '<base href="/hub/"> <script>var platform = "android"; var transport = "webrtc"; var hideSidebar = "true"; var hideBootDevice = "true"</script>'
     );
   });
 });

--- a/packages/expo-device-hub/src/server/boot-device.ts
+++ b/packages/expo-device-hub/src/server/boot-device.ts
@@ -1,0 +1,4 @@
+/** Set only by the standalone CLI before it imports the server bundle. */
+export const SERVER_HIDE_BOOT_DEVICE =
+  process.env.EXPO_DEVICE_HUB_BASE_PATH === '' &&
+  process.env.EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE === 'true';

--- a/packages/expo-device-hub/src/server/cli.ts
+++ b/packages/expo-device-hub/src/server/cli.ts
@@ -85,6 +85,11 @@ async function main(): Promise<void> {
   } else {
     delete process.env.EXPO_DEVICE_HUB_HIDE_SIDEBAR;
   }
+  if (options.hideBootDevice) {
+    process.env.EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE = 'true';
+  } else {
+    delete process.env.EXPO_DEVICE_HUB_HIDE_BOOT_DEVICE;
+  }
   process.env[SERVE_EMU_OPTIONS_ENV] = encodeStandaloneServeEmuOptions(options);
   process.env[SERVE_SIM_OPTIONS_ENV] = encodeStandaloneServeSimOptions(options);
   // @ts-ignore — built sibling of this bundle (dist/server/index.mjs), kept external at build time

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -38,6 +38,7 @@ Options:
       --webrtc-ice-policy <policy> Android ICE policy: ${WEBRTC_ICE_POLICIES.join(', ')} (default: ${DEFAULT_WEBRTC_ICE_POLICY})
       --metrics-cors-origin <origin> Allow an origin to read serve-sim metrics (repeatable)
       --hide-sidebar         Hide the device list sidebar by default
+      --hide-boot-device     Hide controls for booting or creating devices
   -h, --help                 Show this help
 `;
 
@@ -58,6 +59,7 @@ export type CliOptions = {
   webrtcIcePolicy?: WebRtcIcePolicy;
   metricsCorsOrigins?: string[];
   hideSidebar?: boolean;
+  hideBootDevice?: boolean;
   help: boolean;
 };
 
@@ -124,6 +126,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     'webrtc-ice-policy'?: string;
     'metrics-cors-origin': string[];
     'hide-sidebar': boolean;
+    'hide-boot-device': boolean;
     help: boolean;
   };
   try {
@@ -149,6 +152,7 @@ export function parseCliOptions(args: string[]): CliOptions {
         'webrtc-ice-policy': { type: 'string' },
         'metrics-cors-origin': { type: 'string', multiple: true, default: [] },
         'hide-sidebar': { type: 'boolean', default: false },
+        'hide-boot-device': { type: 'boolean', default: false },
         help: { type: 'boolean', short: 'h', default: false },
       },
     }));
@@ -251,6 +255,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     webrtcIcePolicy,
     metricsCorsOrigins: values['metrics-cors-origin'],
     hideSidebar: values['hide-sidebar'],
+    hideBootDevice: values['hide-boot-device'],
     help: false,
   };
 }

--- a/packages/expo-device-hub/src/server/client-shell.ts
+++ b/packages/expo-device-hub/src/server/client-shell.ts
@@ -7,11 +7,13 @@ export function configureClientShell(
   mountPath: string,
   platform: PlatformFilter | undefined,
   transport: Transport | undefined,
-  hideSidebar: boolean
+  hideSidebar: boolean,
+  hideBootDevice: boolean
 ): string {
   return html
     .replaceAll('{{mount}}', mountPath)
     .replaceAll('{{platform}}', platform ?? '')
     .replaceAll('{{transport}}', transport ?? '')
-    .replaceAll('{{hideSidebar}}', String(hideSidebar));
+    .replaceAll('{{hideSidebar}}', String(hideSidebar))
+    .replaceAll('{{hideBootDevice}}', String(hideBootDevice));
 }

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -12,6 +12,7 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
+import { SERVER_HIDE_BOOT_DEVICE } from './boot-device';
 import {
   bootHubDevice,
   createHubDevice,
@@ -67,7 +68,8 @@ async function serveClientIndexHtml(): Promise<Response | null> {
       MOUNT_PATH,
       SERVER_PLATFORM_FILTER,
       SERVER_TRANSPORT,
-      SERVER_HIDE_SIDEBAR
+      SERVER_HIDE_SIDEBAR,
+      SERVER_HIDE_BOOT_DEVICE
     ),
     {
       headers: {


### PR DESCRIPTION
## Summary

- Add a `--hide-boot-device` standalone CLI option.
- Hide the simulator and emulator plus buttons, and remove their add-device empty-state instructions, when enabled.
- Add CLI, shell-injection, and rendered-sidebar coverage plus an `expo-device-hub`-only changeset.

## Usage

```sh
npx expo-device-hub --hide-boot-device
```

This is used for the hosted version of the package where devices are pre-booted for their session.

## Test plan

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run test`

<img width="1440" height="900" alt="Codex Image Aug 28, 2026, 09_50_53 PM" src="https://github.com/user-attachments/assets/69041955-930d-4288-90a8-7fe412da2cdb" />

