### PR TITLE
Default Android streaming to gRPC MMAP

### DIFF
--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -57,18 +57,18 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
-For Android, the standalone CLI can start directly with the emulator screenshot gRPC
-source and choose how each frame reaches the host. PNG sends a compressed image in the
-gRPC message; MMAP sends frame metadata over gRPC while the emulator writes RGB pixels
-to a shared file-backed memory region:
+Android streams use the emulator screenshot gRPC source with MMAP delivery by default,
+both in the Expo CLI plugin and the standalone CLI. MMAP sends frame metadata over gRPC
+while the emulator writes RGB pixels to a shared file-backed memory region:
 
 ```sh
-npx expo-device-hub --platform android --transport webrtc \
-  --stream-source grpc-screenshot --grpc-image-mode mmap
+npx expo-device-hub --platform android --transport webrtc
 ```
 
-The same PNG/MMAP choice is available at runtime under **Stream options** while the gRPC
-capture source is active. Run `npx expo-device-hub --help` for the full option list.
+Use `--stream-source scrcpy` to select scrcpy at startup, or `--grpc-image-mode png` to
+send a compressed image in each gRPC message. The same source and PNG/MMAP choices are
+available at runtime under **Stream options**. Run `npx expo-device-hub --help` for the
+full option list.
 
 MMAP support is experimental and depends on the Android Emulator build. Google
 tracks an Apple Silicon `streamScreenshot` MMAP fix as issue

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -213,6 +213,13 @@ describe('parseCliOptions', () => {
     expect(HELP).toContain('used when the gRPC source is active');
   });
 
+  test('documents the default Android gRPC MMAP stream', () => {
+    expect(HELP).toContain('--stream-source <source>');
+    expect(HELP).toContain('(default: grpc-screenshot)');
+    expect(HELP).toContain('--grpc-image-mode <mode>');
+    expect(HELP).toContain('default: mmap');
+  });
+
   test('hides the device list sidebar on request', () => {
     expect(parseCliOptions(['--hide-sidebar']).hideSidebar).toBe(true);
     expect(HELP).toContain('--hide-sidebar');

--- a/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
@@ -9,20 +9,28 @@ import {
   standaloneServeEmuOptions,
 } from '../serve-emu-options';
 
+const DEFAULT_ANDROID_STREAM = {
+  streamMode: 'grpc-screenshot',
+  grpcImageMode: 'mmap',
+} as const;
+
 describe('standaloneServeEmuOptions', () => {
-  test('uses serve-emu WebSocket defaults without Hub stream flags', () => {
+  test('defaults Android streaming to gRPC with MMAP', () => {
     expect(standaloneServeEmuOptions(parseCliOptions([]))).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: { transport: 'websocket' },
     });
     expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'mjpeg']))).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: { transport: 'websocket' },
     });
     expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'h264']))).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: { transport: 'websocket' },
     });
   });
 
