### PR TITLE
Add input source selector for gRPC streaming

### DIFF
--- a/.changeset/grpc-scrcpy-input.md
+++ b/.changeset/grpc-scrcpy-input.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add selectable scrcpy and emulator-gRPC input delivery for gRPC Android streams, defaulting gRPC capture to scrcpy input.

--- a/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
@@ -9,12 +9,16 @@ describe('parseAndroidStreamSource', () => {
         ok: true,
         mode: 'grpc-screenshot',
         grpcImageMode: 'mmap',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
         availableModes: ['scrcpy', 'grpc-screenshot'],
         sessionGeneration: 4,
       }),
     ).toEqual({
       mode: 'grpc-screenshot',
       grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 4,
     });
@@ -24,10 +28,28 @@ describe('parseAndroidStreamSource', () => {
     const response = {
       ok: true,
       mode: 'grpc-screenshot',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 1,
     };
     expect(parseAndroidStreamSource(response)).toBeNull();
     expect(parseAndroidStreamSource({ ...response, grpcImageMode: 'rgb' })).toBeNull();
+  });
+
+  test('rejects unavailable or unsupported input sources', () => {
+    const response = {
+      ok: true,
+      mode: 'grpc-screenshot',
+      grpcImageMode: 'png',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
+      availableModes: ['scrcpy', 'grpc-screenshot'],
+      sessionGeneration: 1,
+    };
+    expect(parseAndroidStreamSource({ ...response, inputSource: 'adb' })).toBeNull();
+    expect(
+      parseAndroidStreamSource({ ...response, availableInputSources: ['grpc'] }),
+    ).toBeNull();
   });
 });

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -128,12 +128,16 @@ describe('serve-emu capture source contract', () => {
         serial: 'emulator-5554',
         mode: 'grpc-screenshot',
         grpcImageMode: 'mmap',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
         availableModes: ['scrcpy', 'grpc-screenshot'],
         sessionGeneration: 2,
       }),
     ).toEqual({
       mode: 'grpc-screenshot',
       grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 2,
     });
@@ -143,12 +147,16 @@ describe('serve-emu capture source contract', () => {
         serial: 'usb-device',
         mode: 'scrcpy',
         grpcImageMode: 'png',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy'],
         availableModes: ['scrcpy'],
         sessionGeneration: 0,
       }),
     ).toEqual({
       mode: 'scrcpy',
       grpcImageMode: 'png',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy'],
       availableModes: ['scrcpy'],
       sessionGeneration: 0,
     });

--- a/packages/@expo/hub-client/src/android-stream-source.ts
+++ b/packages/@expo/hub-client/src/android-stream-source.ts
@@ -1,5 +1,6 @@
 import {
   type DeviceGrpcImageMode,
+  type DeviceInputSource,
   type DeviceStreamSource,
   type DeviceStreamSourceStatus,
 } from './types';
@@ -34,6 +35,10 @@ function isGrpcImageMode(value: unknown): value is DeviceGrpcImageMode {
   return value === 'png' || value === 'mmap';
 }
 
+function isInputSource(value: unknown): value is DeviceInputSource {
+  return value === 'scrcpy' || value === 'grpc';
+}
+
 /** Parse serve-emu's authoritative device-scoped `/api/stream-mode` response. */
 export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStatus | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
@@ -41,7 +46,17 @@ export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStat
   if (
     candidate.ok !== true ||
     !isAndroidStreamSource(candidate.mode) ||
-    !isGrpcImageMode(candidate.grpcImageMode)
+    !isGrpcImageMode(candidate.grpcImageMode) ||
+    !isInputSource(candidate.inputSource)
+  ) {
+    return null;
+  }
+  if (
+    !Array.isArray(candidate.availableInputSources) ||
+    candidate.availableInputSources.length === 0 ||
+    !candidate.availableInputSources.every(isInputSource) ||
+    new Set(candidate.availableInputSources).size !== candidate.availableInputSources.length ||
+    !candidate.availableInputSources.includes(candidate.inputSource)
   ) {
     return null;
   }
@@ -64,6 +79,8 @@ export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStat
   return {
     mode: candidate.mode,
     grpcImageMode: candidate.grpcImageMode,
+    inputSource: candidate.inputSource,
+    availableInputSources: candidate.availableInputSources,
     availableModes: candidate.availableModes,
     sessionGeneration: candidate.sessionGeneration,
   };

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -152,10 +152,15 @@ export type DeviceStreamSource = 'scrcpy' | 'grpc-screenshot';
 /** Pixel delivery selected for the emulator gRPC screenshot source. */
 export type DeviceGrpcImageMode = 'png' | 'mmap';
 
+/** Input transport used while gRPC provides emulator video. */
+export type DeviceInputSource = 'scrcpy' | 'grpc';
+
 /** Authoritative source state for the selected Android device session. */
 export interface DeviceStreamSourceStatus {
   mode: DeviceStreamSource;
   grpcImageMode: DeviceGrpcImageMode;
+  inputSource: DeviceInputSource;
+  availableInputSources: readonly DeviceInputSource[];
   availableModes: readonly DeviceStreamSource[];
   sessionGeneration: number;
 }
