### PR TITLE
fix(release): skip ignored canary packages

### DIFF
--- a/scripts/apply-canary-version.ts
+++ b/scripts/apply-canary-version.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun";
+import { getChangesetIgnoreList } from "./lib/changeset-ignore.ts";
 import { getPublicPackages } from "./lib/public-packages.ts";
 
 // Rewrites each public package's version into a canary prerelease. Versions
@@ -24,7 +25,13 @@ const sha = (await $`git rev-parse --short HEAD`.text()).trim();
 const date = new Date().toISOString().slice(0, 10).replaceAll("-", "");
 
 console.log(`::group::Applying canary versions (date ${date}, commit ${sha})`);
+const ignore = await getChangesetIgnoreList();
 for (const pkg of await getPublicPackages()) {
+  if (ignore.has(pkg.name)) {
+    console.log(`${pkg.name}: skipped (excluded from release)`);
+    continue;
+  }
+
   const path = `${pkg.dir}/package.json`;
   const json = await Bun.file(path).json();
   const committedVersion = JSON.parse(

--- a/scripts/ignore-packages.ts
+++ b/scripts/ignore-packages.ts
@@ -1,17 +1,7 @@
 #!/usr/bin/env bun
 
+import { getChangesetIgnoreList } from "./lib/changeset-ignore.ts";
 import { getPublicPackages } from "./lib/public-packages.ts";
-
-async function getChangesetIgnoreList(
-  root = process.cwd(),
-): Promise<Set<string>> {
-  const changesetConfig = await Bun.file(
-    `${root}/.changeset/config.json`,
-  ).json();
-  return new Set<string>(
-    Array.isArray(changesetConfig.ignore) ? changesetConfig.ignore : [],
-  );
-}
 
 const root = process.cwd();
 

--- a/scripts/lib/changeset-ignore.ts
+++ b/scripts/lib/changeset-ignore.ts
@@ -1,0 +1,10 @@
+export async function getChangesetIgnoreList(
+  root = process.cwd(),
+): Promise<Set<string>> {
+  const changesetConfig = await Bun.file(
+    `${root}/.changeset/config.json`,
+  ).json();
+  return new Set<string>(
+    Array.isArray(changesetConfig.ignore) ? changesetConfig.ignore : [],
+  );
+}


### PR DESCRIPTION
## Summary

- skip Changesets-ignored workspaces during canary versioning
- share the Changesets ignore-list reader with the publish exclusion step
- avoid reading or rewriting vendored submodule package versions

## Why

Canary releases attempted to read vendored package manifests from the parent Git tree, causing the release job to fail. Those packages are excluded from publishing and should not participate in canary versioning.

## Verification

- ran the canary version script and confirmed only expo-device-hub was versioned
- bun run test
- bun run typecheck
- bun run lint
- git diff --check

— Codex (GPT-5)