-  test('maps shared encoder flags onto scrcpy startup options', () => {
+  test('maps shared encoder flags onto Android startup options', () => {
     expect(
       standaloneServeEmuOptions(
         parseCliOptions([
@@ -37,6 +45,7 @@ describe('standaloneServeEmuOptions', () => {
         ]),
       ),
     ).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       maxSize: 1280,
       bitRate: 4_000_000,
       maxFps: 24,
@@ -44,19 +53,19 @@ describe('standaloneServeEmuOptions', () => {
     });
   });
 
-  test('maps the selected gRPC source and MMAP image mode', () => {
+  test('allows opting out of the gRPC and MMAP defaults', () => {
     expect(
       standaloneServeEmuOptions(
         parseCliOptions([
           '--stream-source',
-          'grpc-screenshot',
+          'scrcpy',
           '--grpc-image-mode',
-          'mmap',
+          'png',
         ]),
       ),
     ).toEqual({
-      streamMode: 'grpc-screenshot',
-      grpcImageMode: 'mmap',
+      streamMode: 'scrcpy',
+      grpcImageMode: 'png',
       streamSettings: { transport: 'websocket' },
     });
   });
@@ -82,6 +91,7 @@ describe('standaloneServeEmuOptions', () => {
         ]),
       ),
     ).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: {
         transport: 'webrtc',
         codec: 'h264',
@@ -100,6 +110,7 @@ describe('standaloneServeEmuOptions', () => {
 
   test('uses serve-emu WebRTC ICE defaults', () => {
     expect(standaloneServeEmuOptions(parseCliOptions(['--transport', 'webrtc']))).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: {
         transport: 'webrtc',
         codec: 'h264',
@@ -129,21 +140,20 @@ describe('standaloneServeEmuOptions', () => {
     });
   });
 
-  test('round-trips through the server environment payload', () => {
-    const options = parseCliOptions([
-      '--transport',
-      'webrtc',
-      '--video-fps',
-      '30',
-      '--stream-source',
-      'grpc-screenshot',
-      '--grpc-image-mode',
-      'mmap',
-    ]);
+  test('round-trips the defaults through the standalone server environment payload', () => {
+    const options = parseCliOptions(['--transport', 'webrtc', '--video-fps', '30']);
     expect(readStandaloneServeEmuOptions(encodeStandaloneServeEmuOptions(options))).toEqual(
       standaloneServeEmuOptions(options),
     );
+  });
+
+  test('uses the defaults when loaded as an Expo CLI plugin without a payload', () => {
+    expect(readStandaloneServeEmuOptions(undefined)).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
+      streamSettings: { transport: 'websocket' },
+    });
     expect(readStandaloneServeEmuOptions('not json')).toEqual({
+      ...DEFAULT_ANDROID_STREAM,
       streamSettings: { transport: 'websocket' },
     });
   });

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -18,8 +18,10 @@ export const WEBRTC_ICE_POLICIES = ['all', 'relay'] as const;
 export type WebRtcIcePolicy = (typeof WEBRTC_ICE_POLICIES)[number];
 export const ANDROID_STREAM_SOURCES = ['scrcpy', 'grpc-screenshot'] as const;
 export type AndroidStreamSource = (typeof ANDROID_STREAM_SOURCES)[number];
+export const DEFAULT_ANDROID_STREAM_SOURCE: AndroidStreamSource = 'grpc-screenshot';
 export const GRPC_IMAGE_MODES = ['png', 'mmap'] as const;
 export type GrpcImageMode = (typeof GRPC_IMAGE_MODES)[number];
+export const DEFAULT_GRPC_IMAGE_MODE: GrpcImageMode = 'mmap';
 
 export const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
 
@@ -35,8 +37,8 @@ Options:
       --mjpeg-quality <quality> MJPEG quality (0.05-1)
       --video-bitrate <bps>  H.264/WebRTC target bitrate (100000-50000000)
       --video-fps <fps>      H.264/WebRTC frame rate (1-120)
-      --stream-source <source> Android capture source: ${ANDROID_STREAM_SOURCES.join(', ')} (default: scrcpy)
-      --grpc-image-mode <mode> gRPC frames: ${GRPC_IMAGE_MODES.join(', ')} (default: png; used when the gRPC source is active)
+      --stream-source <source> Android capture source: ${ANDROID_STREAM_SOURCES.join(', ')} (default: ${DEFAULT_ANDROID_STREAM_SOURCE})
+      --grpc-image-mode <mode> gRPC frames: ${GRPC_IMAGE_MODES.join(', ')} (default: ${DEFAULT_GRPC_IMAGE_MODE}; used when the gRPC source is active)
       --stun-url <urls>      Comma-separated STUN URL(s) for WebRTC ICE
       --turn-url <urls>      Comma-separated TURN URL(s) for WebRTC ICE
       --turn-username <name> TURN username (requires --turn-credential and --turn-url)

--- a/packages/expo-device-hub/src/server/serve-emu-options.ts
+++ b/packages/expo-device-hub/src/server/serve-emu-options.ts
@@ -1,4 +1,6 @@
 import {
+  DEFAULT_ANDROID_STREAM_SOURCE,
+  DEFAULT_GRPC_IMAGE_MODE,
   DEFAULT_WEBRTC_ICE_POLICY,
   type AndroidStreamSource,
   type CliOptions,
@@ -38,6 +40,14 @@ export type StandaloneServeEmuOptions = {
   streamSettings: StandaloneServeEmuStreamSettings;
 };
 
+function defaultServeEmuOptions(): StandaloneServeEmuOptions {
+  return {
+    streamMode: DEFAULT_ANDROID_STREAM_SOURCE,
+    grpcImageMode: DEFAULT_GRPC_IMAGE_MODE,
+    streamSettings: { transport: 'websocket' },
+  };
+}
+
 function webRtcIceServers(options: CliOptions): StandaloneServeEmuIceServer[] {
   const iceServers: StandaloneServeEmuIceServer[] = options.stunUrls
     ? [{ urls: options.stunUrls }]
@@ -61,8 +71,8 @@ export function standaloneServeEmuOptions(options: CliOptions): StandaloneServeE
     ...(options.videoFps !== undefined ? { maxFps: options.videoFps } : {}),
     ...(options.videoBitrate !== undefined ? { bitRate: options.videoBitrate } : {}),
     ...(options.maxDimension !== undefined ? { maxSize: options.maxDimension } : {}),
-    ...(options.streamSource !== undefined ? { streamMode: options.streamSource } : {}),
-    ...(options.grpcImageMode !== undefined ? { grpcImageMode: options.grpcImageMode } : {}),
+    streamMode: options.streamSource ?? DEFAULT_ANDROID_STREAM_SOURCE,
+    grpcImageMode: options.grpcImageMode ?? DEFAULT_GRPC_IMAGE_MODE,
     streamSettings:
       options.transport === 'webrtc'
         ? {
@@ -84,14 +94,14 @@ export function encodeStandaloneServeEmuOptions(options: CliOptions): string {
 export function readStandaloneServeEmuOptions(
   value: string | undefined,
 ): StandaloneServeEmuOptions {
-  if (!value) return { streamSettings: { transport: 'websocket' } };
+  if (!value) return defaultServeEmuOptions();
   try {
     const parsed = JSON.parse(value);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as StandaloneServeEmuOptions)
-      : { streamSettings: { transport: 'websocket' } };
+      ? { ...defaultServeEmuOptions(), ...(parsed as Partial<StandaloneServeEmuOptions>) }
+      : defaultServeEmuOptions();
   } catch {
-    return { streamSettings: { transport: 'websocket' } };
+    return defaultServeEmuOptions();
   }
 }
 


### PR DESCRIPTION
## Summary

- default Android emulator streaming to `grpc-screenshot` with `mmap` frame delivery
- apply the same defaults to standalone CLI payloads and Expo CLI plugin startup
- preserve `--stream-source scrcpy` and `--grpc-image-mode png` as explicit overrides
- update CLI help, tests, and package documentation

Depends on #41.

## Test plan

- [x] `bun run test --filter=expo-device-hub`
- [x] `bun run typecheck --filter=expo-device-hub`
- [x] `bun run build --filter=expo-device-hub`
- [x] verify the built Node.js CLI reports gRPC/MMAP defaults in `--help`

— Codex (GPT-5)