### PR TITLE
Reconnect without reloading from the server overlay

### DIFF
--- a/packages/@expo/hub-components/src/__tests__/server-connection-overlay.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/server-connection-overlay.test.tsx
@@ -10,7 +10,7 @@ import { font } from '../theme/tokens';
 describe('ServerConnectionOverlay', () => {
   test('renders above shared portals with the typed font token', () => {
     const markup = renderToStaticMarkup(
-      <ServerConnectionOverlay status="disconnected" onReload={() => {}} />,
+      <ServerConnectionOverlay status="disconnected" onReconnect={() => {}} />,
     );
     const overlayTag = markup.slice(0, markup.indexOf('>') + 1);
 
@@ -21,6 +21,17 @@ describe('ServerConnectionOverlay', () => {
     expect(overlayTag).toContain('z-index:610');
     expect(overlayTag).toContain('pointer-events:auto');
     expect(overlayTag).toContain(`font-family:${font.sans}`);
+  });
+
+  test('offers an in-place reconnect without suggesting a page reload', () => {
+    for (const status of ['connecting', 'disconnected'] as const) {
+      const markup = renderToStaticMarkup(
+        <ServerConnectionOverlay status={status} onReconnect={() => {}} />,
+      );
+
+      expect(markup).toContain('Reconnect');
+      expect(markup.toLowerCase()).not.toContain('reload');
+    }
   });
 
   test('temporarily makes a portal inert without changing an existing blocker', () => {

--- a/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
+++ b/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
@@ -18,7 +18,7 @@ import {
 
 export type ServerConnectionOverlayProps = {
   status: 'connecting' | 'disconnected';
-  onReload: () => void;
+  onReconnect: () => void;
 };
 
 type InertableElement = Pick<HTMLElement, 'inert'>;
@@ -33,7 +33,7 @@ export function temporarilyInertElement(element: InertableElement): (() => void)
 }
 
 /** Full-page blocker shown until the dashboard can verify its dev server connection. */
-export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOverlayProps) {
+export function ServerConnectionOverlay({ status, onReconnect }: ServerConnectionOverlayProps) {
   const connecting = status === 'connecting';
   const overlayRef = useRef<HTMLElement>(null);
 
@@ -148,12 +148,12 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
               color: text.secondary,
             }}>
             {connecting ? (
-              'If this takes more than a few seconds, restart the Expo dev server in your terminal. Once it is running, reload this page.'
+              'If this takes more than a few seconds, restart the Expo dev server in your terminal. Expo Hub will reconnect automatically once it is available.'
             ) : (
               <>
                 Restart the server in your terminal.
                 <br />
-                Once started reload this page if necessary.
+                Once it is running, reconnect without losing this page.
               </>
             )}
           </p>
@@ -162,9 +162,9 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
           theme="primary"
           size="lg"
           leftSlot={<RefreshIcon size={18} />}
-          onClick={onReload}
+          onClick={onReconnect}
           style={{ marginTop: 24 }}>
-          Reload page
+          Reconnect
         </Button>
       </section>
     </main>

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -111,7 +111,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
   const scheme = useColorScheme();
   const hideBootDevice = dashboardHideBootDevice();
   const platform = dashboardPlatformFilter();
-  const { booted, recent, connectionStatus } = useDeviceLists();
+  const { booted, recent, connectionStatus, reconnect } = useDeviceLists();
   // Installed runtimes/system images and models for the new-device forms.
   const newDeviceOptions = useNewDeviceOptions();
   const hideUnsupportedDevices = useHideUnsupportedDevices();
@@ -471,7 +471,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         createPortal(
           <ServerConnectionOverlay
             status={connectionStatus}
-            onReload={() => window.location.reload()}
+            onReconnect={reconnect}
           />,
           document.body
         )}

--- a/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
@@ -144,7 +144,7 @@ describe('device-list WebSocket subscription', () => {
     const timers = manualTimers();
     const socket = new FakeSocket();
     const statuses: string[] = [];
-    const unsubscribe = subscribeToDeviceList({
+    const subscription = subscribeToDeviceList({
       url: 'ws://localhost/devices',
       createSocket: () => socket,
       schedule: timers.schedule,
@@ -160,14 +160,14 @@ describe('device-list WebSocket subscription', () => {
     socket.onclose?.();
 
     expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
-    unsubscribe();
+    subscription.unsubscribe();
   });
 
   test('times out when the server never sends a valid protocol message', () => {
     const timers = manualTimers();
     const socket = new FakeSocket();
     const statuses: string[] = [];
-    const unsubscribe = subscribeToDeviceList({
+    const subscription = subscribeToDeviceList({
       url: 'ws://localhost/devices',
       createSocket: () => socket,
       schedule: timers.schedule,
@@ -184,7 +184,7 @@ describe('device-list WebSocket subscription', () => {
 
     expect(socket.closed).toBe(true);
     expect(statuses).toEqual(['connecting', 'disconnected']);
-    unsubscribe();
+    subscription.unsubscribe();
   });
 
   test('requires valid messages, detects a missed heartbeat, and reconnects', () => {
@@ -192,7 +192,7 @@ describe('device-list WebSocket subscription', () => {
     const sockets: FakeSocket[] = [];
     const statuses: string[] = [];
     const snapshots: unknown[] = [];
-    const unsubscribe = subscribeToDeviceList({
+    const subscription = subscribeToDeviceList({
       url: 'ws://localhost/devices',
       createSocket: () => {
         const socket = new FakeSocket();
@@ -225,15 +225,55 @@ describe('device-list WebSocket subscription', () => {
     expect(statuses).toEqual(['connecting', 'connected', 'disconnected', 'connected']);
     expect(snapshots).toEqual([list]);
 
-    unsubscribe();
+    subscription.unsubscribe();
     expect(sockets[1].closed).toBe(true);
+  });
+
+  test('reconnects immediately on demand without waiting for backoff', () => {
+    const timers = manualTimers();
+    const sockets: FakeSocket[] = [];
+    const statuses: string[] = [];
+    const subscription = subscribeToDeviceList({
+      url: 'ws://localhost/devices',
+      createSocket: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      schedule: timers.schedule,
+      cancelSchedule: timers.cancelSchedule,
+      reconnectMinMs: 5,
+      reconnectMaxMs: 20,
+      heartbeatTimeoutMs: 60,
+      onSnapshot: () => {},
+      onStatus: (status) => statuses.push(status),
+    });
+
+    sockets[0].message(JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE }));
+    sockets[0].onclose?.();
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
+
+    subscription.reconnect();
+
+    expect(sockets).toHaveLength(2);
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected', 'connecting']);
+    sockets[1].message(JSON.stringify({ type: HEARTBEAT_MESSAGE_TYPE }));
+    expect(statuses).toEqual([
+      'connecting',
+      'connected',
+      'disconnected',
+      'connecting',
+      'connected',
+    ]);
+
+    subscription.unsubscribe();
   });
 
   test('marks connection failures as disconnected and retries with backoff', () => {
     const timers = manualTimers();
     let attempts = 0;
     const statuses: string[] = [];
-    const unsubscribe = subscribeToDeviceList({
+    const subscription = subscribeToDeviceList({
       url: 'ws://localhost/devices',
       createSocket: () => {
         attempts++;
@@ -255,6 +295,6 @@ describe('device-list WebSocket subscription', () => {
     expect(attempts).toBe(3);
     expect(statuses).toEqual(['connecting', 'disconnected']);
 
-    unsubscribe();
+    subscription.unsubscribe();
   });
 });

--- a/packages/expo-device-hub/src/dashboard/useDevices.ts
+++ b/packages/expo-device-hub/src/dashboard/useDevices.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type Device } from '@expo/hub-components';
 
@@ -57,6 +57,12 @@ type DeviceListSubscriptionOptions = {
   onStatus: (status: DeviceListConnectionStatus) => void;
 };
 
+export type DeviceListSubscription = {
+  /** Replace the current socket with a fresh connection attempt immediately. */
+  reconnect: () => void;
+  unsubscribe: () => void;
+};
+
 /**
  * Owns the device-list socket lifecycle independently from React so reconnect
  * and heartbeat-timeout behavior can be tested with fake sockets and clocks.
@@ -71,7 +77,7 @@ export function subscribeToDeviceList({
   heartbeatTimeoutMs = HEARTBEAT_TIMEOUT_MS,
   onSnapshot,
   onStatus,
-}: DeviceListSubscriptionOptions): () => void {
+}: DeviceListSubscriptionOptions): DeviceListSubscription {
   let cancelled = false;
   let socket: DeviceListSocket | null = null;
   let reconnectTimer: ConnectionTimer | null = null;
@@ -153,7 +159,24 @@ export function subscribeToDeviceList({
   onStatus(status);
   connect();
 
-  return () => {
+  const reconnect = () => {
+    if (cancelled) return;
+    if (reconnectTimer !== null) {
+      cancelSchedule(reconnectTimer);
+      reconnectTimer = null;
+    }
+    clearWatchdog();
+    const activeSocket = socket;
+    socket = null;
+    try {
+      activeSocket?.close();
+    } catch {}
+    reconnectDelay = reconnectMinMs;
+    updateStatus('connecting');
+    connect();
+  };
+
+  const unsubscribe = () => {
     cancelled = true;
     if (reconnectTimer !== null) cancelSchedule(reconnectTimer);
     clearWatchdog();
@@ -163,6 +186,8 @@ export function subscribeToDeviceList({
       activeSocket?.close();
     } catch {}
   };
+
+  return { reconnect, unsubscribe };
 }
 
 /**
@@ -173,15 +198,17 @@ export function subscribeToDeviceList({
 function useDeviceList(): {
   devices: DeviceList;
   connectionStatus: DeviceListConnectionStatus;
+  reconnect: () => void;
 } {
   const [devices, setDevices] = useState<DeviceList>(EMPTY);
   const [connectionStatus, setConnectionStatus] =
     useState<DeviceListConnectionStatus>('connecting');
+  const subscriptionRef = useRef<DeviceListSubscription | null>(null);
 
   useEffect(() => {
     let activeErrorIds = new Set<string>();
 
-    return subscribeToDeviceList({
+    const subscription = subscribeToDeviceList({
       onSnapshot: (snapshot) => {
         activeErrorIds = logUtilityErrors(snapshot.errors, activeErrorIds);
         const { errors: _errors, ...nextDevices } = snapshot;
@@ -189,9 +216,17 @@ function useDeviceList(): {
       },
       onStatus: setConnectionStatus,
     });
+    subscriptionRef.current = subscription;
+
+    return () => {
+      if (subscriptionRef.current === subscription) subscriptionRef.current = null;
+      subscription.unsubscribe();
+    };
   }, []);
 
-  return { devices, connectionStatus };
+  const reconnect = useCallback(() => subscriptionRef.current?.reconnect(), []);
+
+  return { devices, connectionStatus, reconnect };
 }
 
 export function parseDeviceListSocketMessage(data: unknown): DeviceListSocketMessage | null {
@@ -247,8 +282,9 @@ export function useDeviceLists(): {
   booted: DeviceList;
   recent: DeviceList;
   connectionStatus: DeviceListConnectionStatus;
+  reconnect: () => void;
 } {
-  const { devices, connectionStatus } = useDeviceList();
+  const { devices, connectionStatus, reconnect } = useDeviceList();
   const lists = useMemo(() => splitDeviceList(devices), [devices]);
-  return { ...lists, connectionStatus };
+  return { ...lists, connectionStatus, reconnect };
 }


### PR DESCRIPTION
## Summary

- replace the page reload copy and action with an in-place Reconnect action
- expose a manual device-list reconnect that cancels pending backoff, closes any stale socket, resets the retry delay, and opens a fresh connection immediately
- preserve the existing automatic reconnect behavior and dashboard page state
- cover both overlay wording and immediate manual reconnect behavior with tests

## Testing

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

## Follow-up considerations

- **Degrade by capability instead of blocking the whole dashboard.** A lost device-list socket does not necessarily mean the active stream, controls, logs, or cached device snapshot are unusable. We could retain the last snapshot and active stream, disable only server-backed mutations, and show a less intrusive stale-connection banner.
- **Coordinate every server-backed channel.** The device list is only one connection. Stream/control WebSockets, WebRTC signaling and ICE, logs and event streams, and the agent-interaction socket should be audited so a server restart can re-establish the whole connection graph through one recovery signal.
- **Retry on useful browser signals.** In addition to backoff, retry immediately on `online`, window focus, or visibility restoration. Add jitter to automatic backoff and consider showing the next automatic attempt so repeated manual clicks are unnecessary.
- **Classify failures before choosing recovery.** A small health and protocol-version handshake could distinguish a stopped server, a proxy that blocks WebSockets, an incompatible restarted server, and an unhealthy device backend. Most cases should reconnect in place; a true client/server version mismatch needs a separate update path rather than making reload the default advice.
- **Protect state across longer outages.** Confirm which transient session data is worth retaining, make retried mutations idempotent, and add telemetry for disconnect reason, recovery time, and which channel failed so future work targets the actual failure modes.