### PR TITLE
Refactor Android device settings into one table

### DIFF
--- a/packages/@expo/hub-client/src/android-device-settings.ts
+++ b/packages/@expo/hub-client/src/android-device-settings.ts
@@ -30,61 +30,105 @@ export function androidTextSizeForFontScale(value: unknown): AndroidTextSize | n
   ).value;
 }
 
+export type AndroidDeviceSettingPath = '/api/uimode' | '/api/network' | '/api/font-scale';
+
 export interface AndroidDeviceSettingRequest {
-  path: '/api/uimode' | '/api/network' | '/api/font-scale';
+  path: AndroidDeviceSettingPath;
   body: Record<string, unknown>;
 }
 
-export function androidDeviceSettingPath(
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+interface AndroidDeviceSettingSpec {
+  path: AndroidDeviceSettingPath;
+  /** Whether the 3s poll refreshes this key. */
+  polled: boolean;
+  /** Hub value to request body, or null when the value is not writable. */
+  encode: (value: string) => Record<string, unknown> | null;
+  /** Server payload to Hub value, or null when it cannot be read. */
+  decode: (data: Record<string, unknown>) => string | null;
+}
+
+const ANDROID_DEVICE_SETTINGS: Record<AndroidDeviceSettingKey, AndroidDeviceSettingSpec> = {
+  appearance: {
+    path: '/api/uimode',
+    polled: false,
+    encode: (value) =>
+      value === 'light' || value === 'dark' ? { night: value === 'dark' ? 'yes' : 'no' } : null,
+    decode: (data) => {
+      if (data.night === 'yes') return 'dark';
+      if (data.night === 'no' || data.night === 'auto') return 'light';
+      return null;
+    },
+  },
+  network: {
+    path: '/api/network',
+    polled: true,
+    encode: (value) => (value === 'on' || value === 'off' ? { enabled: value === 'on' } : null),
+    decode: (data) => {
+      const network = asRecord(data.network);
+      if (!network) return null;
+      if (network.enabled === true) return 'on';
+      if (network.enabled === false) return 'off';
+      return network.enabled === null ? 'unknown' : null;
+    },
+  },
+  'text-size': {
+    path: '/api/font-scale',
+    polled: true,
+    encode: (value) => {
+      const scale = androidFontScaleForTextSize(value);
+      return scale === null ? null : { scale };
+    },
+    decode: (data) => {
+      const fontScale = asRecord(data.fontScale);
+      return fontScale === null ? null : androidTextSizeForFontScale(fontScale.scale);
+    },
+  },
+};
+
+export const ANDROID_DEVICE_SETTING_KEYS: readonly AndroidDeviceSettingKey[] = Object.keys(
+  ANDROID_DEVICE_SETTINGS,
+) as AndroidDeviceSettingKey[];
+
+export const ANDROID_POLLED_DEVICE_SETTING_KEYS: readonly AndroidDeviceSettingKey[] =
+  ANDROID_DEVICE_SETTING_KEYS.filter((key) => ANDROID_DEVICE_SETTINGS[key].polled);
+
+export function createAndroidDeviceSettingVersions(): Record<AndroidDeviceSettingKey, number> {
+  return Object.fromEntries(ANDROID_DEVICE_SETTING_KEYS.map((key) => [key, 0])) as Record<
+    AndroidDeviceSettingKey,
+    number
+  >;
+}
+
+export function androidDeviceSettingPathFor(
   key: AndroidDeviceSettingKey,
-): AndroidDeviceSettingRequest['path'] {
-  if (key === 'appearance') return '/api/uimode';
-  if (key === 'network') return '/api/network';
-  return '/api/font-scale';
+): AndroidDeviceSettingPath {
+  return ANDROID_DEVICE_SETTINGS[key].path;
+}
+
+function isAndroidDeviceSettingKey(key: DeviceSettingKey): key is AndroidDeviceSettingKey {
+  return Object.hasOwn(ANDROID_DEVICE_SETTINGS, key);
 }
 
 export function androidDeviceSettingRequest(
   key: DeviceSettingKey,
   value: string,
 ): AndroidDeviceSettingRequest | null {
-  if (key === 'appearance' && (value === 'light' || value === 'dark')) {
-    return {
-      path: androidDeviceSettingPath(key),
-      body: { night: value === 'dark' ? 'yes' : 'no' },
-    };
-  }
-  if (key === 'network' && (value === 'on' || value === 'off')) {
-    return { path: androidDeviceSettingPath(key), body: { enabled: value === 'on' } };
-  }
-  if (key === 'text-size') {
-    const scale = androidFontScaleForTextSize(value);
-    return scale === null ? null : { path: androidDeviceSettingPath(key), body: { scale } };
-  }
-  return null;
+  if (!isAndroidDeviceSettingKey(key)) return null;
+  const spec = ANDROID_DEVICE_SETTINGS[key];
+  const body = spec.encode(value);
+  return body === null ? null : { path: spec.path, body };
 }
 
 export function parseAndroidDeviceSetting(
   key: AndroidDeviceSettingKey,
   payload: unknown,
 ): string | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const data = payload as Record<string, unknown>;
-  if (data.ok !== true) return null;
-
-  if (key === 'appearance') {
-    if (data.night === 'yes') return 'dark';
-    if (data.night === 'no' || data.night === 'auto') return 'light';
-    return null;
-  }
-  if (key === 'network') {
-    const network = data.network;
-    if (!network || typeof network !== 'object' || Array.isArray(network)) return null;
-    const enabled = (network as Record<string, unknown>).enabled;
-    if (enabled === true) return 'on';
-    if (enabled === false) return 'off';
-    return enabled === null ? 'unknown' : null;
-  }
-  const fontScale = data.fontScale;
-  if (!fontScale || typeof fontScale !== 'object' || Array.isArray(fontScale)) return null;
-  return androidTextSizeForFontScale((fontScale as Record<string, unknown>).scale);
+  const data = asRecord(payload);
+  if (!data || data.ok !== true) return null;
+  return ANDROID_DEVICE_SETTINGS[key].decode(data);
 }

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -27,9 +27,12 @@ import {
   reconcileAndroidSessionEvents,
 } from './android-events';
 import {
+  ANDROID_DEVICE_SETTING_KEYS,
+  ANDROID_POLLED_DEVICE_SETTING_KEYS,
   type AndroidDeviceSettingKey,
-  androidDeviceSettingPath,
+  androidDeviceSettingPathFor,
   androidDeviceSettingRequest,
+  createAndroidDeviceSettingVersions,
   parseAndroidDeviceSetting,
 } from './android-device-settings';
 import {
@@ -91,16 +94,6 @@ const EVENTS_POLL_MS = 1000;
 const STREAM_METADATA_POLL_MS = 1500;
 const STREAM_OPTIONS_POLL_MS = 3000;
 const DEVICE_SETTINGS_POLL_MS = 3000;
-
-const ANDROID_DEVICE_SETTING_KEYS: readonly AndroidDeviceSettingKey[] = [
-  'appearance',
-  'network',
-  'text-size',
-];
-const ANDROID_POLLED_DEVICE_SETTING_KEYS: readonly AndroidDeviceSettingKey[] = [
-  'network',
-  'text-size',
-];
 
 const KEYCODE_R = 46;
 
@@ -253,11 +246,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   // Clear is viewer-local so it does not erase serve-emu's replayable session.
   const eventCursorRef = useRef(createAndroidEventCursor());
   const deviceSettingWriteTrackerRef = useRef(new KeyedWriteTracker<DeviceSettingKey>());
-  const deviceSettingVersionsRef = useRef<Record<AndroidDeviceSettingKey, number>>({
-    appearance: 0,
-    network: 0,
-    'text-size': 0,
-  });
+  const deviceSettingVersionsRef = useRef(createAndroidDeviceSettingVersions());
   const deviceScope = `${active ? 'active' : 'inactive'}\0${baseUrl ?? ''}\0${targetDevice ?? ''}`;
   const deviceScopeRef = useRef(deviceScope);
   useLayoutEffect(() => {
@@ -1580,7 +1569,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           nextControllers.push(controller);
           try {
             const response = await fetch(
-              deviceApiUrl(baseUrl, androidDeviceSettingPath(key), targetDevice),
+              deviceApiUrl(baseUrl, androidDeviceSettingPathFor(key), targetDevice),
               { cache: 'no-store', signal: controller.signal },
             );
             if (!response.ok) return { key, version, pendingAtStart, handled: false as const };


### PR DESCRIPTION
## Summary

- replace the three parallel `if`-chains in `android-device-settings.ts` with one `Record<AndroidDeviceSettingKey, AndroidDeviceSettingSpec>`
- derive `ANDROID_DEVICE_SETTING_KEYS`, the polled subset, and the per-key version map from that table
- no behavior change

## Context

`androidDeviceSettingPath`, `androidDeviceSettingRequest` and `parseAndroidDeviceSetting` each branched on the same key names, and `useAndroidDevice.ts` repeated the key list three more times. Adding one setting meant editing six places, and missing the version map silently read `undefined` in the poll's version check. A `Record` over the closed union makes a missing key a compile error instead.

serve-sim already proved this shape with its `UI_OPTIONS` registry, which is why the iOS path is option-agnostic while the Android path was not. This brings Android to the same shape.

This layer keeps `main`'s serve-emu submodule pin and adds no route, so unlike the layers above it does not depend on expo/serve-emu#26 and can merge on its own.

## Verification

- `bun run typecheck` — 11 tasks successful
- `bun run test` — 522 passed, 0 failed (167 in `expo-device-hub`)
- `bun run lint` — 0 warnings, 0 errors
- `packages/expo-device-hub` defines no `typecheck` script, so the root gate never reads its source. `turbo run typecheck --dry-run=json` reports `expo-device-hub#typecheck -> <NONEXISTENT>`. Ran `tsc --noEmit` in that package directly: 206 error headers, all 206 in `vendor/serve-emu/` (mostly TS5097 on `.ts` import extensions in the vendored copy), none in `src`. This gap predates the stack.

The assertions in `android-device-settings.test.ts` are untouched by this PR, which is the evidence that behavior is preserved.

## Rebase note

Rebased onto `main` after #55 and #67. One conflict in `useAndroidDevice.ts`: `main` renamed `DeviceSettingWriteTracker` to `KeyedWriteTracker<DeviceSettingKey>` and `deviceSettingScope` to `deviceScope`. Resolved by keeping `main`'s names alongside this PR's `createAndroidDeviceSettingVersions()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
