### PR TITLE
Remove black background from live device streams

### DIFF
--- a/packages/@expo/hub-client/src/DeviceScreen.tsx
+++ b/packages/@expo/hub-client/src/DeviceScreen.tsx
@@ -30,7 +30,6 @@ export const DEVICE_SCREEN_SURFACE_LAYOUT_STYLE: CSSProperties = {
   inset: 0,
   containerType: 'size',
   overflow: 'hidden',
-  backgroundColor: '#000',
 };
 
 export const DEVICE_SCREEN_STATUS_LAYOUT_STYLE: CSSProperties = {
@@ -47,6 +46,15 @@ export const DEVICE_SCREEN_STATUS_LAYOUT_STYLE: CSSProperties = {
   fontSize: 13,
   fontFamily: 'var(--expo-font-mono)',
 };
+
+export function deviceScreenSurfaceStyle(
+  status: DeviceScreenProps['client']['status']
+): CSSProperties {
+  return {
+    ...DEVICE_SCREEN_SURFACE_LAYOUT_STYLE,
+    ...(status === 'streaming' ? {} : { backgroundColor: '#000' }),
+  };
+}
 
 /** Keep media geometry tied to the same synchronous size container as the frame. */
 export function deviceScreenMediaStyle(rotation: number): CSSProperties {
@@ -319,7 +327,7 @@ export function DeviceScreen({
   const rotation = geometry.rotationDegrees;
 
   const surfaceStyle: CSSProperties = {
-    ...DEVICE_SCREEN_SURFACE_LAYOUT_STYLE,
+    ...deviceScreenSurfaceStyle(status),
     borderRadius,
     ...(squircle ? ({ cornerShape: 'superellipse(1.3)' } as Record<string, unknown>) : {}),
   };

--- a/packages/@expo/hub-client/src/__tests__/device-screen-layout.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/device-screen-layout.test.tsx
@@ -3,6 +3,7 @@ import {
   DEVICE_SCREEN_STATUS_LAYOUT_STYLE,
   DEVICE_SCREEN_SURFACE_LAYOUT_STYLE,
   deviceScreenMediaStyle,
+  deviceScreenSurfaceStyle,
 } from '../DeviceScreen';
 
 describe('DeviceScreen layout', () => {
@@ -24,5 +25,10 @@ describe('DeviceScreen layout', () => {
     expect(DEVICE_SCREEN_STATUS_LAYOUT_STYLE.position).toBe('absolute');
     expect(DEVICE_SCREEN_STATUS_LAYOUT_STYLE.inset).toBe(0);
     expect(DEVICE_SCREEN_STATUS_LAYOUT_STYLE.boxSizing).toBe('border-box');
+  });
+
+  test('leaves only the live stream surface background transparent', () => {
+    expect(deviceScreenSurfaceStyle('streaming').backgroundColor).toBeUndefined();
+    expect(deviceScreenSurfaceStyle('connecting').backgroundColor).toBe('#000');
   });
 });


### PR DESCRIPTION
## Summary

- omit the device screen background while the stream is active
- retain the black fallback for connecting, idle, and error states
- add regression coverage for both streaming and connecting styles

## Cause

The live DeviceScreen surface always set a black background. Fractional clipping around framed streams could expose that surface as a thin black seam.

## Verification

- bun run --cwd packages/@expo/hub-client test
- bun run --cwd packages/@expo/hub-client typecheck
- bun run --cwd packages/@expo/hub-client lint
- bun run build