### PR TITLE
Improve agent interaction cursor UI

### DIFF
--- a/packages/@expo/hub-client/package.json
+++ b/packages/@expo/hub-client/package.json
@@ -37,14 +37,17 @@
     "format:check": "oxfmt --check"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.43",
     "@types/bun": "latest",
     "@types/react": "~19.2.2",
+    "@types/react-dom": "~19.2.0",
     "oxfmt": "^0.56.0",
+    "react-dom": "catalog:",
     "oxlint": "^1.71.0",
     "typescript": "~6.0.3"
   },

--- a/packages/@expo/hub-client/src/AgentInteractionIndicator.tsx
+++ b/packages/@expo/hub-client/src/AgentInteractionIndicator.tsx
@@ -7,6 +7,13 @@ import {
   agentInteractionPointsWithTravelAt,
   agentInteractionTravelMs,
 } from './agent-interaction-animation';
+import {
+  DEVICE_POINTER_LABEL_OFFSET_X,
+  DEVICE_POINTER_LABEL_OFFSET_Y,
+  DEVICE_POINTER_LABEL_STYLE,
+  DEVICE_POINTER_STYLE,
+  devicePointerLabelRadius,
+} from './device-pointer-presentation';
 import { AGENT_TOUCH_INDICATOR_STYLE } from './TouchIndicator';
 import { type AgentInteraction, type AgentInteractionPoint } from './types';
 