@@ -468,6 +473,8 @@ export interface DeviceClient {
   setStreamSource: (source: DeviceStreamSource) => void;
   /** Restart the gRPC source with compressed PNG or shared-memory RGB delivery. */
   setGrpcImageMode: (mode: DeviceGrpcImageMode) => void;
+  /** Restart gRPC streaming with scrcpy or emulator-gRPC input delivery. */
+  setGrpcInputSource: (source: DeviceInputSource) => void;
   /** Live WebRTC stream telemetry; null for HTTP/WebSocket transports. */
   streamStats: DeviceStreamStats | null;
   /** Enable telemetry polling while a consumer is displaying WebRTC statistics. */

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -56,6 +56,7 @@ import {
   type DeviceConnectionOptions,
   type DeviceEvent,
   type DeviceGrpcImageMode,
+  type DeviceInputSource,
   type DeviceLog,
   type DeviceSettingKey,
   type DeviceSettings,
@@ -448,7 +449,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   });
 
   const putStreamMode = useCallback(
-    (body: { mode: DeviceStreamSource; grpcImageMode?: DeviceGrpcImageMode }) => {
+    (body: {
+      mode: DeviceStreamSource;
+      grpcImageMode?: DeviceGrpcImageMode;
+      inputSource?: DeviceInputSource;
+    }) => {
       if (!streamSourceUrl || streamSourcePendingRef.current) return;
       const request = ++streamSourceRequestRef.current;
       const controller = new AbortController();
@@ -510,7 +515,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       ) {
         return;
       }
-      putStreamMode({ mode: source });
+      putStreamMode({
+        mode: source,
+        ...(source === 'grpc-screenshot' ? { inputSource: 'scrcpy' as const } : {}),
+      });
     },
     [putStreamMode],
   );
@@ -525,7 +533,31 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       ) {
         return;
       }
-      putStreamMode({ mode: previous.mode, grpcImageMode });
+      putStreamMode({
+        mode: previous.mode,
+        grpcImageMode,
+        inputSource: previous.inputSource,
+      });
+    },
+    [putStreamMode],
+  );
+
+  const setGrpcInputSource = useCallback(
+    (inputSource: DeviceInputSource) => {
+      const previous = streamSourceRef.current;
+      if (
+        !previous ||
+        previous.mode !== 'grpc-screenshot' ||
+        previous.inputSource === inputSource ||
+        !previous.availableInputSources.includes(inputSource)
+      ) {
+        return;
+      }
+      putStreamMode({
+        mode: previous.mode,
+        grpcImageMode: previous.grpcImageMode,
+        inputSource,
+      });
     },
     [putStreamMode],
   );
@@ -555,8 +587,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           setStreamSourceState((current) =>
             current?.mode === next.mode &&
             current.grpcImageMode === next.grpcImageMode &&
+            current.inputSource === next.inputSource &&
             current.sessionGeneration === next.sessionGeneration &&
-            current.availableModes.join() === next.availableModes.join()
+            current.availableModes.join() === next.availableModes.join() &&
+            current.availableInputSources.join() === next.availableInputSources.join()
               ? current
               : next,
           );
@@ -1473,6 +1507,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     streamSourceError,
     setStreamSource,
     setGrpcImageMode,
+    setGrpcInputSource,
     streamStats,
     setStreamStatsEnabled,
     webRtcCodec: 'h264',

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -515,10 +515,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       ) {
         return;
       }
-      putStreamMode({
-        mode: source,
-        ...(source === 'grpc-screenshot' ? { inputSource: 'scrcpy' as const } : {}),
-      });
+      putStreamMode({ mode: source });
     },
     [putStreamMode],
   );

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -1360,6 +1360,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     streamSourceError: null,
     setStreamSource: () => {},
     setGrpcImageMode: () => {},
+    setGrpcInputSource: () => {},
     streamStats,
     setStreamStatsEnabled,
     webRtcCodec,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -32,6 +32,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   streamSourceError: null,
   setStreamSource: () => {},
   setGrpcImageMode: () => {},
