### PR TITLE
Add an Android display-size control

### DIFF
--- a/.changeset/android-display-size-option.md
+++ b/.changeset/android-display-size-option.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add an Android display-size control to the shared device options UI, with the resulting smallest-width dp shown beneath it.

--- a/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-device-settings.test.ts
@@ -4,6 +4,7 @@ import {
   ANDROID_DEVICE_SETTING_KEYS,
   ANDROID_POLLED_DEVICE_SETTING_KEYS,
   androidDeviceSettingRequest,
+  androidDisplayWidthDpFromPayload,
   androidFontScaleForTextSize,
   androidTextSizeForFontScale,
   createAndroidDeviceSettingVersions,
@@ -57,6 +58,58 @@ describe('Android device setting contract', () => {
       'unknown',
     );
     expect(parseAndroidDeviceSetting('text-size', { ok: false })).toBeNull();
+  });
+
+  test('builds display-size payloads from the shared size steps', () => {
+    expect(androidDeviceSettingRequest('display-size', 'small')).toEqual({
+      path: '/api/display-density',
+      body: { scale: 0.85 },
+    });
+    expect(androidDeviceSettingRequest('display-size', 'extra-large')).toEqual({
+      path: '/api/display-density',
+      body: { scale: 1.3 },
+    });
+    expect(androidDeviceSettingRequest('display-size', 'gigantic')).toBeNull();
+  });
+
+  test('snaps reported display densities onto the nearest step', () => {
+    expect(
+      parseAndroidDeviceSetting('display-size', { ok: true, displayDensity: { scale: 1 } }),
+    ).toBe('medium');
+    expect(
+      parseAndroidDeviceSetting('display-size', { ok: true, displayDensity: { scale: 1.3 } }),
+    ).toBe('extra-large');
+    expect(
+      parseAndroidDeviceSetting('display-size', { ok: true, displayDensity: { scale: 1.143 } }),
+    ).toBe('large');
+    expect(parseAndroidDeviceSetting('display-size', { ok: true })).toBeNull();
+  });
+
+  test('reads the smallest-width dp out of a display-density payload', () => {
+    expect(
+      androidDisplayWidthDpFromPayload({
+        ok: true,
+        displayDensity: { scale: 1, widthDp: 411, raw: 'Physical density: 420' },
+      }),
+    ).toBe(411);
+  });
+
+  test('reports no smallest-width dp when the payload cannot supply one', () => {
+    expect(androidDisplayWidthDpFromPayload({ ok: true })).toBeNull();
+    expect(androidDisplayWidthDpFromPayload({ ok: true, displayDensity: { scale: 1 } })).toBeNull();
+    expect(
+      androidDisplayWidthDpFromPayload({ ok: true, displayDensity: { widthDp: 0 } }),
+    ).toBeNull();
+    expect(
+      androidDisplayWidthDpFromPayload({ ok: true, displayDensity: { widthDp: -411 } }),
+    ).toBeNull();
+    expect(
+      androidDisplayWidthDpFromPayload({ ok: true, displayDensity: { widthDp: '411' } }),
+    ).toBeNull();
+    expect(androidDisplayWidthDpFromPayload('411')).toBeNull();
+    expect(
+      androidDisplayWidthDpFromPayload({ ok: false, displayDensity: { widthDp: 411 } }),
+    ).toBeNull();
   });
 
   test('builds accessibility toggle payloads in both directions', () => {
@@ -167,6 +220,7 @@ describe('Android device setting table', () => {
       'appearance',
       'network',
       'text-size',
+      'display-size',
       'reduce-motion',
       'bold-text',
       'increase-contrast',
@@ -174,6 +228,7 @@ describe('Android device setting table', () => {
     expect(ANDROID_POLLED_DEVICE_SETTING_KEYS).toEqual([
       'network',
       'text-size',
+      'display-size',
       'reduce-motion',
       'bold-text',
       'increase-contrast',
@@ -186,6 +241,7 @@ describe('Android device setting table', () => {
       appearance: 0,
       network: 0,
       'text-size': 0,
+      'display-size': 0,
       'reduce-motion': 0,
       'bold-text': 0,
       'increase-contrast': 0,

--- a/packages/@expo/hub-client/src/android-device-settings.ts
+++ b/packages/@expo/hub-client/src/android-device-settings.ts
@@ -2,13 +2,19 @@ import { type DeviceSettingKey } from './types';
 
 export type AndroidDeviceSettingKey = Extract<
   DeviceSettingKey,
-  'appearance' | 'network' | 'text-size' | 'reduce-motion' | 'bold-text' | 'increase-contrast'
+  | 'appearance'
+  | 'network'
+  | 'text-size'
+  | 'display-size'
+  | 'reduce-motion'
+  | 'bold-text'
+  | 'increase-contrast'
 >;
 
-export type AndroidTextSize = 'small' | 'medium' | 'large' | 'extra-large';
+export type AndroidSizeStep = 'small' | 'medium' | 'large' | 'extra-large';
 
-const ANDROID_FONT_SCALES: ReadonlyArray<{
-  value: AndroidTextSize;
+const ANDROID_SIZE_SCALES: ReadonlyArray<{
+  value: AndroidSizeStep;
   scale: number;
 }> = [
   { value: 'small', scale: 0.85 },
@@ -17,23 +23,29 @@ const ANDROID_FONT_SCALES: ReadonlyArray<{
   { value: 'extra-large', scale: 1.3 },
 ];
 
-export function androidFontScaleForTextSize(value: string): number | null {
-  return ANDROID_FONT_SCALES.find((preset) => preset.value === value)?.scale ?? null;
+export function androidScaleForSizeStep(value: string): number | null {
+  return ANDROID_SIZE_SCALES.find((preset) => preset.value === value)?.scale ?? null;
 }
 
 /** Map externally-set Android scales onto the nearest S–XL Hub option. */
-export function androidTextSizeForFontScale(value: unknown): AndroidTextSize | null {
+export function androidSizeStepForScale(value: unknown): AndroidSizeStep | null {
   const scale = Number(value);
   if (!Number.isFinite(scale) || scale <= 0) return null;
-  return ANDROID_FONT_SCALES.reduce((nearest, preset) =>
+  return ANDROID_SIZE_SCALES.reduce((nearest, preset) =>
     Math.abs(preset.scale - scale) < Math.abs(nearest.scale - scale) ? preset : nearest,
   ).value;
 }
+
+/** The text-size spelling of the shared step helpers. */
+export type AndroidTextSize = AndroidSizeStep;
+export const androidFontScaleForTextSize = androidScaleForSizeStep;
+export const androidTextSizeForFontScale = androidSizeStepForScale;
 
 export type AndroidDeviceSettingPath =
   | '/api/uimode'
   | '/api/network'
   | '/api/font-scale'
+  | '/api/display-density'
   | '/api/reduce-motion'
   | '/api/font-weight'
   | '/api/high-text-contrast';
@@ -97,12 +109,24 @@ const ANDROID_DEVICE_SETTINGS: Record<AndroidDeviceSettingKey, AndroidDeviceSett
     path: '/api/font-scale',
     polled: true,
     encode: (value) => {
-      const scale = androidFontScaleForTextSize(value);
+      const scale = androidScaleForSizeStep(value);
       return scale === null ? null : { scale };
     },
     decode: (data) => {
       const fontScale = asRecord(data.fontScale);
-      return fontScale === null ? null : androidTextSizeForFontScale(fontScale.scale);
+      return fontScale === null ? null : androidSizeStepForScale(fontScale.scale);
+    },
+  },
+  'display-size': {
+    path: '/api/display-density',
+    polled: true,
+    encode: (value) => {
+      const scale = androidScaleForSizeStep(value);
+      return scale === null ? null : { scale };
+    },
+    decode: (data) => {
+      const displayDensity = asRecord(data.displayDensity);
+      return displayDensity === null ? null : androidSizeStepForScale(displayDensity.scale);
     },
   },
   'reduce-motion': {
@@ -166,4 +190,12 @@ export function parseAndroidDeviceSetting(
   const data = asRecord(payload);
   if (!data || data.ok !== true) return null;
   return ANDROID_DEVICE_SETTINGS[key].decode(data);
+}
+
+/** The smallest-width dp a display-density payload reports, in `swNNNdp` terms. */
+export function androidDisplayWidthDpFromPayload(payload: unknown): number | null {
+  const data = asRecord(payload);
+  if (!data || data.ok !== true) return null;
+  const widthDp = asRecord(data.displayDensity)?.widthDp;
+  return typeof widthDp === 'number' && Number.isFinite(widthDp) && widthDp > 0 ? widthDp : null;
 }

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -100,6 +100,7 @@ export type DeviceSettingKey =
   | 'liquid-glass'
   | 'color-filter'
   | 'text-size'
+  | 'display-size'
   | 'reduce-motion'
   | 'bold-text'
   | 'increase-contrast'
@@ -486,6 +487,11 @@ export interface DeviceClient {
   deviceSettingsPending: ReadonlySet<DeviceSettingKey>;
   /** Change one simulator/device option. Unsupported keys are ignored by each backend. */
   setDeviceSetting: (key: DeviceSettingKey, value: string) => void;
+  /**
+   * The device's smallest-width dp that the Display size control surfaces, or
+   * null when it is unknown.
+   */
+  displayWidthDp: number | null;
 
   /** Emulator camera feeds, or null before the first read or when the backend has none. */
   camera: DeviceCameraStatus | null;

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -32,6 +32,7 @@ import {
   type AndroidDeviceSettingKey,
   androidDeviceSettingPathFor,
   androidDeviceSettingRequest,
+  androidDisplayWidthDpFromPayload,
   createAndroidDeviceSettingVersions,
   parseAndroidDeviceSetting,
 } from './android-device-settings';
@@ -204,6 +205,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   // The device's system dark/light setting. null until `/api/uimode` reports it.
   const [appearance, setAppearanceState] = useState<DeviceAppearance | null>(null);
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings | null>(null);
+  const [displayWidthDp, setDisplayWidthDp] = useState<number | null>(null);
   const [deviceSettingsPending, setDeviceSettingsPending] = useState<
     ReadonlySet<DeviceSettingKey>
   >(() => new Set());
@@ -1547,6 +1549,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     setDeviceSettingsPending(new Set());
     setDeviceSettings(null);
     setAppearanceState(null);
+    setDisplayWidthDp(null);
     if (!active || !baseUrl) {
       return;
     }
@@ -1573,12 +1576,14 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
               { cache: 'no-store', signal: controller.signal },
             );
             if (!response.ok) return { key, version, pendingAtStart, handled: false as const };
+            const payload: unknown = await response.json();
             return {
               key,
               version,
               pendingAtStart,
               handled: true as const,
-              value: parseAndroidDeviceSetting(key, await response.json()),
+              value: parseAndroidDeviceSetting(key, payload),
+              payload,
             };
           } catch {
             return { key, version, pendingAtStart, handled: false as const };
@@ -1609,6 +1614,19 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         (appearanceResult.value === 'light' || appearanceResult.value === 'dark')
       ) {
         setAppearanceState(appearanceResult.value);
+      }
+      const displaySizeResult = results.find((result) => result.key === 'display-size');
+      if (
+        displaySizeResult &&
+        !displaySizeResult.pendingAtStart &&
+        deviceSettingVersionsRef.current['display-size'] === displaySizeResult.version &&
+        !tracker.pending.has('display-size')
+      ) {
+        setDisplayWidthDp(
+          displaySizeResult.handled
+            ? androidDisplayWidthDpFromPayload(displaySizeResult.payload)
+            : null,
+        );
       }
     };
 
@@ -1649,6 +1667,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    displayWidthDp,
     camera,
     cameraPending,
     cameraError,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -1350,6 +1350,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    displayWidthDp: null,
     camera: null,
     cameraPending: NO_PENDING_CAMERA_WRITES,
     cameraError: null,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -24,6 +24,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   deviceSettings: null,
   deviceSettingsPending: new Set(),
   setDeviceSetting: () => {},
+  displayWidthDp: null,
   camera: null,
   cameraPending: NO_PENDING_CAMERA_WRITES,
   cameraError: null,

--- a/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
@@ -25,6 +25,7 @@ const BASE_CLIENT: DeviceClient = {
   deviceSettings: null,
   deviceSettingsPending: new Set(),
   setDeviceSetting: () => {},
+  displayWidthDp: null,
   camera: null,
   cameraPending: new Set(),
   cameraError: null,

--- a/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
@@ -13,6 +13,7 @@ const DEFAULT_VALUES: Record<DeviceSettingKey, string> = {
   'liquid-glass': 'clear',
   'color-filter': 'none',
   'text-size': 'large',
+  'display-size': 'medium',
   'reduce-motion': 'off',
   'bold-text': 'off',
   'increase-contrast': 'off',
@@ -61,6 +62,13 @@ const ANDROID_TEXT_SIZE_OPTIONS: SelectOption[] = [
   { value: 'extra-large', label: 'XL' },
 ];
 
+const ANDROID_DISPLAY_SIZE_OPTIONS: SelectOption[] = [
+  { value: 'small', label: 'S' },
+  { value: 'medium', label: 'M' },
+  { value: 'large', label: 'L' },
+  { value: 'extra-large', label: 'XL' },
+];
+
 const SWITCH_OPTIONS: ReadonlyArray<{ key: DeviceSettingKey; label: string }> = [
   { key: 'reduce-motion', label: 'Reduce motion' },
   { key: 'bold-text', label: 'Bold text' },
@@ -103,9 +111,11 @@ export function DeviceOptionsSection({
 }) {
   const [open, setOpen] = useState(true);
   const unavailableFrameDescriptionId = useId();
+  const displaySizeDescriptionId = useId();
   const settings = client?.deviceSettings ?? null;
   const pending = client?.deviceSettingsPending ?? EMPTY_PENDING_SETTINGS;
   const platform = client?.platform;
+  const displayWidthDp = client?.displayWidthDp ?? null;
 
   function visible(key: DeviceSettingKey) {
     if (settings === null) return key === 'appearance' || platform === 'ios';
@@ -169,6 +179,22 @@ export function DeviceOptionsSection({
           'Text size',
           platform === 'android' ? ANDROID_TEXT_SIZE_OPTIONS : TEXT_SIZE_OPTIONS,
         )}
+
+      {showDeviceSettings && platform === 'android' && visible('display-size') && (
+        <SidebarRow
+          label="Display size"
+          description={displayWidthDp === null ? undefined : `sw${displayWidthDp}dp`}
+          descriptionId={displayWidthDp === null ? undefined : displaySizeDescriptionId}>
+          <Select
+            ariaLabel="Display size"
+            ariaDescribedBy={displayWidthDp === null ? undefined : displaySizeDescriptionId}
+            options={ANDROID_DISPLAY_SIZE_OPTIONS}
+            value={value('display-size')}
+            disabled={disabled('display-size')}
+            onChange={(nextValue) => setValue('display-size', nextValue)}
+          />
+        </SidebarRow>
+      )}
 
       {showDeviceSettings &&
         SWITCH_OPTIONS.map(({ key, label }) =>

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -46,6 +46,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       : { appearance: 'light', network: 'on', 'text-size': 'medium' },
     deviceSettingsPending: new Set(),
     setDeviceSetting: () => {},
+    displayWidthDp: null,
     camera: null,
     cameraPending: new Set(),
     cameraError: null,
@@ -1014,6 +1015,73 @@ test('maps Android device options onto Network and S–XL selects', () => {
   expect(selectValue(html, 'Network')).toBe('On');
   expect(selectOptionLabels(html, 'Text size')).toEqual(['S', 'M', 'L', 'XL']);
   expect(selectValue(html, 'Text size')).toBe('M');
+});
+
+test('renders the Android display-size control the backend reports', () => {
+  const client = {
+    ...inspectorClient('android'),
+    deviceSettings: {
+      appearance: 'light',
+      network: 'on',
+      'text-size': 'medium',
+      'display-size': 'large',
+    },
+  };
+  const html = renderToStaticMarkup(<LogSidebar client={client} />);
+
+  expect(selectOptionLabels(html, 'Display size')).toEqual(['S', 'M', 'L', 'XL']);
+  expect(selectValue(html, 'Display size')).toBe('L');
+});
+
+test('describes the Android display-size control with the resulting dp width', () => {
+  const client = {
+    ...inspectorClient('android'),
+    deviceSettings: {
+      appearance: 'light',
+      network: 'on',
+      'text-size': 'medium',
+      'display-size': 'large',
+    },
+    displayWidthDp: 411,
+  };
+  const html = renderToStaticMarkup(<LogSidebar client={client} />);
+  const describedBy = /aria-describedby="([^"]+)"/.exec(selectMarkup(html, 'Display size'))?.[1];
+
+  expect(html).toContain('>sw411dp<');
+  expect(describedBy).toBeTruthy();
+  expect(html).toContain(`id="${describedBy}"`);
+});
+
+test('omits the dp width when the Android device has not reported one', () => {
+  const client = {
+    ...inspectorClient('android'),
+    deviceSettings: {
+      appearance: 'light',
+      network: 'on',
+      'text-size': 'medium',
+      'display-size': 'large',
+    },
+  };
+  const html = renderToStaticMarkup(<LogSidebar client={client} />);
+
+  expect(html).not.toMatch(/sw\d+dp/);
+  expect(selectMarkup(html, 'Display size')).not.toContain('aria-describedby');
+});
+
+test('omits the Android display-size control the backend does not report', () => {
+  const html = renderToStaticMarkup(<LogSidebar client={inspectorClient('android')} />);
+
+  expect(html).not.toContain('>Display size<');
+});
+
+test('never renders the Android-only display-size control on iOS', () => {
+  const client = {
+    ...inspectorClient('ios'),
+    deviceSettings: { ...inspectorClient('ios').deviceSettings, 'display-size': 'large' },
+  };
+  const html = renderToStaticMarkup(<LogSidebar client={client} />);
+
+  expect(html).not.toContain('>Display size<');
 });
 
 test('renders the Android accessibility switches the backend reports', () => {


### PR DESCRIPTION
## Summary

- add the `display-size` key to `DeviceSettingKey`, the Android settings table, and the options UI as an S / M / L / XL select under Text size
- show the resulting smallest-width dp (`sw411dp`) beneath the row
- collapse the duplicated four-step scale into one `ANDROID_SIZE_SCALES` table shared by `text-size` and `display-size`
- add a minor changeset

## Depends on

**expo/serve-emu#26**, through #44. `/api/display-density` comes from the submodule bump in that layer, so this PR adds no server code.

## Context

This is Android's Display size accessibility setting. It changes the actual framebuffer layout rather than a display filter, so it is visible in the Hub stream and affects every app, and iOS has no equivalent.

The route takes a *scale*, not an absolute dpi, because `wm density` needs an absolute value and only the device knows its own physical density. serve-emu reads `wm density`, which returns `Physical density: N` plus an optional `Override density: M` in one call, and resolves the scale against the physical value. `medium` issues `wm density reset` rather than writing the physical density back, so the default leaves the device with no override at all.

"Display size XL" is ambiguous on its own, because it makes UI elements larger while making the usable screen *smaller* in dp. The `swNNNdp` readout resolves that, and it is the number a layout developer actually reasons about. `DeviceSettings` holds one opaque string per key and `display-size` has to stay the step name for the select's shown value, so the dp travels as its own `DeviceClient` field rather than riding the setting value.

The shared step table lands in the same commit so the second four-step scale does not arrive alongside a duplicate of the first. `AndroidTextSize`, `androidFontScaleForTextSize` and `androidTextSizeForFontScale` are kept as aliases over the generic helpers purely so the existing text-size assertions stay untouched, which is the evidence the reshape preserves behavior. Migrating that test to the generic names and deleting the three aliases is a clean follow-up.

`ANDROID_DISPLAY_SIZE_OPTIONS` duplicates `ANDROID_TEXT_SIZE_OPTIONS` today. Kept separate because the file's pattern is one options table per control, and because the two step lists should be free to diverge.

### Two changes since the first review

The control is a `Select`, not a segmented control. `main`'s sidebar redesign (#55) converted every device setting to `Select` and deleted `SETTING_ORDER`, `hasFollowingRow`, `pillOptions`, and the `compact` and `borderBottom` row props this row used. The row is now a plain `SidebarRow` with `description` and `descriptionId`, which still carries the `swNNNdp` line and its `aria-describedby`. The five tests moved from the deleted `segmentedControlMarkup` helper to `selectMarkup`, `selectValue` and `selectOptionLabels`.

The route moved to serve-emu. This layer originally added `/api/display-density` to the in-repo compatibility layer; #39 deleted that file once `/api/network` and `/api/font-scale` landed upstream, so this follows the same path.

## Verification

- `bun run typecheck` — 11 tasks successful
- `bun run test` — 539 passed, 0 failed (174 in `expo-device-hub`)
- `bun run lint` — 0 warnings, 0 errors
- `bunx changeset status` — only `expo-device-hub` bumped, at minor
- `packages/expo-device-hub` defines no `typecheck` script, so the root gate never reads its source. `turbo run typecheck --dry-run=json` reports `expo-device-hub#typecheck -> <NONEXISTENT>`. Ran `tsc --noEmit` in that package directly: 206 error headers, all 206 in `vendor/serve-emu/` (mostly TS5097 on `.ts` import extensions in the vendored copy), none in `src`. This gap predates the stack and affects the layers below too.
- Wire contract checked against the built bundle rather than the source: `/api/display-density` and its `displayDensity` response key both appear in `vendor/serve-emu/dist/middleware.js`, and the client reads `displayDensity.scale` and `displayDensity.widthDp`.
- End to end against a booted API 36 emulator: each step written through the real route and confirmed with `adb`, including `large` producing `Override density: 483` and `medium` clearing the override line entirely.
- The dp readout checked against Android itself, not against the formula. Clicking S in the browser moved the device to density 357, the row changed to `sw484dp`, and `adb shell am get-config` independently reported `-sw484dp`. The four pinned test pairs come from that same command at the four step densities.
- The two end-to-end runs predate the move to serve-emu. The adb commands and the response envelope are unchanged, so they now stand as evidence for serve-emu's implementation of the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
