### PR TITLE
Add Android reduce-motion and increase-contrast controls

### DIFF
--- a/.changeset/android-accessibility-options.md
+++ b/.changeset/android-accessibility-options.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add Android reduce-motion and increase-contrast controls to the shared device options UI.

--- a/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  ANDROID_DEVICE_SETTING_KEYS,
+  ANDROID_POLLED_DEVICE_SETTING_KEYS,
   androidDeviceSettingRequest,
   androidFontScaleForTextSize,
   androidTextSizeForFontScale,
+  createAndroidDeviceSettingVersions,
   parseAndroidDeviceSetting,
 } from '../android-device-settings';
 
@@ -54,5 +57,112 @@ describe('Android device setting contract', () => {
       'unknown',
     );
     expect(parseAndroidDeviceSetting('text-size', { ok: false })).toBeNull();
+  });
+
+  test('builds accessibility toggle payloads in both directions', () => {
+    expect(androidDeviceSettingRequest('reduce-motion', 'on')).toEqual({
+      path: '/api/reduce-motion',
+      body: { enabled: true },
+    });
+    expect(androidDeviceSettingRequest('reduce-motion', 'off')).toEqual({
+      path: '/api/reduce-motion',
+      body: { enabled: false },
+    });
+    expect(androidDeviceSettingRequest('increase-contrast', 'on')).toEqual({
+      path: '/api/high-text-contrast',
+      body: { enabled: true },
+    });
+    expect(androidDeviceSettingRequest('increase-contrast', 'off')).toEqual({
+      path: '/api/high-text-contrast',
+      body: { enabled: false },
+    });
+    expect(androidDeviceSettingRequest('reduce-motion', 'unknown')).toBeNull();
+    expect(androidDeviceSettingRequest('increase-contrast', 'unknown')).toBeNull();
+  });
+
+  test('normalizes accessibility responses into on/off', () => {
+    expect(
+      parseAndroidDeviceSetting('reduce-motion', { ok: true, reduceMotion: { enabled: true } }),
+    ).toBe('on');
+    expect(
+      parseAndroidDeviceSetting('reduce-motion', { ok: true, reduceMotion: { enabled: false } }),
+    ).toBe('off');
+    expect(
+      parseAndroidDeviceSetting('increase-contrast', {
+        ok: true,
+        highTextContrast: { enabled: true },
+      }),
+    ).toBe('on');
+    expect(
+      parseAndroidDeviceSetting('increase-contrast', {
+        ok: true,
+        highTextContrast: { enabled: false },
+      }),
+    ).toBe('off');
+  });
+
+  test('rejects accessibility responses it cannot read', () => {
+    expect(parseAndroidDeviceSetting('reduce-motion', { ok: false })).toBeNull();
+    expect(parseAndroidDeviceSetting('reduce-motion', { ok: true })).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('reduce-motion', { ok: true, reduceMotion: 'on' }),
+    ).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('reduce-motion', { ok: true, reduceMotion: { enabled: 1 } }),
+    ).toBeNull();
+    expect(parseAndroidDeviceSetting('increase-contrast', { ok: false })).toBeNull();
+    expect(parseAndroidDeviceSetting('increase-contrast', { ok: true })).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('increase-contrast', { ok: true, highTextContrast: [] }),
+    ).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('increase-contrast', {
+        ok: true,
+        highTextContrast: { enabled: 'yes' },
+      }),
+    ).toBeNull();
+  });
+
+  /** Only `network` has an unknown state; a copy-pasted decoder would regress here. */
+  test('never reports unknown for the accessibility keys', () => {
+    expect(
+      parseAndroidDeviceSetting('reduce-motion', { ok: true, reduceMotion: { enabled: null } }),
+    ).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('increase-contrast', {
+        ok: true,
+        highTextContrast: { enabled: null },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('Android device setting table', () => {
+  test('derives the full and polled key lists in table order', () => {
+    expect(ANDROID_DEVICE_SETTING_KEYS).toEqual([
+      'appearance',
+      'network',
+      'text-size',
+      'reduce-motion',
+      'increase-contrast',
+    ]);
+    expect(ANDROID_POLLED_DEVICE_SETTING_KEYS).toEqual([
+      'network',
+      'text-size',
+      'reduce-motion',
+      'increase-contrast',
+    ]);
+  });
+
+  test('hands every device session its own zeroed poll versions', () => {
+    const versions = createAndroidDeviceSettingVersions();
+    expect(versions).toEqual({
+      appearance: 0,
+      network: 0,
+      'text-size': 0,
+      'reduce-motion': 0,
+      'increase-contrast': 0,
+    });
+    expect(createAndroidDeviceSettingVersions()).not.toBe(versions);
   });
 });

--- a/packages/@expo/hub-client/src/android-device-settings.ts
+++ b/packages/@expo/hub-client/src/android-device-settings.ts
@@ -2,7 +2,7 @@ import { type DeviceSettingKey } from './types';
 
 export type AndroidDeviceSettingKey = Extract<
   DeviceSettingKey,
-  'appearance' | 'network' | 'text-size'
+  'appearance' | 'network' | 'text-size' | 'reduce-motion' | 'increase-contrast'
 >;
 
 export type AndroidTextSize = 'small' | 'medium' | 'large' | 'extra-large';
@@ -30,7 +30,12 @@ export function androidTextSizeForFontScale(value: unknown): AndroidTextSize | n
   ).value;
 }
 
-export type AndroidDeviceSettingPath = '/api/uimode' | '/api/network' | '/api/font-scale';
+export type AndroidDeviceSettingPath =
+  | '/api/uimode'
+  | '/api/network'
+  | '/api/font-scale'
+  | '/api/reduce-motion'
+  | '/api/high-text-contrast';
 
 export interface AndroidDeviceSettingRequest {
   path: AndroidDeviceSettingPath;
@@ -40,6 +45,17 @@ export interface AndroidDeviceSettingRequest {
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
+}
+
+function enabledBodyForOnOff(value: string): Record<string, unknown> | null {
+  return value === 'on' || value === 'off' ? { enabled: value === 'on' } : null;
+}
+
+function onOffForEnabledBody(value: unknown): string | null {
+  const enabled = asRecord(value)?.enabled;
+  if (enabled === true) return 'on';
+  if (enabled === false) return 'off';
+  return null;
 }
 
 interface AndroidDeviceSettingSpec {
@@ -67,7 +83,7 @@ const ANDROID_DEVICE_SETTINGS: Record<AndroidDeviceSettingKey, AndroidDeviceSett
   network: {
     path: '/api/network',
     polled: true,
-    encode: (value) => (value === 'on' || value === 'off' ? { enabled: value === 'on' } : null),
+    encode: enabledBodyForOnOff,
     decode: (data) => {
       const network = asRecord(data.network);
       if (!network) return null;
@@ -87,6 +103,18 @@ const ANDROID_DEVICE_SETTINGS: Record<AndroidDeviceSettingKey, AndroidDeviceSett
       const fontScale = asRecord(data.fontScale);
       return fontScale === null ? null : androidTextSizeForFontScale(fontScale.scale);
     },
+  },
+  'reduce-motion': {
+    path: '/api/reduce-motion',
+    polled: true,
+    encode: enabledBodyForOnOff,
+    decode: (data) => onOffForEnabledBody(data.reduceMotion),
+  },
+  'increase-contrast': {
+    path: '/api/high-text-contrast',
+    polled: true,
+    encode: enabledBodyForOnOff,
+    decode: (data) => onOffForEnabledBody(data.highTextContrast),
   },
 };
 

--- a/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
@@ -169,7 +169,6 @@ export function DeviceOptionsSection({
         )}
 
       {showDeviceSettings &&
-        platform === 'ios' &&
         SWITCH_OPTIONS.map(({ key, label }) =>
           visible(key) ? (
             <SidebarRow key={key} label={label}>

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -1016,6 +1016,31 @@ test('maps Android device options onto Network and S–XL selects', () => {
   expect(selectValue(html, 'Text size')).toBe('M');
 });
 
+test('renders the Android accessibility switches the backend reports', () => {
+  const client = {
+    ...inspectorClient('android'),
+    deviceSettings: {
+      appearance: 'light',
+      network: 'on',
+      'text-size': 'medium',
+      'reduce-motion': 'on',
+      'increase-contrast': 'off',
+    },
+  };
+  const html = renderToStaticMarkup(<LogSidebar client={client} />);
+
+  expect(switchMarkup(html, 'Reduce motion')).toContain('aria-checked="true"');
+  expect(switchMarkup(html, 'Increase contrast')).toContain('aria-checked="false"');
+});
+
+test('omits the Android accessibility switches the backend does not report', () => {
+  const html = renderToStaticMarkup(<LogSidebar client={inspectorClient('android')} />);
+
+  for (const label of ['Reduce motion', 'Increase contrast']) {
+    expect(html).not.toContain(`>${label}<`);
+  }
+});
+
 test('keeps keyboard controls at the end of the device options list', () => {
   const html = renderToStaticMarkup(<LogSidebar client={inspectorClient('ios')} />);
   const section = sectionMarkup(html, 'Device options');


### PR DESCRIPTION
## Summary

- bump the serve-emu submodule to pick up `/api/reduce-motion` and `/api/high-text-contrast`
- add both keys to the Android device-settings table
- drop the `platform === 'ios'` gate on the accessibility switches so Android shows the switches it reports
- add a minor changeset

## Depends on

**expo/serve-emu#26.** This PR pins serve-emu `55045f6`, the head of that PR. It cannot merge until #26 lands and the pin moves to the merged SHA.

## Context

Both settings are framework-level, so any app observes them, not only React Native. Reduce motion drives the three `global` animation scales that Android's own "Remove animations" toggle moves, and reads back `transition_animation_scale` as the authority, because that is the single key React Native's `AccessibilityInfo.isReduceMotionEnabled` parses. Increase contrast drives `secure high_text_contrast_enabled`, which `isHighTextContrastEnabled` reads.

### Where the routes live

This PR originally added both routes to an in-repo compatibility layer, `serve-emu-device-options.ts`, because the Expo branch of serve-emu had neither `/api/network` nor `/api/font-scale` at the time. That premise is gone. #39 deleted that file once those two landed upstream, and these four follow the same path: they live in serve-emu (expo/serve-emu#26), and the Hub reaches them through the same vendored router as every other route.

So this layer carries **no server code at all** — only the submodule bump plus the client and UI wiring. That also removes the duplication the compatibility layer required: it shipped its own `adb` exec wrapper, timeouts, concurrency limiter and JSON body reader beside the ones serve-emu already had.

Colour filter and invert colours are deliberately excluded. Both accept writes and are readable by apps, but `dumpsys color_display` reports the display features as "Not available" on emulator images, and screenshot comparison confirms nothing changes on screen. A switch that visibly does nothing reads as broken.

The `platform === 'ios'` removal is a deletion rather than a new Android branch because `visible(key)` already hides any key the backend does not report.

## Verification

- `bun run typecheck` — 11 tasks successful
- `bun run test` — 530 passed, 0 failed (169 in `expo-device-hub`)
- `bun run lint` — 0 warnings, 0 errors
- `packages/expo-device-hub` defines no `typecheck` script, so the root gate never reads its source. `turbo run typecheck --dry-run=json` reports `expo-device-hub#typecheck -> <NONEXISTENT>`. Ran `tsc --noEmit` in that package directly: 206 error headers, all 206 in `vendor/serve-emu/` (mostly TS5097 on `.ts` import extensions in the vendored copy), none in `src`. This gap predates the stack.
- Wire contract checked against the built bundle rather than the source: `/api/reduce-motion` and `/api/high-text-contrast`, and their `reduceMotion` and `highTextContrast` response keys, all appear in `vendor/serve-emu/dist/middleware.js`.
- End to end against a booted API 36 `google_apis_playstore` emulator, driven through the browser rather than the API: clicked both switches, confirmed via `adb` that all three animation scales became `0` and `high_text_contrast_enabled` became `1`, confirmed both switches read back as checked, then confirmed toggling off restored the defaults. That run predates the move to serve-emu. The adb commands and the response envelopes are unchanged, so it now stands as evidence for serve-emu's implementation of the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