+  setGrpcInputSource: () => {},
   streamStats: null,
   setStreamStatsEnabled: () => {},
   webRtcCodec: 'h264',

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -4,6 +4,7 @@ import {
   type DeviceClient,
   type DeviceGrpcImageMode,
   type DeviceHttpCodec,
+  type DeviceInputSource,
   type DeviceStreamCapabilities,
   type DeviceStreamEncoderSettings,
   type DeviceStreamMode,
@@ -66,6 +67,13 @@ const GRPC_IMAGE_MODE_OPTIONS: ReadonlyArray<{
 }> = [
   { value: 'png', label: 'PNG' },
   { value: 'mmap', label: 'MMAP' },
+];
+const GRPC_INPUT_SOURCE_OPTIONS: ReadonlyArray<{
+  value: DeviceInputSource;
+  label: string;
+}> = [
+  { value: 'scrcpy', label: 'scrcpy' },
+  { value: 'grpc', label: 'gRPC' },
 ];
 const STREAM_SETTING_ORDER: readonly (keyof DeviceStreamEncoderSettings)[] = [
   'maxDimension',
@@ -173,6 +181,9 @@ export function StreamOptionsSection({
   const sourceOptions = STREAM_SOURCE_OPTIONS.filter((option) =>
     streamSource?.availableModes.includes(option.value),
   );
+  const inputSourceOptions = GRPC_INPUT_SOURCE_OPTIONS.filter((option) =>
+    streamSource?.availableInputSources.includes(option.value),
+  );
   const settingsReady = client.streamSettings !== null;
   const settingsDisabled = !settingsReady || client.streamSettingsPending;
   const transport: StreamTransport =
@@ -272,17 +283,32 @@ export function StreamOptionsSection({
         </>
       )}
       {streamSource?.mode === 'grpc-screenshot' && (
-        <SidebarRow label="gRPC frames">
-          <SegmentedControl
-            ariaLabel="gRPC image mode"
-            options={GRPC_IMAGE_MODE_OPTIONS.map((option) => ({
-              ...option,
-              disabled: client.streamSourcePending,
-            }))}
-            value={streamSource.grpcImageMode}
-            onChange={client.setGrpcImageMode}
-          />
-        </SidebarRow>
+        <>
+          {inputSourceOptions.length > 1 && (
+            <SidebarRow label="Input">
+              <SegmentedControl
+                ariaLabel="Input source"
+                options={inputSourceOptions.map((option) => ({
+                  ...option,
+                  disabled: client.streamSourcePending,
+                }))}
+                value={streamSource.inputSource}
+                onChange={client.setGrpcInputSource}
+              />
+            </SidebarRow>
+          )}
+          <SidebarRow label="gRPC frames">
+            <SegmentedControl
+              ariaLabel="gRPC image mode"
+              options={GRPC_IMAGE_MODE_OPTIONS.map((option) => ({
+                ...option,
+                disabled: client.streamSourcePending,
+              }))}
+              value={streamSource.grpcImageMode}
+              onChange={client.setGrpcImageMode}
+            />
+          </SidebarRow>
+        </>
       )}
       <SidebarRow label="Transport">
         <SegmentedControl

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -71,6 +71,8 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       : {
           mode: 'scrcpy',
           grpcImageMode: 'png',
+          inputSource: 'scrcpy',
+          availableInputSources: ['scrcpy'],
           availableModes: ['scrcpy', 'grpc-screenshot'],
           sessionGeneration: 0,
         },
@@ -78,6 +80,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
     streamSourceError: null,
     setStreamSource: () => {},
     setGrpcImageMode: () => {},
+    setGrpcInputSource: () => {},
     streamStats: null,
     setStreamStatsEnabled: () => {},
     webRtcCodec: 'h264',
@@ -361,6 +364,8 @@ test('shows PNG and MMAP only while the gRPC source is active', () => {
     streamSource: {
       mode: 'grpc-screenshot',
       grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 1,
     },
@@ -369,7 +374,12 @@ test('shows PNG and MMAP only while the gRPC source is active', () => {
     <StreamOptionsSection client={grpcClient} defaultOpen />,
   );
   const imageMode = segmentedControlMarkup(grpcHtml, 'gRPC image mode');
+  const inputSource = segmentedControlMarkup(grpcHtml, 'Input source');
 
+  expect(grpcHtml).toContain('>Input</span>');
+  expect(inputSource).toContain('>scrcpy</button>');
+  expect(inputSource).toContain('>gRPC</button>');
+  expect(inputSource).toMatch(/aria-pressed="true"[^>]*>scrcpy<\/button>/);
   expect(grpcHtml).toContain('>gRPC frames</span>');
   expect(imageMode).toContain('>PNG</button>');
   expect(imageMode).toContain('>MMAP</button>');
@@ -406,6 +416,8 @@ test('hides the Android capture source row when gRPC is unavailable', () => {
     streamSource: {
       mode: 'scrcpy',
       grpcImageMode: 'png',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy'],
       availableModes: ['scrcpy'],
       sessionGeneration: 0,
     },


### PR DESCRIPTION
## Summary

This fixes keyboard input not working for emulators which are started with hw keyboard setting disabled. `scrcpy` input works regardless the emulator settings.

- show an Input selector when the Android stream source is gRPC
- default gRPC video to scrcpy input, with gRPC input still selectable
- keep input source and gRPC frame mode consistent across stream restarts
- pin the serve-emu transport implementation from https://github.com/expo/serve-emu/pull/20

## Testing

- bun run typecheck
- bun run test
- bun run lint
- serve-emu: bun run check
- integrated Codex browser against Android emulator: switched scrcpy → gRPC → scrcpy input, then triggered Home; stream remained live

## Screenshot

![Expo Device Hub showing gRPC streaming with scrcpy input selected](https://gist.githubusercontent.com/krystofwoldrich/38a91e0df4fb6cdda1e4c5e18f58cb2f/raw/grpc-scrcpy-input-full-ui.svg)

— Codex (GPT-5.6)