### PR TITLE
Distinguish rotate icon from reload icon

### DIFF
--- a/packages/@expo/hub-components/src/components/icons.tsx
+++ b/packages/@expo/hub-components/src/components/icons.tsx
@@ -41,7 +41,7 @@ export function RefreshIcon({ size = 16, color = 'currentColor', strokeWidth = 1
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={style}>
       <path
-        d="M21 12a9 9 0 1 1-2.64-6.36M21 3v4.5h-4.5"
+        d="M21 12A9 9 0 1 1 18.36 5.64L20.72 8M17.12 8H20.72V4.4"
         stroke={color}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
@@ -127,14 +127,14 @@ export function SidebarIcon({ size = 20, color = 'currentColor', strokeWidth = 1
 export function RotateIcon({ size = 16, color = 'currentColor', strokeWidth = 1.67, style }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={style}>
+      <rect x="4.1" y="8" width="9" height="11.6" rx="2.3" stroke={color} strokeWidth={strokeWidth} />
       <path
-        d="M21 12a9 9 0 1 1-3-6.7L21 8"
+        d="M8.6 4.1A9.7 9.7 0 0 1 18.3 13.8M16.18 11.68 18.3 13.8 20.42 11.68"
         stroke={color}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M21 3v5h-5" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }


### PR DESCRIPTION
## Why

I admit this doesn't follow any designs atm.

`RotateIcon` and `RefreshIcon` drew the same 270° circular arrow, so the Rotate menu item and the Reload button were indistinguishable.

`RefreshIcon`'s arrowhead was also detached from its arc: an L-bracket with its vertex at `21, 7.5` — 10.06 units from the centre of a radius-9 circle, and 3.23 units from where the arc stopped.

## What changed

`packages/@expo/hub-components/src/components/icons.tsx`


Both heads follow one rule: the vertex is the arc's end point, and the arms sit astride the tangent there.

## Test plan

Rendered both icons at 16 / 20 / 24 / 40 / 64 px on light and dark grounds, and in a mock of the stream-controls dropdown. They are legible and distinct at every size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)