### PR TITLE
Add an Android bold-text control

### DIFF
--- a/.changeset/android-bold-text-option.md
+++ b/.changeset/android-bold-text-option.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add an Android bold-text control to the shared device options UI.

--- a/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
@@ -76,8 +76,17 @@ describe('Android device setting contract', () => {
       path: '/api/high-text-contrast',
       body: { enabled: false },
     });
+    expect(androidDeviceSettingRequest('bold-text', 'on')).toEqual({
+      path: '/api/font-weight',
+      body: { enabled: true },
+    });
+    expect(androidDeviceSettingRequest('bold-text', 'off')).toEqual({
+      path: '/api/font-weight',
+      body: { enabled: false },
+    });
     expect(androidDeviceSettingRequest('reduce-motion', 'unknown')).toBeNull();
     expect(androidDeviceSettingRequest('increase-contrast', 'unknown')).toBeNull();
+    expect(androidDeviceSettingRequest('bold-text', 'unknown')).toBeNull();
   });
 
   test('normalizes accessibility responses into on/off', () => {
@@ -98,6 +107,12 @@ describe('Android device setting contract', () => {
         ok: true,
         highTextContrast: { enabled: false },
       }),
+    ).toBe('off');
+    expect(parseAndroidDeviceSetting('bold-text', { ok: true, fontWeight: { enabled: true } })).toBe(
+      'on',
+    );
+    expect(
+      parseAndroidDeviceSetting('bold-text', { ok: true, fontWeight: { enabled: false } }),
     ).toBe('off');
   });
 
@@ -121,6 +136,12 @@ describe('Android device setting contract', () => {
         highTextContrast: { enabled: 'yes' },
       }),
     ).toBeNull();
+    expect(parseAndroidDeviceSetting('bold-text', { ok: false })).toBeNull();
+    expect(parseAndroidDeviceSetting('bold-text', { ok: true })).toBeNull();
+    expect(parseAndroidDeviceSetting('bold-text', { ok: true, fontWeight: 300 })).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('bold-text', { ok: true, fontWeight: { adjustment: 300 } }),
+    ).toBeNull();
   });
 
   /** Only `network` has an unknown state; a copy-pasted decoder would regress here. */
@@ -134,6 +155,9 @@ describe('Android device setting contract', () => {
         highTextContrast: { enabled: null },
       }),
     ).toBeNull();
+    expect(
+      parseAndroidDeviceSetting('bold-text', { ok: true, fontWeight: { enabled: null } }),
+    ).toBeNull();
   });
 });
 
@@ -144,12 +168,14 @@ describe('Android device setting table', () => {
       'network',
       'text-size',
       'reduce-motion',
+      'bold-text',
       'increase-contrast',
     ]);
     expect(ANDROID_POLLED_DEVICE_SETTING_KEYS).toEqual([
       'network',
       'text-size',
       'reduce-motion',
+      'bold-text',
       'increase-contrast',
     ]);
   });
@@ -161,6 +187,7 @@ describe('Android device setting table', () => {
       network: 0,
       'text-size': 0,
       'reduce-motion': 0,
+      'bold-text': 0,
       'increase-contrast': 0,
     });
     expect(createAndroidDeviceSettingVersions()).not.toBe(versions);

--- a/packages/@expo/hub-client/src/android-device-settings.ts
+++ b/packages/@expo/hub-client/src/android-device-settings.ts
@@ -2,7 +2,7 @@ import { type DeviceSettingKey } from './types';
 
 export type AndroidDeviceSettingKey = Extract<
   DeviceSettingKey,
-  'appearance' | 'network' | 'text-size' | 'reduce-motion' | 'increase-contrast'
+  'appearance' | 'network' | 'text-size' | 'reduce-motion' | 'bold-text' | 'increase-contrast'
 >;
 
 export type AndroidTextSize = 'small' | 'medium' | 'large' | 'extra-large';
@@ -35,6 +35,7 @@ export type AndroidDeviceSettingPath =
   | '/api/network'
   | '/api/font-scale'
   | '/api/reduce-motion'
