### PR TITLE
Fix WebRTC signaling behind TLS proxies

### DIFF
--- a/.changeset/proxy-forwarded-protocol.md
+++ b/.changeset/proxy-forwarded-protocol.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Honor `X-Forwarded-Proto` in the standalone CLI so WebRTC signaling works behind TLS-terminating reverse proxies.

--- a/packages/expo-device-hub/src/server/__tests__/node-fetch-server.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/node-fetch-server.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import type { IncomingMessage } from 'node:http';
+
+import { requestOrigin } from '../cli/node-fetch-server';
+
+function incomingRequest({
+  encrypted = false,
+  forwardedProto,
+  host = 'preview.example.test',
+}: {
+  encrypted?: boolean;
+  forwardedProto?: string;
+  host?: string;
+} = {}): IncomingMessage {
+  return {
+    headers: {
+      host,
+      ...(forwardedProto ? { 'x-forwarded-proto': forwardedProto } : {}),
+    },
+    socket: encrypted ? { encrypted: true } : {},
+  } as IncomingMessage;
+}
+
+describe(requestOrigin, () => {
+  test('uses the forwarded protocol when TLS terminates at a reverse proxy', () => {
+    expect(requestOrigin(incomingRequest({ forwardedProto: 'https' }))).toBe('https://preview.example.test');
+  });
+
+  test('uses the client-facing protocol from a proxy chain', () => {
+    expect(requestOrigin(incomingRequest({ forwardedProto: 'https, http' }))).toBe(
+      'https://preview.example.test'
+    );
+  });
+
+  test('falls back to the socket protocol for unsupported forwarded values', () => {
+    expect(requestOrigin(incomingRequest({ encrypted: true, forwardedProto: 'ftp' }))).toBe(
+      'https://preview.example.test'
+    );
+  });
+});

--- a/packages/expo-device-hub/src/server/cli/node-fetch-server.ts
+++ b/packages/expo-device-hub/src/server/cli/node-fetch-server.ts
@@ -4,7 +4,13 @@ import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
 /** `http(s)://host` origin of an incoming request, for absolutizing its URL. */
 export function requestOrigin(request: IncomingMessage): string {
-  const proto = 'encrypted' in request.socket && request.socket.encrypted ? 'https' : 'http';
+  const forwardedProto = request.headers['x-forwarded-proto'];
+  const clientProto = (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto)
+    ?.split(',', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  const socketProto = 'encrypted' in request.socket && request.socket.encrypted ? 'https' : 'http';
+  const proto = clientProto === 'http' || clientProto === 'https' ? clientProto : socketProto;
   return `${proto}://${request.headers.host ?? 'localhost'}`;
 }
 


### PR DESCRIPTION
## Summary

- honor `X-Forwarded-Proto` when the standalone CLI constructs request URLs
- retain the direct-socket fallback for missing or unsupported forwarded protocols
- add regression coverage for TLS termination and proxy chains
- add a patch changeset for `expo-device-hub`

## Context

When ngrok terminates TLS, the browser sends WebRTC signaling from an HTTPS origin while the local Node socket is HTTP. The standalone CLI previously reconstructed `/webrtc/offer` with an HTTP URL, causing the origin policy to return `403 forbidden_origin`. This was found while validating expo/eas-cli#4304.

## Verification

- `bun test` in `packages/expo-device-hub` — 171 passed
- `bunx turbo run build --filter=expo-device-hub` — 7 tasks passed
- focused strict TypeScript check for the changed source and test
- `bun changeset status` — `expo-device-hub` patch detected
- live ngrok check — WebRTC offer changed from 403 to 200 and the stream connected