@@ -90,7 +97,7 @@ export function AgentInteractionIndicator({
       paint(
         reduceMotion
           ? agentInteractionPointsAt(activeInteraction, elapsedMs)
-          : agentInteractionPointsWithTravelAt(activeInteraction, previousPoints, elapsedMs)
+          : agentInteractionPointsWithTravelAt(activeInteraction, previousPoints, elapsedMs),
       );
       if (!reduceMotion && elapsedMs < endMs) scheduleUpdate();
     }
@@ -107,7 +114,7 @@ export function AgentInteractionIndicator({
     <div
       aria-hidden="true"
       data-testid="agent-interaction-indicator"
-      style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none' }}
+      style={{ position: 'absolute', inset: 0, overflow: 'visible', pointerEvents: 'none' }}
     >
       {[0, 1].map((index) => (
         <div
@@ -116,17 +123,37 @@ export function AgentInteractionIndicator({
             layerRefs.current[index] = element;
           }}
           hidden
-          style={{ position: 'absolute', inset: 0, willChange: 'transform' }}
+          style={{ position: 'absolute', inset: 0, zIndex: 2 - index, willChange: 'transform' }}
         >
           <div
-            data-agent-touch={index}
+            data-agent-cursor={index}
             style={{
-              ...AGENT_TOUCH_INDICATOR_STYLE,
-              left: 0,
-              top: 0,
-              transform: 'translate(-50%, -50%)',
+              ...DEVICE_POINTER_STYLE,
             }}
-          />
+          >
+            <span data-agent-touch={index} style={AGENT_TOUCH_INDICATOR_STYLE} />
+            {index === 0 && (
+              <span
+                data-agent-cursor-label
+                style={{
+                  ...DEVICE_POINTER_LABEL_STYLE,
+                  position: 'absolute',
+                  left: DEVICE_POINTER_LABEL_OFFSET_X,
+                  top: DEVICE_POINTER_LABEL_OFFSET_Y,
+                  minWidth: 58,
+                  borderRadius: devicePointerLabelRadius({
+                    horizontal: 'right',
+                    vertical: 'below',
+                  }),
+                  backgroundColor: 'var(--expo-theme-agent-accent)',
+                  color: 'var(--expo-theme-agent-on-accent)',
+                  fontWeight: 500,
+                }}
+              >
+                agent
+              </span>
+            )}
+          </div>
         </div>
       ))}
     </div>

--- a/packages/@expo/hub-client/src/DeviceScreen.tsx
+++ b/packages/@expo/hub-client/src/DeviceScreen.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 
 import { streamGeometry } from './orientation';
 import { AgentInteractionIndicator } from './AgentInteractionIndicator';
@@ -107,6 +108,7 @@ export function DeviceScreen({
   borderRadius,
   squircle,
   agentInteraction,
+  agentInteractionPortalTarget,
 }: DeviceScreenProps) {
   const { videoKind, attachVideo, sendTouch, sendMultiTouch, sendKey, screen, status, error } =
     client;
@@ -378,7 +380,14 @@ export function DeviceScreen({
         </>
       )}
 
-      <AgentInteractionIndicator interaction={agentInteraction} />
+      {agentInteractionPortalTarget === undefined ? (
+        <AgentInteractionIndicator interaction={agentInteraction} />
+      ) : agentInteractionPortalTarget ? (
+        createPortal(
+          <AgentInteractionIndicator interaction={agentInteraction} />,
+          agentInteractionPortalTarget
+        )
+      ) : null}
 
       {status !== 'streaming' && (
         <div

--- a/packages/@expo/hub-client/src/TouchIndicator.tsx
+++ b/packages/@expo/hub-client/src/TouchIndicator.tsx
@@ -6,7 +6,7 @@ export const TOUCH_INDICATOR_STYLE: CSSProperties = {
   position: 'absolute',
   width: 20,
   height: 20,
-  borderRadius: '50%',
+  borderRadius: 'var(--expo-radius-full)',
   background: 'rgba(255, 255, 255, 0.45)',
   border: '1.25px solid rgba(0, 0, 0, 0.55)',
   boxShadow: '0 1px 3px rgba(0, 0, 0, 0.45)',
@@ -15,8 +15,13 @@ export const TOUCH_INDICATOR_STYLE: CSSProperties = {
 };
 
 export const AGENT_TOUCH_INDICATOR_STYLE: CSSProperties = {
-  ...TOUCH_INDICATOR_STYLE,
-  border: '2px solid var(--expo-theme-border-info)',
+  position: 'absolute',
+  inset: 0,
+  borderRadius: 'var(--expo-radius-full)',
+  background: 'var(--expo-theme-agent-surface)',
+  border: '1px solid var(--expo-theme-agent-border)',
+  pointerEvents: 'none',
+  boxSizing: 'border-box',
 };
 
 export function TouchIndicator({ point }: { point: AgentInteractionPoint }) {

--- a/packages/@expo/hub-client/src/__tests__/agent-interaction-indicator.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/agent-interaction-indicator.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { AgentInteractionIndicator } from '../AgentInteractionIndicator';
+import {
+  DEVICE_POINTER_LABEL_STYLE,
+  devicePointerLabelRadius,
+} from '../device-pointer-presentation';
+
+describe('AgentInteractionIndicator', () => {
+  test('renders the reference pink cursor treatment with one agent name tag', () => {
+    const markup = renderToStaticMarkup(<AgentInteractionIndicator />);
+
+    expect(markup.match(/data-agent-cursor=/g)).toHaveLength(2);
+    expect(markup.match(/data-agent-cursor-label/g)).toHaveLength(1);
+    expect(markup).toContain('background:var(--expo-theme-agent-surface)');
+    expect(markup).toContain('border:1px solid var(--expo-theme-agent-border)');
+    expect(markup).toContain('background-color:var(--expo-theme-agent-accent)');
+    expect(markup).toContain('color:var(--expo-theme-agent-on-accent)');
+    expect(markup).toContain('font-size:var(--expo-text-size-xs-font-size)');
+    expect(markup).toContain('border-radius:var(--expo-radius-sm) var(--expo-radius-xl)');
+    expect(markup).toContain('overflow:visible');
+    expect(markup).not.toContain('overflow:hidden');
+    expect(markup).toContain('>agent</span>');
+    expect(markup).not.toContain('var(--expo-theme-border-info)');
+  });
+
+  test('shares token-backed label typography and mirrors the attached corner', () => {
+    expect(DEVICE_POINTER_LABEL_STYLE.fontSize).toBe('var(--expo-text-size-xs-font-size)');
+    expect(devicePointerLabelRadius({ horizontal: 'right', vertical: 'below' })).toStartWith(
+      'var(--expo-radius-sm)',
+    );
+    expect(devicePointerLabelRadius({ horizontal: 'left', vertical: 'below' })).toBe(
+      'var(--expo-radius-xl) var(--expo-radius-sm) var(--expo-radius-xl) var(--expo-radius-xl)',
+    );
+    expect(devicePointerLabelRadius({ horizontal: 'left', vertical: 'above' })).toBe(
+      'var(--expo-radius-xl) var(--expo-radius-xl) var(--expo-radius-sm) var(--expo-radius-xl)',
+    );
+    expect(devicePointerLabelRadius({ horizontal: 'right', vertical: 'above' })).toEndWith(
+      'var(--expo-radius-sm)',
+    );
+  });
+});

--- a/packages/@expo/hub-client/src/device-pointer-presentation.ts
+++ b/packages/@expo/hub-client/src/device-pointer-presentation.ts
@@ -1,0 +1,55 @@
+import { type CSSProperties } from 'react';
+
+export type DevicePointerLabelPlacement = {
+  horizontal: 'left' | 'right';
+  vertical: 'above' | 'below';
+};
+
+export const DEVICE_POINTER_SIZE = 31;
+export const DEVICE_POINTER_LABEL_OFFSET_X = DEVICE_POINTER_SIZE;
+export const DEVICE_POINTER_LABEL_OFFSET_Y = 23;
+
+/** Shared pointer geometry used by both the agent and viewer cursors. */
+export const DEVICE_POINTER_STYLE: CSSProperties = {
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  width: DEVICE_POINTER_SIZE,
+  height: DEVICE_POINTER_SIZE,
+  transform: 'translate(-50%, -50%)',
+};
+
+/**
+ * Shared attached-label treatment. The typography variables mirror
+ * `@expo/hub-components`' `textSize.xs` token without creating a package cycle.
+ */
+export const DEVICE_POINTER_LABEL_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: 29,
+  padding: '0 12px',
+  boxSizing: 'border-box',
+  fontFamily: 'var(--expo-font-sans)',
+  fontSize: 'var(--expo-text-size-xs-font-size)',
+  fontWeight: 'var(--expo-text-size-xs-font-weight)',
+  lineHeight: 'var(--expo-text-size-xs-line-height)',
+  letterSpacing: 'var(--expo-text-size-xs-letter-spacing)',
+  whiteSpace: 'nowrap',
+};
+
+/** Keep the small attached corner facing the pointer in every placement. */
+export function devicePointerLabelRadius({
+  horizontal,
+  vertical,
+}: DevicePointerLabelPlacement): string {
+  const outer = 'var(--expo-radius-xl)';
+  const attached = 'var(--expo-radius-sm)';
+  const corners = [outer, outer, outer, outer];
+
+  if (horizontal === 'right' && vertical === 'below') corners[0] = attached;
+  if (horizontal === 'left' && vertical === 'below') corners[1] = attached;
+  if (horizontal === 'left' && vertical === 'above') corners[2] = attached;
+  if (horizontal === 'right' && vertical === 'above') corners[3] = attached;
+
+  return corners.join(' ');
+}

--- a/packages/@expo/hub-client/src/index.ts
+++ b/packages/@expo/hub-client/src/index.ts
@@ -18,7 +18,17 @@ export {
   agentInteractionEndMs,
   agentInteractionPointsAt,
 } from './agent-interaction-animation';
+export {
+  DEVICE_POINTER_LABEL_OFFSET_X,
+  DEVICE_POINTER_LABEL_OFFSET_Y,
+  DEVICE_POINTER_LABEL_STYLE,
+  DEVICE_POINTER_SIZE,
+  DEVICE_POINTER_STYLE,
+  devicePointerLabelRadius,
+  type DevicePointerLabelPlacement,
+} from './device-pointer-presentation';
 export { displayScreen, streamGeometry } from './orientation';
 export { useIosDeviceClient } from './useIosDevice';
 export { useAndroidDeviceClient } from './useAndroidDevice';
+export { useActiveAgentInteraction } from './useActiveAgentInteraction';
 export { useActiveDeviceClient, type ActiveDeviceTarget } from './useActiveDeviceClient';

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -422,6 +422,8 @@ export interface DeviceScreenProps {
   client: DeviceClient;
   /** Last active Argent gesture for the streamed device; removed after its idle timeout. */
   agentInteraction?: AgentInteraction | null;
+  /** Optional unclipped host for the agent cursor, aligned to the rendered stream. */
+  agentInteractionPortalTarget?: HTMLElement | null;
   /** Corner radius for the video surface (matches the PhoneFrame placeholder). */
   borderRadius?: CSSProperties['borderRadius'];
   /** Apply the iOS `corner-shape: squircle`. */

--- a/packages/@expo/hub-client/src/useActiveAgentInteraction.ts
+++ b/packages/@expo/hub-client/src/useActiveAgentInteraction.ts
@@ -1,0 +1,34 @@
+import { useEffect, useReducer, useRef } from 'react';
+
+import { agentInteractionCursorExpiresAt } from './agent-interaction-animation';
+import { type AgentInteraction } from './types';
+
+/**
+ * Return the current interaction only while its cursor is active, and schedule
+ * the expiry render so every consumer shares the indicator's timeout boundary.
+ */
+export function useActiveAgentInteraction(
+  interaction?: AgentInteraction | null,
+): AgentInteraction | null {
+  const fallback = useRef({ interaction, startedAt: Date.now() });
+  const [, renderAtExpiry] = useReducer((value: number) => value + 1, 0);
+
+  if (fallback.current.interaction !== interaction) {
+    fallback.current = { interaction, startedAt: Date.now() };
+  }
+
+  const expiresAt = interaction
+    ? agentInteractionCursorExpiresAt(interaction, fallback.current.startedAt)
+    : null;
+  const active = interaction && expiresAt !== null && expiresAt > Date.now() ? interaction : null;
+
+  useEffect(() => {
+    if (expiresAt === null) return;
+    const delay = expiresAt - Date.now();
+    if (delay <= 0) return;
+    const timer = window.setTimeout(renderAtExpiry, delay + 1);
+    return () => window.clearTimeout(timer);
+  }, [expiresAt]);
+
+  return active;
+}

--- a/packages/@expo/hub-components/package.json
+++ b/packages/@expo/hub-components/package.json
@@ -40,6 +40,7 @@
     "format:check": "oxfmt --check"
   },
   "dependencies": {
+    "@expo/hub-client": "workspace:*",
     "@expo/styleguide": "^14.1.5",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -51,7 +52,6 @@
     "react-dom": "*"
   },
   "devDependencies": {
-    "@expo/hub-client": "workspace:*",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.43",
     "@types/react": "~19.2.2",

--- a/packages/@expo/hub-components/src/__tests__/agent-device-status.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/agent-device-status.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { type DeviceClient } from '@expo/hub-client';
+import { devicePointerLabelRadius } from '@expo/hub-client';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { DeviceListItem } from '../components/DeviceListItem';
 import { shouldCompactAgentDeviceStatus } from '../components/useCompactAgentDeviceStatus';
-import { AgentDeviceOverlay } from '../dashboard/AgentDeviceOverlay';
+import { AgentDeviceOverlay, agentDeviceOverlayPlacement } from '../dashboard/AgentDeviceOverlay';
 import { type Device } from '../dashboard/data';
 import { type DeviceFrameAssets } from '../dashboard/deviceFrame';
 import { PhoneFrame } from '../dashboard/PhoneFrame';
@@ -55,14 +56,16 @@ const LANDSCAPE_CLIENT = {
 } as DeviceClient;
 
 describe('agent device status', () => {
-  test('labels active device rows and renders the blue status badge', () => {
+  test('labels active device rows and renders the pink status badge', () => {
     const markup = renderToStaticMarkup(
-      <DeviceListItem name="iPhone 16 Pro" version="iOS 18.6" usedByAgent />
+      <DeviceListItem name="iPhone 16 Pro" version="iOS 18.6" usedByAgent />,
     );
 
     expect(markup).toContain('aria-label="iPhone 16 Pro, iOS 18.6, used by agent"');
     expect(markup).toContain('data-agent-device-status="active"');
     expect(markup).toContain('data-agent-device-badge="true"');
+    expect(markup).toContain('color:var(--expo-theme-agent-text)');
+    expect(markup).toContain('background-color:var(--expo-theme-agent-accent)');
     expect(markup).toContain('Used by agent');
   });
 
@@ -76,7 +79,7 @@ describe('agent device status', () => {
 
   test('keeps long device rows contained and compacts agent status when needed', () => {
     const markup = renderToStaticMarkup(
-      <DeviceListItem name="Medium_Phone_API_36.1" version="Android 16.0" usedByAgent />
+      <DeviceListItem name="Medium_Phone_API_36.1" version="Android 16.0" usedByAgent />,
     );
     const buttonTag = markup.slice(0, markup.indexOf('>') + 1);
 
@@ -91,7 +94,7 @@ describe('agent device status', () => {
         version: 82,
         badge: 7,
         label: 66,
-      })
+      }),
     ).toBeTrue();
     expect(
       shouldCompactAgentDeviceStatus({
@@ -100,67 +103,147 @@ describe('agent device status', () => {
         version: 58,
         badge: 7,
         label: 66,
-      })
+      }),
     ).toBeFalse();
   });
 
-  test('only reveals the phone overlay while hover state is active', () => {
-    const hidden = renderToStaticMarkup(
-      <AgentDeviceOverlay visible={false} onTakeOver={() => {}} />
+  test('renders a non-blocking user pointer label and neutral interruption warning', () => {
+    const hidden = renderToStaticMarkup(<AgentDeviceOverlay visible={false} />);
+    const visible = renderToStaticMarkup(<AgentDeviceOverlay visible />);
+    const afterUserInteraction = renderToStaticMarkup(
+      <AgentDeviceOverlay visible warningVisible={false} />,
     );
-    const visible = renderToStaticMarkup(<AgentDeviceOverlay visible onTakeOver={() => {}} />);
     const visibleOverlayTag = visible.slice(0, visible.indexOf('>') + 1);
+    const warningStart = visible.indexOf('data-testid="agent-interruption-warning"');
+    const warningTag = visible.slice(warningStart, visible.indexOf('>', warningStart) + 1);
 
     expect(hidden).toContain('hidden=""');
     expect(hidden).toContain('display:none');
     expect(visible).not.toContain('hidden=""');
-    expect(visible).toContain('display:flex');
+    expect(visible).toContain('display:block');
     expect(visibleOverlayTag).not.toContain('border-radius');
-    expect(visible).toContain('color:rgba(218, 233, 255, 0.74)');
+    expect(visibleOverlayTag).toContain('pointer-events:none');
+    expect(visibleOverlayTag).toContain('overflow:visible');
     expect(visibleOverlayTag).not.toContain('backdrop-filter');
-    expect(visibleOverlayTag).toContain('background-color:rgba(0, 0, 0, 0.55)');
-    expect(visible).toContain('Agent is using this device');
-    expect(visible).toContain('color:rgba(255, 255, 255, 0.7)');
-    expect(visible).toContain('Taking over might collide with what the agent is doing.');
-    expect(visible).toContain('Take over anyway');
-    expect(visible).toContain('background-color:var(--expo-theme-button-agent-overlay-background)');
-    expect(visible).toContain('font-family:inherit');
+    expect(visibleOverlayTag).not.toContain('background-color');
+    expect(visible).not.toContain('role="dialog"');
+    expect(visible).toContain('data-testid="user-pointer-cursor"');
+    expect(visible).toContain('data-testid="user-pointer-label"');
+    expect(visible).toContain('width:31px;height:31px;transform:translate(-50%, -50%)');
+    expect(visible).toContain('left:31px;top:23px');
     expect(visible).toContain(
-      '<span style="font-size:12px;font-weight:500;line-height:1.6;letter-spacing:0">Take over anyway</span>'
+      'border-radius:var(--expo-radius-sm) var(--expo-radius-xl) var(--expo-radius-xl) var(--expo-radius-xl)',
+    );
+    expect(visible).toContain('border:1px solid var(--expo-theme-border-secondary)');
+    expect(visible).toContain('>you</span>');
+    expect(visible).toContain('role="note"');
+    expect(visible).toContain('background-color:var(--expo-theme-background-overlay)');
+    expect(warningTag).toContain('width:max-content');
+    expect(warningTag).toContain('max-width:calc(100vw - 32px)');
+    expect(warningTag).toContain('padding:6px 8px');
+    expect(warningTag).toContain('font-size:10px');
+    expect(warningTag).not.toContain('border:');
+    expect(visible).toContain('Interacting could interrupt');
+    expect(visible).toContain('the agent&#x27;s current work.');
+    expect(afterUserInteraction).toContain('data-testid="user-pointer-cursor"');
+    expect(afterUserInteraction).toContain('data-testid="user-pointer-label"');
+    expect(afterUserInteraction).toContain('>you</span>');
+    expect(afterUserInteraction).not.toContain('data-testid="agent-interruption-warning"');
+    expect(visible).not.toContain('Take over anyway');
+  });
+
+  test('places pointer notices on whichever side has browser viewport space', () => {
+    expect(
+      agentDeviceOverlayPlacement({
+        clientX: 100,
+        clientY: 100,
+        viewportWidth: 1200,
+        viewportHeight: 900,
+      }),
+    ).toEqual({ horizontal: 'right', vertical: 'below' });
+    expect(
+      agentDeviceOverlayPlacement({
+        clientX: 1100,
+        clientY: 840,
+        viewportWidth: 1200,
+        viewportHeight: 900,
+      }),
+    ).toEqual({ horizontal: 'left', vertical: 'above' });
+    expect(devicePointerLabelRadius({ horizontal: 'left', vertical: 'below' })).toBe(
+      'var(--expo-radius-xl) var(--expo-radius-sm) var(--expo-radius-xl) var(--expo-radius-xl)',
     );
   });
 
-  test('keeps the agent takeover button borderless in light mode', () => {
+  test('leaves the normal device cursor visible when no agent is interacting', () => {
+    const markup = renderToStaticMarkup(
+      <PhoneFrame
+        device={{ ...IPHONE, deviceFrame: null }}
+        client={STREAMING_CLIENT}
+        DeviceScreen={() => <div role="application" style={{ cursor: 'crosshair' }} />}
+        displayScreen={() => null}
+      />,
+    );
+    const frameStart = markup.indexOf('data-testid="device-screen-frame"');
+    const frameTag = markup.slice(frameStart, markup.indexOf('>', frameStart) + 1);
+    const overlayStart = markup.indexOf('data-testid="agent-device-overlay"');
+    const overlayTagStart = markup.lastIndexOf('<div', overlayStart);
+    const overlayTag = markup.slice(overlayTagStart, markup.indexOf('>', overlayStart) + 1);
+
+    expect(frameTag).toContain('data-agent-active="false"');
+    expect(frameTag).not.toContain('cursor:none');
+    expect(markup).toContain('role="application" style="cursor:crosshair"');
+    expect(overlayTag).toContain('hidden=""');
+    expect(overlayTag).toContain('display:none');
+  });
+
+  test('defines a dedicated pink semantic palette for agent-owned UI', () => {
     const themeCss = readFileSync(new URL('../theme/theme.css', import.meta.url), 'utf8');
     const lightTheme = themeCss.slice(themeCss.indexOf(':root {'), themeCss.indexOf('.dark-theme'));
 
-    expect(lightTheme).toContain('--expo-theme-button-agent-overlay-border: transparent;');
-    expect(lightTheme).toContain('--expo-theme-button-agent-overlay-disabled-border: transparent;');
+    expect(lightTheme).toContain('--expo-theme-agent-accent: var(--pink-9);');
+    expect(lightTheme).toContain(
+      '--expo-theme-agent-surface: color-mix(in srgb, var(--pink-9) 30%, transparent);',
+    );
+    expect(lightTheme).toContain('--expo-theme-agent-border: var(--pink-7);');
+    expect(lightTheme).not.toMatch(/--expo-theme-agent-[^:]+:\s*(?:#|rgba?\()/);
   });
 
-  test('clips the stream and unshaped overlay with one shared iOS screen shape', () => {
+  test('clips the stream while keeping the pointer notice free to use nearby space', () => {
     const markup = renderToStaticMarkup(
       <PhoneFrame
         device={{ ...IPHONE, deviceFrame: null }}
         DeviceScreen={() => null}
         displayScreen={() => null}
-      />
+      />,
     );
     const screenClipStart = markup.indexOf('data-testid="device-screen-clip"');
     const screenClipTag = markup.slice(screenClipStart, markup.indexOf('>', screenClipStart) + 1);
     const frameStart = markup.indexOf('data-testid="device-screen-frame"');
     const frameTag = markup.slice(frameStart, markup.indexOf('>', frameStart) + 1);
-    const overlayStart = markup.indexOf('data-testid="agent-device-overlay-clip"');
+    const overlayStart = markup.indexOf('data-testid="agent-device-overlay"');
     const overlayTag = markup.slice(overlayStart, markup.indexOf('>', overlayStart) + 1);
+    const agentOverlayStart = markup.indexOf('data-testid="agent-interaction-overlay"');
+    const agentOverlayTag = markup.slice(
+      agentOverlayStart,
+      markup.indexOf('>', agentOverlayStart) + 1,
+    );
 
     expect(screenClipTag).not.toContain('overflow:hidden');
     expect(screenClipTag).not.toContain('border-radius');
     expect(screenClipTag).not.toContain('corner-shape');
     expect(screenClipTag).toContain('clip-path:shape(');
     expect(frameTag).not.toContain('box-shadow');
-    expect(overlayTag).not.toContain('overflow:hidden');
+    expect(markup).not.toContain('data-testid="agent-device-overlay-clip"');
+    expect(overlayTag).toContain('overflow:visible');
+    expect(overlayTag).toContain('pointer-events:none');
     expect(overlayTag).not.toContain('border-radius');
     expect(overlayTag).not.toContain('corner-shape');
+    expect(agentOverlayTag).toContain('overflow:visible');
+    expect(agentOverlayTag).toContain('pointer-events:none');
+    expect(agentOverlayTag).not.toContain('overflow:hidden');
+    expect(agentOverlayTag).not.toContain('clip-path');
+    expect(agentOverlayTag).not.toContain('border-radius');
+    expect(agentOverlayStart).toBeGreaterThan(screenClipStart);
   });
 
   test('clips the stream to the calibrated opening below iPhone artwork', () => {
@@ -170,7 +253,7 @@ describe('agent device status', () => {
         deviceFrameAssets={FRAME_ASSETS}
         DeviceScreen={() => null}
         displayScreen={() => null}
-      />
+      />,
     );
     const screenStart = markup.indexOf('data-testid="device-screen-clip"');
     const screenTag = markup.slice(screenStart, markup.indexOf('>', screenStart) + 1);
@@ -180,6 +263,16 @@ describe('agent device status', () => {
     const streamTag = markup.slice(streamStart, markup.indexOf('>', streamStart) + 1);
     const artworkStart = markup.indexOf('data-testid="device-frame-artwork"');
     const artworkTag = markup.slice(artworkStart, markup.indexOf('>', artworkStart) + 1);
+    const agentOverlayStart = markup.indexOf('data-testid="agent-interaction-overlay"');
+    const agentOverlayTag = markup.slice(
+      agentOverlayStart,
+      markup.indexOf('>', agentOverlayStart) + 1,
+    );
+    const agentAlignmentStart = markup.indexOf('data-testid="agent-interaction-stream-alignment"');
+    const agentAlignmentTag = markup.slice(
+      agentAlignmentStart,
+      markup.indexOf('>', agentAlignmentStart) + 1,
+    );
 
     expect(markup).toContain('data-device-frame-kind="ios:iphone-17-pro"');
     expect(frameTag).toContain('flex-shrink:0');
@@ -203,6 +296,15 @@ describe('agent device status', () => {
     expect(streamStart).toBeLessThan(artworkStart);
     expect(artworkTag).toContain('src="/iphone.png"');
     expect(artworkTag).toContain('pointer-events:none');
+    expect(agentOverlayTag).toContain('left:calc(3.9695% - 1px)');
+    expect(agentOverlayTag).toContain('top:calc(1.6236% - 1px)');
+    expect(agentOverlayTag).toContain('overflow:visible');
+    expect(agentOverlayTag).toContain('z-index:3');
+    expect(agentOverlayTag).not.toContain('overflow:hidden');
+    expect(agentOverlayTag).not.toContain('border-radius');
+    expect(agentAlignmentTag).toContain('width:max(100cqw, 46.043165cqh)');
+    expect(agentAlignmentTag).toContain('height:max(100cqh, 217.187500cqw)');
+    expect(agentOverlayStart).toBeGreaterThan(artworkStart);
     expect(artworkTag).toContain('z-index:2');
 
     const stableArtworkTags = [
@@ -231,7 +333,7 @@ describe('agent device status', () => {
           <div data-testid="connection-state-surface" data-status={client.status} />
         )}
         displayScreen={() => null}
-      />
+      />,
     );
     const viewportStart = markup.indexOf('data-testid="device-frame-viewport"');
     const viewportTag = markup.slice(viewportStart, markup.indexOf('>', viewportStart) + 1);
@@ -241,7 +343,7 @@ describe('agent device status', () => {
     expect(viewportTag).toContain('min-height:0');
     expect(viewportTag).toContain('width:100%');
     expect(markup).toMatch(
-      /data-testid="device-frame-viewport"[^>]*><div data-testid="device-screen-frame"[\s\S]*data-testid="device-frame-stream-cover"[^>]*><div data-testid="connection-state-surface" data-status="connecting"><\/div>/
+      /data-testid="device-frame-viewport"[^>]*><div data-testid="device-screen-frame"[\s\S]*data-testid="device-frame-stream-cover"[^>]*><div data-testid="connection-state-surface" data-status="connecting"><\/div>/,
     );
   });
 
@@ -253,7 +355,7 @@ describe('agent device status', () => {
         deviceFrameAssets={FRAME_ASSETS}
         DeviceScreen={() => null}
         displayScreen={(screen) => screen ?? null}
-      />
+      />,
     );
     const screenStart = markup.indexOf('data-testid="device-screen-clip"');
     const screenTag = markup.slice(screenStart, markup.indexOf('>', screenStart) + 1);
@@ -281,7 +383,7 @@ describe('agent device status', () => {
         deviceFrameAssets={FRAME_ASSETS}
         DeviceScreen={StableDeviceScreen}
         displayScreen={() => null}
-      />
+      />,
     );
     const hidden = renderToStaticMarkup(
       <PhoneFrame
@@ -291,7 +393,7 @@ describe('agent device status', () => {
         showDeviceFrame={false}
         DeviceScreen={StableDeviceScreen}
         displayScreen={() => null}
-      />
+      />,
     );
     expect(shown).toContain('data-device-frame-kind="android:pixel-10-pro"');
     expect(shown).toContain('src="/pixel.png"');
@@ -299,7 +401,7 @@ describe('agent device status', () => {
     expect(hidden).not.toContain('data-testid="device-frame-artwork"');
     for (const markup of [shown, hidden]) {
       expect(markup).toMatch(
-        /data-testid="device-frame-stream-cover"[^>]*><div data-testid="stable-device-screen"><\/div><\/div>/
+        /data-testid="device-frame-stream-cover"[^>]*><div data-testid="stable-device-screen"><\/div><\/div>/,
       );
     }
   });

--- a/packages/@expo/hub-components/src/components/AgentDeviceStatus.tsx
+++ b/packages/@expo/hub-components/src/components/AgentDeviceStatus.tsx
@@ -1,6 +1,6 @@
 import { type RefObject } from 'react';
 
-import { icon, radius, text, textSize } from '../theme/tokens';
+import { agent, radius, textSize } from '../theme/tokens';
 
 /** Reserved device-row status that appears without shifting the device name. */
 export function AgentDeviceStatus({
@@ -22,7 +22,7 @@ export function AgentDeviceStatus({
         gap: compact ? 0 : 5,
         flexShrink: 0,
         visibility: active ? 'visible' : 'hidden',
-        color: text.info,
+        color: agent.text,
         ...textSize['2xs'],
       }}>
       <span
@@ -32,7 +32,7 @@ export function AgentDeviceStatus({
           height: 7,
           flexShrink: 0,
           borderRadius: radius.full,
-          backgroundColor: icon.info,
+          backgroundColor: agent.accent,
         }}
       />
       <span

--- a/packages/@expo/hub-components/src/components/Button.tsx
+++ b/packages/@expo/hub-components/src/components/Button.tsx
@@ -22,8 +22,7 @@ export type ButtonTheme =
   | 'quaternary'
   | 'primary-destructive'
   | 'secondary-destructive'
-  | 'tertiary-destructive'
-  | 'agent-overlay';
+  | 'tertiary-destructive';
 
 export type ButtonSize = '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
@@ -46,7 +45,6 @@ const THEME_TOKENS: Record<ButtonTheme, ThemeTokens> = {
   'primary-destructive': cssTheme('primary-destructive'),
   'secondary-destructive': cssTheme('secondary-destructive'),
   'tertiary-destructive': cssTheme('tertiary-destructive'),
-  'agent-overlay': cssTheme('agent-overlay'),
 };
 
 function cssTheme(name: string): ThemeTokens {

--- a/packages/@expo/hub-components/src/dashboard/AgentDeviceOverlay.tsx
+++ b/packages/@expo/hub-components/src/dashboard/AgentDeviceOverlay.tsx
@@ -1,61 +1,194 @@
-import { Button, textSize } from '../primitives';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 
-// Match the flat connection-state surface in @expo/hub-client/DeviceScreen.
-const DEVICE_STATUS_OVERLAY_BACKGROUND = 'rgba(0, 0, 0, 0.55)';
-const DEVICE_STATUS_OVERLAY_TEXT = 'rgba(255, 255, 255, 0.7)';
-const DEVICE_STATUS_OVERLAY_AGENT_TEXT = 'rgba(218, 233, 255, 0.74)';
+import {
+  DEVICE_POINTER_LABEL_OFFSET_X,
+  DEVICE_POINTER_LABEL_OFFSET_Y,
+  DEVICE_POINTER_LABEL_STYLE,
+  DEVICE_POINTER_STYLE,
+  devicePointerLabelRadius,
+} from '@expo/hub-client';
+import { bg, border, radius, shadow, text, textSize } from '../primitives';
 
-/** Unshaped hover notice; PhoneFrame clips it to the device screen. */
-export function AgentDeviceOverlay({
-  visible,
-  onTakeOver,
+export type AgentDeviceOverlayPlacement = {
+  horizontal: 'left' | 'right';
+  vertical: 'above' | 'below';
+};
+
+export type AgentDeviceOverlayPosition = {
+  clientX: number;
+  clientY: number;
+  frameLeft: number;
+  frameTop: number;
+  viewportWidth: number;
+  viewportHeight: number;
+};
+
+export type AgentDeviceOverlayHandle = {
+  position: (position: AgentDeviceOverlayPosition) => void;
+};
+
+const CALLOUT_GAP = 16;
+const CALLOUT_MARGIN = 16;
+const CALLOUT_WIDTH = 168;
+const CALLOUT_HEIGHT = 50;
+
+/** Keep the pointer callout on the side with enough browser viewport space. */
+export function agentDeviceOverlayPlacement({
+  clientX,
+  clientY,
+  viewportWidth,
+  viewportHeight,
 }: {
-  visible: boolean;
-  onTakeOver: () => void;
-}) {
+  clientX: number;
+  clientY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}): AgentDeviceOverlayPlacement {
+  return {
+    horizontal:
+      clientX + CALLOUT_GAP + CALLOUT_WIDTH + CALLOUT_MARGIN <= viewportWidth ? 'right' : 'left',
+    vertical:
+      clientY + CALLOUT_GAP + CALLOUT_HEIGHT + CALLOUT_MARGIN <= viewportHeight ? 'below' : 'above',
+  };
+}
+
+/** Non-blocking identity and interruption notice positioned beside the user's pointer. */
+export const AgentDeviceOverlay = forwardRef<
+  AgentDeviceOverlayHandle,
+  { visible: boolean; warningVisible?: boolean }
+>(function AgentDeviceOverlay({ visible, warningVisible = true }, ref) {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const stackRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLSpanElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    position({ clientX, clientY, frameLeft, frameTop, viewportWidth, viewportHeight }) {
+      const callout = anchorRef.current;
+      const stack = stackRef.current;
+      const label = labelRef.current;
+      if (!callout || !stack || !label) return;
+
+      const placement = agentDeviceOverlayPlacement({
+        clientX,
+        clientY,
+        viewportWidth,
+        viewportHeight,
+      });
+      callout.style.left = `${clientX - frameLeft}px`;
+      callout.style.top = `${clientY - frameTop}px`;
+      callout.dataset.horizontalPlacement = placement.horizontal;
+      callout.dataset.verticalPlacement = placement.vertical;
+
+      stack.style.left =
+        placement.horizontal === 'right' ? `${DEVICE_POINTER_LABEL_OFFSET_X}px` : 'auto';
+      stack.style.right =
+        placement.horizontal === 'left' ? `${DEVICE_POINTER_LABEL_OFFSET_X}px` : 'auto';
+      stack.style.top =
+        placement.vertical === 'below' ? `${DEVICE_POINTER_LABEL_OFFSET_Y}px` : 'auto';
+      stack.style.bottom =
+        placement.vertical === 'above' ? `${DEVICE_POINTER_LABEL_OFFSET_Y}px` : 'auto';
+      stack.style.alignItems = placement.horizontal === 'right' ? 'flex-start' : 'flex-end';
+      stack.style.flexDirection = placement.vertical === 'below' ? 'column' : 'column-reverse';
+      label.style.borderRadius = devicePointerLabelRadius(placement);
+    },
+  }));
+
   return (
     <div
       hidden={!visible}
       aria-hidden={!visible}
-      role="dialog"
-      aria-label="Agent device activity"
       data-testid="agent-device-overlay"
       style={{
         position: 'absolute',
         inset: 0,
-        zIndex: 2,
-        display: visible ? 'flex' : 'none',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: 24,
-        boxSizing: 'border-box',
-        pointerEvents: 'auto',
-        textAlign: 'center',
-        backgroundColor: DEVICE_STATUS_OVERLAY_BACKGROUND,
-      }}>
+        zIndex: 3,
+        display: visible ? 'block' : 'none',
+        overflow: 'visible',
+        pointerEvents: 'none',
+      }}
+    >
       <div
+        ref={anchorRef}
+        data-testid="user-pointer-callout"
         style={{
-          display: 'flex',
-          width: '100%',
-          maxWidth: 300,
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 12,
-        }}>
-        <div style={{ color: DEVICE_STATUS_OVERLAY_AGENT_TEXT, ...textSize.sm, fontWeight: 600 }}>
-          Agent is using this device
+          ...DEVICE_POINTER_STYLE,
+          pointerEvents: 'none',
+          willChange: 'left, top',
+        }}
+      >
+        <span
+          aria-hidden="true"
+          data-testid="user-pointer-cursor"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            boxSizing: 'border-box',
+            border: `1px solid ${border.secondary}`,
+            borderRadius: radius.full,
+            backgroundColor: bg.overlay,
+            boxShadow: shadow.sm,
+            opacity: 0.78,
+          }}
+        />
+        <div
+          ref={stackRef}
+          data-testid="user-pointer-callout-stack"
+          style={{
+            position: 'absolute',
+            left: DEVICE_POINTER_LABEL_OFFSET_X,
+            top: DEVICE_POINTER_LABEL_OFFSET_Y,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: 6,
+          }}
+        >
+          <span
+            ref={labelRef}
+            data-testid="user-pointer-label"
+            style={{
+              ...DEVICE_POINTER_LABEL_STYLE,
+              minWidth: 50,
+              border: `1px solid ${border.default}`,
+              borderRadius: devicePointerLabelRadius({
+                horizontal: 'right',
+                vertical: 'below',
+              }),
+              backgroundColor: bg.overlay,
+              boxShadow: shadow.sm,
+              color: text.default,
+              fontWeight: 600,
+            }}
+          >
+            you
+          </span>
+          {warningVisible && (
+            <span
+              role="note"
+              data-testid="agent-interruption-warning"
+              style={{
+                display: 'block',
+                width: 'max-content',
+                maxWidth: `calc(100vw - ${CALLOUT_MARGIN * 2}px)`,
+                padding: '6px 8px',
+                boxSizing: 'border-box',
+                borderRadius: radius.lg,
+                backgroundColor: bg.overlay,
+                boxShadow: shadow.md,
+                color: text.secondary,
+                ...textSize['2xs'],
+              }}
+            >
+              <span style={{ display: 'block', whiteSpace: 'nowrap' }}>
+                Interacting could interrupt
+              </span>
+              <span style={{ display: 'block', whiteSpace: 'nowrap' }}>
+                the agent's current work.
+              </span>
+            </span>
+          )}
         </div>
-        <div style={{ maxWidth: 260, color: DEVICE_STATUS_OVERLAY_TEXT, ...textSize.xs }}>
-          Taking over might collide with what the agent is doing.
-        </div>
-        <Button
-          theme="agent-overlay"
-          size="sm"
-          onClick={onTakeOver}
-          style={{ fontFamily: 'inherit' }}>
-          <span style={{ ...textSize.xs, fontWeight: 500 }}>Take over anyway</span>
-        </Button>
       </div>
     </div>
   );
-}
+});

--- a/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
+++ b/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
@@ -1,13 +1,21 @@
-import { type ComponentType, type CSSProperties, useState } from 'react';
+import {
+  type ComponentType,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   type AgentInteraction,
   type DeviceClient,
   type DeviceScreenProps,
   type ScreenSize,
+  useActiveAgentInteraction,
 } from '@expo/hub-client';
 import { bg } from '../primitives';
-import { AgentDeviceOverlay } from './AgentDeviceOverlay';
+import { AgentDeviceOverlay, type AgentDeviceOverlayHandle } from './AgentDeviceOverlay';
 import { type Device } from './data';
 import {
   deviceFramePresentation,
@@ -73,7 +81,10 @@ export function PhoneFrame({
   deviceFrameAssets?: DeviceFrameAssets;
 }) {
   const [hovered, setHovered] = useState(false);
-  const [dismissedInteractionId, setDismissedInteractionId] = useState<string | null>(null);
+  const [warningDismissed, setWarningDismissed] = useState(false);
+  const [agentInteractionPortalTarget, setAgentInteractionPortalTarget] =
+    useState<HTMLDivElement | null>(null);
+  const pointerOverlayRef = useRef<AgentDeviceOverlayHandle>(null);
   const { ratio: fallbackRatio, radiusFraction, squircle } = CONFIG[device.platform];
 
   // Prefer the live screen's aspect ratio once known, so the stream fills the
@@ -97,30 +108,35 @@ export function PhoneFrame({
   const radiusCqw = (radiusFraction / Math.max(ratio, 1)) * 100;
   const borderRadius = `${radiusCqw.toFixed(3)}cqw`;
   const live = client && client.status !== 'idle';
-  const overlayVisible =
-    !!agentInteraction && hovered && dismissedInteractionId !== agentInteraction.id;
+  const activeAgentInteraction = useActiveAgentInteraction(agentInteraction);
+  const overlayVisible = !!activeAgentInteraction && hovered;
+  const warningVisible = overlayVisible && !warningDismissed;
+
+  useEffect(() => {
+    if (!activeAgentInteraction) setWarningDismissed(false);
+  }, [activeAgentInteraction]);
+
+  const positionPointerCallout = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const frame = event.currentTarget.getBoundingClientRect();
+    pointerOverlayRef.current?.position({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      frameLeft: frame.left,
+      frameTop: frame.top,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+  };
 
   const deviceSurface = live ? (
-    <DeviceScreen client={client} agentInteraction={agentInteraction} />
+    <DeviceScreen
+      client={client}
+      agentInteraction={activeAgentInteraction}
+      agentInteractionPortalTarget={agentInteractionPortalTarget}
+    />
   ) : (
     <div style={{ position: 'absolute', inset: 0, backgroundColor: bg.element }} />
   );
-  const takeoverOverlay = (
-    <div
-      data-testid="agent-device-overlay-clip"
-      style={{
-        position: 'absolute',
-        inset: 0,
-        zIndex: 2,
-        pointerEvents: overlayVisible ? 'auto' : 'none',
-      }}>
-      <AgentDeviceOverlay
-        visible={overlayVisible}
-        onTakeOver={() => setDismissedInteractionId(agentInteraction?.id ?? null)}
-      />
-    </div>
-  );
-
   const frameAsset =
     showDeviceFrame && device.deviceFrame ? deviceFrameAssets?.[device.deviceFrame] : undefined;
   const framed = frameAsset
@@ -136,31 +152,56 @@ export function PhoneFrame({
     : {
         position: 'absolute',
         inset: 0,
-        // One responsive path clips both the stream and every overlay, which
-        // avoids fractional seams between separate composited masks.
+        // Keep the stream clipped to the device screen while pointer notices
+        // can use the nearby panel space outside the physical frame.
         clipPath: deviceScreenClipPath(radiusCqw, squircle),
       };
+  const agentInteractionOverlayStyle: CSSProperties = {
+    ...screenStyle,
+    zIndex: 3,
+    overflow: 'visible',
+    borderRadius: undefined,
+    backgroundColor: 'transparent',
+    clipPath: undefined,
+    pointerEvents: 'none',
+  };
 
   return (
     <div
       data-testid="device-screen-frame"
       data-device-frame-kind={framed ? device.deviceFrame : 'none'}
-      data-agent-active={agentInteraction ? 'true' : 'false'}
-      style={framed ? framed.frameStyle : { ...wrapperStyle, borderRadius }}
-      onPointerEnter={(event) => {
-        if (event.pointerType === 'mouse') setHovered(true);
+      data-agent-active={activeAgentInteraction ? 'true' : 'false'}
+      style={{
+        ...(framed ? framed.frameStyle : { ...wrapperStyle, borderRadius }),
+        cursor: activeAgentInteraction ? 'none' : undefined,
       }}
-      onPointerLeave={() => setHovered(false)}>
+      onPointerEnter={(event) => {
+        if (event.pointerType !== 'touch') {
+          positionPointerCallout(event);
+          setHovered(true);
+        }
+      }}
+      onPointerMove={(event) => {
+        if (event.pointerType !== 'touch' && activeAgentInteraction) positionPointerCallout(event);
+      }}
+      onPointerDown={(event) => {
+        if (!activeAgentInteraction) return;
+        if (event.pointerType !== 'touch') positionPointerCallout(event);
+        setWarningDismissed(true);
+      }}
+      onPointerLeave={() => setHovered(false)}
+    >
       <div
         data-testid="device-screen-clip"
         data-device-frame-screen={framed ? 'true' : undefined}
-        style={screenStyle}>
+        style={screenStyle}
+      >
         <div
           data-testid="device-frame-stream-cover"
-          style={framed ? framed.streamStyle : { position: 'absolute', inset: 0 }}>
+          style={framed ? framed.streamStyle : { position: 'absolute', inset: 0 }}
+        >
           {deviceSurface}
         </div>
-        {takeoverOverlay}
       </div>
       {deviceFrameAssets
         ? (Object.keys(deviceFrameAssets) as (keyof DeviceFrameAssets)[]).map((kind) => {
@@ -183,6 +224,27 @@ export function PhoneFrame({
             );
           })
         : null}
+      <div
+        aria-hidden="true"
+        data-testid="agent-interaction-overlay"
+        style={agentInteractionOverlayStyle}
+      >
+        <div
+          data-testid="agent-interaction-stream-alignment"
+          style={framed ? framed.streamStyle : { position: 'absolute', inset: 0 }}
+        >
+          <div
+            ref={setAgentInteractionPortalTarget}
+            data-testid="agent-interaction-portal-target"
+            style={{ position: 'absolute', inset: 0, overflow: 'visible', pointerEvents: 'none' }}
+          />
+        </div>
+      </div>
+      <AgentDeviceOverlay
+        ref={pointerOverlayRef}
+        visible={overlayVisible}
+        warningVisible={warningVisible}
+      />
     </div>
   );
 }

--- a/packages/@expo/hub-components/src/theme/theme.css
+++ b/packages/@expo/hub-components/src/theme/theme.css
@@ -29,27 +29,26 @@
   --expo-radius-3xl: 24px;
   --expo-radius-full: 9999px;
 
-  /* Agent takeover prompt — stays bright against the dark status overlay. */
-  --expo-theme-button-agent-overlay-background: var(--expo-color-white);
-  --expo-theme-button-agent-overlay-border: transparent;
-  --expo-theme-button-agent-overlay-hover: var(--slate-2);
-  --expo-theme-button-agent-overlay-text: var(--slate-12);
-  --expo-theme-button-agent-overlay-disabled-background: var(--slate-2);
-  --expo-theme-button-agent-overlay-disabled-border: transparent;
-  --expo-theme-button-agent-overlay-disabled-text: var(--slate-9);
-}
+  /* Shared cross-package binding for the `textSize.xs` scale. */
+  --expo-text-size-xs-font-size: 12px;
+  --expo-text-size-xs-font-weight: 400;
+  --expo-text-size-xs-line-height: 1.6;
+  --expo-text-size-xs-letter-spacing: 0;
 
-.dark-theme {
-  --expo-theme-button-agent-overlay-background: var(--slate-3);
-  --expo-theme-button-agent-overlay-border: transparent;
-  --expo-theme-button-agent-overlay-hover: var(--slate-5);
-  --expo-theme-button-agent-overlay-text: var(--expo-color-white);
-  --expo-theme-button-agent-overlay-disabled-background: var(--slate-2);
-  --expo-theme-button-agent-overlay-disabled-border: transparent;
-  --expo-theme-button-agent-overlay-disabled-text: var(--slate-11);
+  /* Agent-owned interaction — based on the pink shared-cursor treatment. */
+  --expo-theme-agent-accent: var(--pink-9);
+  --expo-theme-agent-surface: color-mix(in srgb, var(--pink-9) 30%, transparent);
+  --expo-theme-agent-border: var(--pink-7);
+  --expo-theme-agent-text: var(--pink-11);
+  --expo-theme-agent-on-accent: var(--expo-color-white);
 }
 
 /* React's inline-style serialization does not yet expose this new CSS property. */
 [data-device-frame-screen='true'] {
   corner-shape: var(--expo-device-frame-corner-shape, round);
+}
+
+/* The pointer-following “you” marker replaces DeviceScreen's native cursor while an agent is active. */
+[data-agent-active='true'] [role='application'] {
+  cursor: none !important;
 }

--- a/packages/@expo/hub-components/src/theme/tokens.ts
+++ b/packages/@expo/hub-components/src/theme/tokens.ts
@@ -68,6 +68,15 @@ export const border = {
   preview: 'var(--expo-theme-border-preview)',
 } as const;
 
+/** Agent-owned interaction colors, separate from informational blue UI. */
+export const agent = {
+  accent: 'var(--expo-theme-agent-accent)',
+  surface: 'var(--expo-theme-agent-surface)',
+  border: 'var(--expo-theme-agent-border)',
+  text: 'var(--expo-theme-agent-text)',
+  onAccent: 'var(--expo-theme-agent-on-accent)',
+} as const;
+
 /** Border radii. Tailwind: `rounded-*`. */
 export const radius = {
   none: '0',
@@ -98,9 +107,9 @@ export const font = {
 } as const;
 
 type TextStyle = {
-  fontSize: number;
-  fontWeight: number;
-  lineHeight: number;
+  fontSize: number | string;
+  fontWeight: number | string;
+  lineHeight: number | string;
   letterSpacing: string;
 };
 
@@ -114,7 +123,12 @@ export const textSize: Record<'2xl' | 'xl' | 'lg' | 'base' | 'sm' | 'xs' | '2xs'
   lg: { fontSize: 18, fontWeight: 400, lineHeight: 1.4, letterSpacing: '0' },
   base: { fontSize: 16, fontWeight: 400, lineHeight: 1.6, letterSpacing: '0' },
   sm: { fontSize: 14, fontWeight: 400, lineHeight: 1.6, letterSpacing: '0' },
-  xs: { fontSize: 12, fontWeight: 400, lineHeight: 1.6, letterSpacing: '0' },
+  xs: {
+    fontSize: 'var(--expo-text-size-xs-font-size)',
+    fontWeight: 'var(--expo-text-size-xs-font-weight)',
+    lineHeight: 'var(--expo-text-size-xs-line-height)',
+    letterSpacing: 'var(--expo-text-size-xs-letter-spacing)',
+  },
   '2xs': { fontSize: 10, fontWeight: 500, lineHeight: 1.6, letterSpacing: '0' },
 };
 
@@ -142,6 +156,7 @@ export const tokens = {
   text,
   icon,
   border,
+  agent,
   radius,
   shadow,
   font,


### PR DESCRIPTION
## Summary

- render agent interactions with a named pink cursor and matching device status
- replace the blocking takeover overlay with a viewer cursor, attached `you` label, and compact interruption note
- keep cursor labels visible beyond device frames and adapt their attached corners to available viewport space
- keep warning dismissal scoped to the continuous agent-active session and restore the native cursor after inactivity
- share cursor geometry and use semantic color, radius, border, and typography tokens

## Test plan

- `bun test` focused interaction, animation, layout, activity, and device-status suites — 26 passing
- `bun run --cwd packages/@expo/hub-client typecheck`
- `bun run --cwd packages/@expo/hub-components typecheck`
- `bun run --cwd packages/@expo/hub-client lint`
- `bun run --cwd packages/@expo/hub-components lint`
- `bun run build`
- validated the hover, user-interaction, subsequent-agent-action, edge-placement, overflow, and inactivity transitions with real Argent interactions in Safari through the running device hub