+  | '/api/font-weight'
   | '/api/high-text-contrast';
 
 export interface AndroidDeviceSettingRequest {
@@ -109,6 +110,12 @@ const ANDROID_DEVICE_SETTINGS: Record<AndroidDeviceSettingKey, AndroidDeviceSett
     polled: true,
     encode: enabledBodyForOnOff,
     decode: (data) => onOffForEnabledBody(data.reduceMotion),
+  },
+  'bold-text': {
+    path: '/api/font-weight',
+    polled: true,
+    encode: enabledBodyForOnOff,
+    decode: (data) => onOffForEnabledBody(data.fontWeight),
   },
   'increase-contrast': {
     path: '/api/high-text-contrast',

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -101,6 +101,7 @@ export type DeviceSettingKey =
   | 'color-filter'
   | 'text-size'
   | 'reduce-motion'
+  | 'bold-text'
   | 'increase-contrast'
   | 'show-borders'
   | 'reduce-transparency'

--- a/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
@@ -14,6 +14,7 @@ const DEFAULT_VALUES: Record<DeviceSettingKey, string> = {
   'color-filter': 'none',
   'text-size': 'large',
   'reduce-motion': 'off',
+  'bold-text': 'off',
   'increase-contrast': 'off',
   'show-borders': 'off',
   'reduce-transparency': 'off',
@@ -62,6 +63,7 @@ const ANDROID_TEXT_SIZE_OPTIONS: SelectOption[] = [
 
 const SWITCH_OPTIONS: ReadonlyArray<{ key: DeviceSettingKey; label: string }> = [
   { key: 'reduce-motion', label: 'Reduce motion' },
+  { key: 'bold-text', label: 'Bold text' },
   { key: 'increase-contrast', label: 'Increase contrast' },
   { key: 'show-borders', label: 'Show borders' },
   { key: 'reduce-transparency', label: 'Reduce transparency' },

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -1024,19 +1024,21 @@ test('renders the Android accessibility switches the backend reports', () => {
       network: 'on',
       'text-size': 'medium',
       'reduce-motion': 'on',
+      'bold-text': 'on',
       'increase-contrast': 'off',
     },
   };
   const html = renderToStaticMarkup(<LogSidebar client={client} />);
 
   expect(switchMarkup(html, 'Reduce motion')).toContain('aria-checked="true"');
+  expect(switchMarkup(html, 'Bold text')).toContain('aria-checked="true"');
   expect(switchMarkup(html, 'Increase contrast')).toContain('aria-checked="false"');
 });
 
 test('omits the Android accessibility switches the backend does not report', () => {
   const html = renderToStaticMarkup(<LogSidebar client={inspectorClient('android')} />);
 
-  for (const label of ['Reduce motion', 'Increase contrast']) {
+  for (const label of ['Reduce motion', 'Bold text', 'Increase contrast']) {
     expect(html).not.toContain(`>${label}<`);
   }
 });


### PR DESCRIPTION
## Summary

- add the `bold-text` key to `DeviceSettingKey`, the Android settings table, and the options UI
- add a minor changeset

## Depends on

**expo/serve-emu#26**, through #44. `/api/font-weight` comes from the submodule bump in that layer, so this PR adds no server code.

## Context

Bold text writes `secure font_weight_adjustment` with `300`, the value Android's own Bold text toggle uses. That key feeds `Configuration.fontWeightAdjustment`, so plain Android views, Compose, and React Native all honor it.

The route returns `{ enabled, raw }` rather than the parsed integer. Nothing reads the integer, and `raw` already carries the value.

This layer originally added `/api/font-weight` to the in-repo compatibility layer, and argued for a minimal contract so it would be easier to reconcile if serve-emu ever grew the route. serve-emu has the route now, so that reconcile is done rather than deferred: the implementation lives in expo/serve-emu#26 and this PR is client and UI only.

The response key is `fontWeight`, matching the route name, and the client reads `data.fontWeight`. Worth stating explicitly because the envelope key and the setting key differ here — the setting is `bold-text`, the route and payload are `font-weight`.

## Verification

- `bun run typecheck` — 11 tasks successful
- `bun run test` — 530 passed, 0 failed (169 in `expo-device-hub`)
- `bun run lint` — 0 warnings, 0 errors
- `packages/expo-device-hub` defines no `typecheck` script, so the root gate never reads its source. `turbo run typecheck --dry-run=json` reports `expo-device-hub#typecheck -> <NONEXISTENT>`. Ran `tsc --noEmit` in that package directly: 206 error headers, all 206 in `vendor/serve-emu/` (mostly TS5097 on `.ts` import extensions in the vendored copy), none in `src`. This gap predates the stack.
- Wire contract checked against the built bundle rather than the source: `/api/font-weight` and its `fontWeight` response key both appear in `vendor/serve-emu/dist/middleware.js`.
- End to end against the same API 36 emulator, driven through the browser: clicked the switch with the native Settings app in the foreground, confirmed `font_weight_adjustment` became `300` and the Settings headings rendered visibly heavier in the stream, then confirmed toggling off wrote `0` and restored the original weight. That run predates the move to serve-emu. The adb command and the response envelope are unchanged, so it now stands as evidence for serve-emu's implementation of the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
