### PR TITLE
Add VP8 and VP9 Android gRPC stream options

### DIFF
--- a/.changeset/calm-codecs-stream.md
+++ b/.changeset/calm-codecs-stream.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add selectable H.264, VP8, and VP9 host encoding for Android emulator gRPC WebSocket streams.

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ registers the plugin against itself, so the standalone app still gets the real
 
 [`@expo/hub-client`](packages/@expo/hub-client) is the **device-client layer**. The
 two backends speak very different wire protocols — serve-sim streams MJPEG/H.264 and
-takes binary touch packets, while serve-emu streams H.264 (WebCodecs) and takes JSON
-gestures — so this package hides that behind one shared contract:
+takes binary touch packets, while serve-emu streams H.264, VP8, or VP9 through
+WebCodecs and takes JSON gestures — so this package hides that behind one shared contract:
 
 - a hook (`useIosDeviceClient` / `useAndroidDeviceClient` and general
   `useActiveDeviceClient`) that owns the WebSocket connection and exposes the live

--- a/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 
-import { parseAndroidStreamSource } from '../android-stream-source';
+import {
+  androidStreamSourceSupportsWebRtc,
+  parseAndroidStreamSource,
+} from '../android-stream-source';
 
 describe('parseAndroidStreamSource', () => {
   test('parses the authoritative gRPC image mode', () => {
@@ -11,6 +14,7 @@ describe('parseAndroidStreamSource', () => {
         grpcImageMode: 'mmap',
         inputSource: 'scrcpy',
         availableInputSources: ['scrcpy', 'grpc'],
+        grpcVideoCodec: 'vp9',
         availableModes: ['scrcpy', 'grpc-screenshot'],
         sessionGeneration: 4,
       }),
@@ -19,9 +23,72 @@ describe('parseAndroidStreamSource', () => {
       grpcImageMode: 'mmap',
       inputSource: 'scrcpy',
       availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'vp9',
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 4,
     });
+  });
+
+  test('uses WebRTC only for sources backed by H.264', () => {
+    expect(androidStreamSourceSupportsWebRtc(null)).toBeTrue();
+    expect(
+      androidStreamSourceSupportsWebRtc({
+        mode: 'scrcpy',
+        grpcImageMode: 'png',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy'],
+        grpcVideoCodec: 'vp9',
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 1,
+      }),
+    ).toBeTrue();
+    expect(
+      androidStreamSourceSupportsWebRtc({
+        mode: 'grpc-screenshot',
+        grpcImageMode: 'mmap',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
+        grpcVideoCodec: 'h264',
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 2,
+      }),
+    ).toBeTrue();
+    expect(
+      androidStreamSourceSupportsWebRtc({
+        mode: 'grpc-screenshot',
+        grpcImageMode: 'mmap',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
+        grpcVideoCodec: 'vp8',
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 3,
+      }),
+    ).toBeFalse();
+    expect(
+      androidStreamSourceSupportsWebRtc({
+        mode: 'grpc-screenshot',
+        grpcImageMode: 'mmap',
+        inputSource: 'grpc',
+        availableInputSources: ['scrcpy', 'grpc'],
+        grpcVideoCodec: 'vp9',
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 4,
+      }),
+    ).toBeFalse();
+  });
+
+  test('defaults legacy responses without a video codec to H.264', () => {
+    expect(
+      parseAndroidStreamSource({
+        ok: true,
+        mode: 'grpc-screenshot',
+        grpcImageMode: 'png',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 1,
+      }),
+    ).toMatchObject({ grpcVideoCodec: 'h264' });
   });
 
   test('rejects missing or unsupported image modes', () => {
@@ -35,6 +102,13 @@ describe('parseAndroidStreamSource', () => {
     };
     expect(parseAndroidStreamSource(response)).toBeNull();
     expect(parseAndroidStreamSource({ ...response, grpcImageMode: 'rgb' })).toBeNull();
+    expect(
+      parseAndroidStreamSource({
+        ...response,
+        grpcImageMode: 'png',
+        grpcVideoCodec: 'av1',
+      }),
+    ).toBeNull();
   });
 
   test('rejects unavailable or unsupported input sources', () => {

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -8,7 +8,19 @@ import {
   androidStreamSourceErrorMessage,
   parseAndroidStreamSource,
 } from '../android-stream-source';
-import { androidWsUrlFor, parseServeEmuStreamSettings } from '../useAndroidDevice';
+import {
+  fixedWebCodecsCodec,
+  isRawVideoKeyFrame,
+  parseAndroidVideoSession,
+  resolveVideoKeyFrame,
+  webCodecsCodec,
+} from '../android-video-codec';
+import { parseFramePacket } from '../h264';
+import {
+  androidWsUrlFor,
+  parseServeEmuStreamSettings,
+  parseServeEmuViewerTransports,
+} from '../useAndroidDevice';
 
 describe('serve-emu stream contract', () => {
   test('uses a metadata video socket for H.264 and an input-only socket for WebRTC', () => {
@@ -18,6 +30,69 @@ describe('serve-emu stream contract', () => {
     expect(androidWsUrlFor('https://hub.test/vendor/serve-emu/', 'pixel 9', false)).toBe(
       'wss://hub.test/vendor/serve-emu/ws?video=0&device=pixel+9',
     );
+  });
+
+  test('parses authoritative codec generation boundaries for WebSocket video', () => {
+    expect(
+      parseAndroidVideoSession({
+        type: 'video-session',
+        size: { width: 1080, height: 2400 },
+        codec: 'vp9',
+      }),
+    ).toEqual({ size: { width: 1080, height: 2400 }, codec: 'vp9' });
+    expect(
+      parseAndroidVideoSession({
+        type: 'video-session',
+        size: { width: 1080, height: 2400 },
+      }),
+    ).toBeNull();
+    expect(
+      parseAndroidVideoSession({
+        type: 'video-session',
+        size: { width: 0, height: 2400 },
+        codec: 'vp8',
+      }),
+    ).toBeNull();
+    expect(fixedWebCodecsCodec('h264')).toBeNull();
+    expect(fixedWebCodecsCodec('vp8')).toBe('vp8');
+    expect(fixedWebCodecsCodec('vp9')).toBe('vp09.00.10.08');
+    expect(webCodecsCodec('h264', Uint8Array.of(0x67, 0x64, 0, 0x29))).toBe('avc1.640029');
+    expect(webCodecsCodec('h264', Uint8Array.of(0x67, 0x64))).toBeNull();
+  });
+
+  test('recovers VPx keyframes from raw payloads only when SEMU metadata is absent', () => {
+    const vp8Key = Uint8Array.of(0xf0, 0x02, 0, 0x9d, 0x01, 0x2a, 0x10, 0, 0x10, 0);
+    const vp9Key = Uint8Array.of(0x82, 0x49, 0x83, 0x42);
+
+    expect(isRawVideoKeyFrame('vp8', vp8Key)).toBe(true);
+    expect(isRawVideoKeyFrame('vp8', Uint8Array.of(0xb1, 1, 0, 5))).toBe(false);
+    expect(isRawVideoKeyFrame('vp9', vp9Key)).toBe(true);
+    expect(isRawVideoKeyFrame('vp9', Uint8Array.of(0x82, 0, 0, 0))).toBe(false);
+    expect(resolveVideoKeyFrame('vp8', false, vp8Key)).toBe(false);
+    expect(resolveVideoKeyFrame('vp9', true, Uint8Array.of(1, 2, 3))).toBe(true);
+    expect(resolveVideoKeyFrame('vp8', null, vp8Key)).toBe(true);
+  });
+
+  test('reads keyframe and PTS metadata from SEMU v1 and v2 packets', () => {
+    const packet = (version: 1 | 2, payload: number[]) => {
+      const headerBytes = version === 1 ? 16 : 24;
+      const bytes = new Uint8Array(headerBytes + payload.length);
+      const view = new DataView(bytes.buffer);
+      view.setUint32(0, 0x53454d55, false);
+      view.setUint8(4, version);
+      view.setUint8(5, 1);
+      view.setBigUint64(8, 123_456n, false);
+      if (version === 2) view.setBigUint64(16, 987_654_321n, false);
+      bytes.set(payload, headerBytes);
+      return bytes;
+    };
+
+    for (const version of [1, 2] as const) {
+      const parsed = parseFramePacket(packet(version, [1, 2, 3]));
+      expect(parsed.isKey).toBe(true);
+      expect(parsed.timestamp).toBe(123_456);
+      expect([...parsed.data]).toEqual([1, 2, 3]);
+    }
   });
 
   test('accepts the host-owned H.264 WebRTC configuration', () => {
@@ -48,6 +123,29 @@ describe('serve-emu stream contract', () => {
       ],
       iceTransportPolicy: 'relay',
     });
+  });
+
+  test('disables WebRTC when the active source codec only supports WebSocket viewing', () => {
+    expect(
+      parseServeEmuViewerTransports({
+        default: 'websocket',
+        available: ['websocket'],
+        webrtc: null,
+      }),
+    ).toEqual({ transport: 'websocket' });
+    expect(
+      parseServeEmuViewerTransports({
+        default: 'webrtc',
+        available: ['websocket', 'webrtc'],
+        webrtc: {
+          transport: 'webrtc',
+          codec: 'h264',
+          iceServers: [{ urls: ['stun:stun.example.test:3478'] }],
+          iceTransportPolicy: 'all',
+        },
+      }),
+    ).toMatchObject({ transport: 'webrtc', codec: 'h264' });
+    expect(parseServeEmuViewerTransports({ available: ['webtransport'] })).toBeNull();
   });
 
   test('rejects unsupported codecs and malformed ICE settings', () => {
@@ -130,6 +228,7 @@ describe('serve-emu capture source contract', () => {
         grpcImageMode: 'mmap',
         inputSource: 'scrcpy',
         availableInputSources: ['scrcpy', 'grpc'],
+        grpcVideoCodec: 'vp8',
         availableModes: ['scrcpy', 'grpc-screenshot'],
         sessionGeneration: 2,
       }),
@@ -138,6 +237,7 @@ describe('serve-emu capture source contract', () => {
       grpcImageMode: 'mmap',
       inputSource: 'scrcpy',
       availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'vp8',
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 2,
     });
@@ -157,6 +257,7 @@ describe('serve-emu capture source contract', () => {
       grpcImageMode: 'png',
       inputSource: 'scrcpy',
       availableInputSources: ['scrcpy'],
+      grpcVideoCodec: 'h264',
       availableModes: ['scrcpy'],
       sessionGeneration: 0,
     });

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -11,6 +11,8 @@ import {
 import {
   fixedWebCodecsCodec,
   isRawVideoKeyFrame,
+  isWebCodecsUnsupportedError,
+  mseFallbackCodecError,
   parseAndroidVideoSession,
   resolveVideoKeyFrame,
   webCodecsCodec,
@@ -45,7 +47,7 @@ describe('serve-emu stream contract', () => {
         type: 'video-session',
         size: { width: 1080, height: 2400 },
       }),
-    ).toBeNull();
+    ).toEqual({ size: { width: 1080, height: 2400 }, codec: 'h264' });
     expect(
       parseAndroidVideoSession({
         type: 'video-session',
@@ -58,6 +60,15 @@ describe('serve-emu stream contract', () => {
     expect(fixedWebCodecsCodec('vp9')).toBe('vp09.00.10.08');
     expect(webCodecsCodec('h264', Uint8Array.of(0x67, 0x64, 0, 0x29))).toBe('avc1.640029');
     expect(webCodecsCodec('h264', Uint8Array.of(0x67, 0x64))).toBeNull();
+    expect(mseFallbackCodecError('h264')).toBeNull();
+    expect(mseFallbackCodecError('h264', false)).toBe(
+      'This browser cannot decode H.264 (WebCodecs unavailable).',
+    );
+    expect(mseFallbackCodecError('vp8')).toBe(
+      'VP8 WebSocket video requires WebCodecs.',
+    );
+    expect(isWebCodecsUnsupportedError({ name: 'NotSupportedError' })).toBe(true);
+    expect(isWebCodecsUnsupportedError(new Error('decode failed'))).toBe(false);
   });
 
   test('recovers VPx keyframes from raw payloads only when SEMU metadata is absent', () => {

--- a/packages/@expo/hub-client/src/android-stream-source.ts
+++ b/packages/@expo/hub-client/src/android-stream-source.ts
@@ -1,5 +1,6 @@
 import {
   type DeviceGrpcImageMode,
+  type DeviceGrpcVideoCodec,
   type DeviceInputSource,
   type DeviceStreamSource,
   type DeviceStreamSourceStatus,
@@ -39,6 +40,17 @@ function isInputSource(value: unknown): value is DeviceInputSource {
   return value === 'scrcpy' || value === 'grpc';
 }
 
+function isGrpcVideoCodec(value: unknown): value is DeviceGrpcVideoCodec {
+  return value === 'h264' || value === 'vp8' || value === 'vp9';
+}
+
+/** Whether the active source can feed serve-emu's H.264-only WebRTC publisher. */
+export function androidStreamSourceSupportsWebRtc(
+  source: DeviceStreamSourceStatus | null,
+): boolean {
+  return source?.mode !== 'grpc-screenshot' || source.grpcVideoCodec === 'h264';
+}
+
 /** Parse serve-emu's authoritative device-scoped `/api/stream-mode` response. */
 export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStatus | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
@@ -47,7 +59,8 @@ export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStat
     candidate.ok !== true ||
     !isAndroidStreamSource(candidate.mode) ||
     !isGrpcImageMode(candidate.grpcImageMode) ||
-    !isInputSource(candidate.inputSource)
+    !isInputSource(candidate.inputSource) ||
+    (candidate.grpcVideoCodec !== undefined && !isGrpcVideoCodec(candidate.grpcVideoCodec))
   ) {
     return null;
   }
@@ -81,6 +94,8 @@ export function parseAndroidStreamSource(value: unknown): DeviceStreamSourceStat
     grpcImageMode: candidate.grpcImageMode,
     inputSource: candidate.inputSource,
     availableInputSources: candidate.availableInputSources,
+    // Older serve-emu versions always emitted H.264 and omit this field.
+    grpcVideoCodec: candidate.grpcVideoCodec ?? 'h264',
     availableModes: candidate.availableModes,
     sessionGeneration: candidate.sessionGeneration,
   };

--- a/packages/@expo/hub-client/src/android-video-codec.ts
+++ b/packages/@expo/hub-client/src/android-video-codec.ts
@@ -14,7 +14,12 @@ export function isDeviceGrpcVideoCodec(value: unknown): value is DeviceGrpcVideo
 export function parseAndroidVideoSession(value: unknown): AndroidVideoSession | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const candidate = value as Record<string, unknown>;
-  if (candidate.type !== 'video-session' || !isDeviceGrpcVideoCodec(candidate.codec)) return null;
+  if (
+    candidate.type !== 'video-session' ||
+    (candidate.codec !== undefined && !isDeviceGrpcVideoCodec(candidate.codec))
+  ) {
+    return null;
+  }
   if (!candidate.size || typeof candidate.size !== 'object' || Array.isArray(candidate.size)) {
     return null;
   }
@@ -31,7 +36,8 @@ export function parseAndroidVideoSession(value: unknown): AndroidVideoSession | 
   }
   return {
     size: { width: size.width, height: size.height },
-    codec: candidate.codec,
+    // Older serve-emu releases emitted H.264 and omitted the codec field.
+    codec: candidate.codec ?? 'h264',
   };
 }
 
@@ -54,6 +60,26 @@ export function webCodecsCodec(
 export function grpcVideoCodecLabel(codec: DeviceGrpcVideoCodec): string {
   if (codec === 'h264') return 'H.264';
   return codec.toUpperCase();
+}
+
+/** Report why a codec cannot use the browser's non-WebCodecs fallback. */
+export function mseFallbackCodecError(
+  codec: DeviceGrpcVideoCodec,
+  mseSupported = true,
+): string | null {
+  if (codec !== 'h264') {
+    return `${grpcVideoCodecLabel(codec)} WebSocket video requires WebCodecs.`;
+  }
+  return mseSupported ? null : 'This browser cannot decode H.264 (WebCodecs unavailable).';
+}
+
+export function isWebCodecsUnsupportedError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'NotSupportedError'
+  );
 }
 
 class BitReader {

--- a/packages/@expo/hub-client/src/android-video-codec.ts
+++ b/packages/@expo/hub-client/src/android-video-codec.ts
@@ -1,0 +1,113 @@
+import { type DeviceGrpcVideoCodec } from './types';
+import { buildCodecString, scanAU } from './h264';
+
+export type AndroidVideoSession = {
+  size: { width: number; height: number };
+  codec: DeviceGrpcVideoCodec;
+};
+
+export function isDeviceGrpcVideoCodec(value: unknown): value is DeviceGrpcVideoCodec {
+  return value === 'h264' || value === 'vp8' || value === 'vp9';
+}
+
+/** Parse serve-emu's generation boundary before accepting encoded WebSocket frames. */
+export function parseAndroidVideoSession(value: unknown): AndroidVideoSession | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type !== 'video-session' || !isDeviceGrpcVideoCodec(candidate.codec)) return null;
+  if (!candidate.size || typeof candidate.size !== 'object' || Array.isArray(candidate.size)) {
+    return null;
+  }
+  const size = candidate.size as Record<string, unknown>;
+  if (
+    typeof size.width !== 'number' ||
+    !Number.isFinite(size.width) ||
+    size.width <= 0 ||
+    typeof size.height !== 'number' ||
+    !Number.isFinite(size.height) ||
+    size.height <= 0
+  ) {
+    return null;
+  }
+  return {
+    size: { width: size.width, height: size.height },
+    codec: candidate.codec,
+  };
+}
+
+/** VPx codec strings accepted by WebCodecs; H.264 is derived from its SPS instead. */
+export function fixedWebCodecsCodec(codec: DeviceGrpcVideoCodec): string | null {
+  if (codec === 'vp8') return 'vp8';
+  if (codec === 'vp9') return 'vp09.00.10.08';
+  return null;
+}
+
+/** Resolve H.264's in-band profile or a VPx codec's fixed WebCodecs identifier. */
+export function webCodecsCodec(
+  codec: DeviceGrpcVideoCodec,
+  h264Sps: Uint8Array | null = null,
+): string | null {
+  if (codec !== 'h264') return fixedWebCodecsCodec(codec);
+  return h264Sps && h264Sps.byteLength >= 4 ? buildCodecString(h264Sps) : null;
+}
+
+export function grpcVideoCodecLabel(codec: DeviceGrpcVideoCodec): string {
+  if (codec === 'h264') return 'H.264';
+  return codec.toUpperCase();
+}
+
+class BitReader {
+  #offset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  read(bits: number): number | null {
+    if (!Number.isSafeInteger(bits) || bits < 0 || bits > 31) return null;
+    if (this.#offset + bits > this.bytes.byteLength * 8) return null;
+    let value = 0;
+    for (let index = 0; index < bits; index++) {
+      const position = this.#offset++;
+      value = value * 2 + ((this.bytes[position >> 3]! >> (7 - (position & 7))) & 1);
+    }
+    return value;
+  }
+}
+
+function isRawVp8KeyFrame(data: Uint8Array): boolean {
+  return (
+    data.byteLength >= 10 &&
+    (data[0]! & 1) === 0 &&
+    data[3] === 0x9d &&
+    data[4] === 0x01 &&
+    data[5] === 0x2a
+  );
+}
+
+function isRawVp9KeyFrame(data: Uint8Array): boolean {
+  const bits = new BitReader(data);
+  if (bits.read(2) !== 0b10) return false;
+  const profileLow = bits.read(1);
+  const profileHigh = bits.read(1);
+  if (profileLow === null || profileHigh === null) return false;
+  const profile = profileLow | (profileHigh << 1);
+  if (profile === 3 && bits.read(1) !== 0) return false;
+  if (bits.read(1) !== 0 || bits.read(1) !== 0) return false;
+  if (bits.read(1) === null || bits.read(1) === null) return false;
+  return bits.read(24) === 0x498342;
+}
+
+/** Detect a keyframe when legacy/raw video arrives without SEMU metadata. */
+export function isRawVideoKeyFrame(codec: DeviceGrpcVideoCodec, data: Uint8Array): boolean {
+  if (codec === 'h264') return scanAU(data).isKey;
+  if (codec === 'vp8') return isRawVp8KeyFrame(data);
+  return isRawVp9KeyFrame(data);
+}
+
+/** SEMU's key bit is authoritative; inspect bytes only for metadata-free frames. */
+export function resolveVideoKeyFrame(
+  codec: DeviceGrpcVideoCodec,
+  metadataKey: boolean | null,
+  data: Uint8Array,
+): boolean {
+  return metadataKey ?? isRawVideoKeyFrame(codec, data);
+}

--- a/packages/@expo/hub-client/src/h264.ts
+++ b/packages/@expo/hub-client/src/h264.ts
@@ -42,11 +42,11 @@ export function scanAU(buf: Uint8Array): ScanResult {
   return { isKey, spsBytes };
 }
 
-// serve-emu prefixes each WS frame with a 16-byte "SEMU" header carrying the
-// keyframe flag + presentation timestamp (see server.ts `withFrameMeta`).
+// serve-emu prefixes each WS frame with a versioned "SEMU" header carrying the
+// keyframe flag + presentation timestamp (see shared/frame-meta.ts).
 const FRAME_META_MAGIC = 0x53454d55; // "SEMU"
-const FRAME_META_VERSION = 1;
-const FRAME_META_HEADER_BYTES = 16;
+const FRAME_META_V1_HEADER_BYTES = 16;
+const FRAME_META_V2_HEADER_BYTES = 24;
 const FRAME_FLAG_KEY = 1 << 0;
 
 export interface FramePacket {
@@ -55,15 +55,25 @@ export interface FramePacket {
   timestamp: number | null;
 }
 
-/** Split a `/ws?frame-meta=1` binary message into its meta + Annex-B payload. */
+/** Split a `/ws?frame-meta=1` binary message into its metadata and encoded payload. */
 export function parseFramePacket(raw: ArrayBuffer | Uint8Array): FramePacket {
   const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
-  if (bytes.byteLength > FRAME_META_HEADER_BYTES) {
-    const view = new DataView(bytes.buffer, bytes.byteOffset, FRAME_META_HEADER_BYTES);
-    if (view.getUint32(0, false) === FRAME_META_MAGIC && view.getUint8(4) === FRAME_META_VERSION) {
+  if (bytes.byteLength > FRAME_META_V1_HEADER_BYTES) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    if (view.getUint32(0, false) === FRAME_META_MAGIC) {
+      const version = view.getUint8(4);
+      const headerBytes =
+        version === 1
+          ? FRAME_META_V1_HEADER_BYTES
+          : version === 2 && bytes.byteLength > FRAME_META_V2_HEADER_BYTES
+            ? FRAME_META_V2_HEADER_BYTES
+            : null;
+      if (headerBytes === null || bytes.byteLength <= headerBytes) {
+        return { data: bytes, isKey: null, timestamp: null };
+      }
       const pts = view.getBigUint64(8, false);
       return {
-        data: bytes.subarray(FRAME_META_HEADER_BYTES),
+        data: bytes.subarray(headerBytes),
         isKey: (view.getUint8(5) & FRAME_FLAG_KEY) !== 0,
         timestamp: pts <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(pts) : null,
       };

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -155,12 +155,16 @@ export type DeviceGrpcImageMode = 'png' | 'mmap';
 /** Input transport used while gRPC provides emulator video. */
 export type DeviceInputSource = 'scrcpy' | 'grpc';
 
+/** Host-side video encoder used by the emulator gRPC screenshot source. */
+export type DeviceGrpcVideoCodec = 'h264' | 'vp8' | 'vp9';
+
 /** Authoritative source state for the selected Android device session. */
 export interface DeviceStreamSourceStatus {
   mode: DeviceStreamSource;
   grpcImageMode: DeviceGrpcImageMode;
   inputSource: DeviceInputSource;
   availableInputSources: readonly DeviceInputSource[];
+  grpcVideoCodec: DeviceGrpcVideoCodec;
   availableModes: readonly DeviceStreamSource[];
   sessionGeneration: number;
 }
@@ -475,6 +479,8 @@ export interface DeviceClient {
   setGrpcImageMode: (mode: DeviceGrpcImageMode) => void;
   /** Restart gRPC streaming with scrcpy or emulator-gRPC input delivery. */
   setGrpcInputSource: (source: DeviceInputSource) => void;
+  /** Restart the gRPC source with the selected host-side video encoder. */
+  setGrpcVideoCodec: (codec: DeviceGrpcVideoCodec) => void;
   /** Live WebRTC stream telemetry; null for HTTP/WebSocket transports. */
   streamStats: DeviceStreamStats | null;
   /** Enable telemetry polling while a consumer is displaying WebRTC statistics. */

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -1040,6 +1040,15 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       const packet = parseFramePacket(raw);
 
       if (useMse) {
+        const fallbackError = mseFallbackCodecError(codec, mseSupported);
+        if (fallbackError) {
+          if (!decoderConfigFailed) {
+            decoderConfigFailed = true;
+            setStatus('error');
+            setError(fallbackError);
+          }
+          return;
+        }
         if (codec !== 'h264') return;
         const isKey = packet.isKey ?? scanAU(packet.data).isKey;
         if (!msePlayer) {

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -43,6 +43,8 @@ import {
 import {
   fixedWebCodecsCodec,
   grpcVideoCodecLabel,
+  isWebCodecsUnsupportedError,
+  mseFallbackCodecError,
   parseAndroidVideoSession,
   resolveVideoKeyFrame,
   webCodecsCodec,
@@ -907,11 +909,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     // Media Source Extensions — not secure-context gated — which decodes the same
     // H.264 through a <video> element blitted onto the canvas (see MsePlayer).
     const useMse = !isWebCodecsSupported();
-    if (useMse && !MsePlayer.isSupported()) {
-      setStatus('error');
-      setError('This browser cannot decode H.264 (WebCodecs unavailable).');
-      return;
-    }
+    const mseSupported = !useMse || MsePlayer.isSupported();
 
     setStatus('connecting');
     setError(null);
@@ -927,7 +925,9 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     let reconnectDelay = 500;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let decoder: VideoDecoder | null = null;
-    let activeCodec: DeviceGrpcVideoCodec | null = null;
+    // Older H.264-only serve-emu versions send neither an initial session
+    // announcement nor a codec field on resize announcements.
+    let activeCodec: DeviceGrpcVideoCodec | null = 'h264';
     let decoderConfigFailed = false;
     let sawKeyframe = false;
     let droppingUntilKeyframe = false;
@@ -952,6 +952,17 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       if (now - lastKeyframeRequestAt < KEYFRAME_REQUEST_COOLDOWN_MS) return;
       lastKeyframeRequestAt = now;
       ws.send(JSON.stringify({ type: 'reset-video', ack: false }));
+    };
+
+    const reportUnsupportedDecoder = () => {
+      decoderConfigFailed = true;
+      closeDecoder();
+      setStatus('error');
+      setError(
+        activeCodec
+          ? `This browser cannot decode ${grpcVideoCodecLabel(activeCodec)}.`
+          : 'This browser cannot configure the video decoder.',
+      );
     };
 
     const paint = (frame: VideoFrame) => {
@@ -996,13 +1007,16 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           }
           paint(frame);
         },
-        error: () => {
-          if (decoder === created) {
-            closeDecoder();
-            sawKeyframe = false;
-            droppingUntilKeyframe = true;
-            requestKeyframe();
+        error: (error) => {
+          if (decoder !== created) return;
+          if (isWebCodecsUnsupportedError(error)) {
+            reportUnsupportedDecoder();
+            return;
           }
+          closeDecoder();
+          sawKeyframe = false;
+          droppingUntilKeyframe = true;
+          requestKeyframe();
         },
       });
       try {
@@ -1010,16 +1024,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         decoder = created;
         return true;
       } catch {
-        decoderConfigFailed = true;
         try {
           created.close();
         } catch {}
-        setStatus('error');
-        setError(
-          activeCodec
-            ? `This browser cannot decode ${grpcVideoCodecLabel(activeCodec)}.`
-            : 'This browser cannot configure the video decoder.',
-        );
+        reportUnsupportedDecoder();
         return false;
       }
     };
@@ -1132,7 +1140,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
     const connect = () => {
       if (cancelled) return;
-      activeCodec = null;
+      activeCodec = 'h264';
       decoderConfigFailed = false;
       let ws: WebSocket;
       try {
@@ -1195,11 +1203,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
               droppingUntilKeyframe = true;
               setScreen({ width: msg.size.width, height: msg.size.height });
               setFps(0);
-              if (useMse && msg.codec !== 'h264') {
+              const fallbackError = useMse
+                ? mseFallbackCodecError(msg.codec, mseSupported)
+                : null;
+              if (fallbackError) {
                 setStatus('error');
-                setError(
-                  `${grpcVideoCodecLabel(msg.codec)} WebSocket video requires WebCodecs.`,
-                );
+                setError(fallbackError);
                 return;
               }
               setStatus('connecting');

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -2,13 +2,13 @@
  * serve-emu (Android) implementation of the {@link DeviceClient} interface.
  *
  * Wire protocol (see serve-emu `src/middleware.ts` / `src/input.ts`):
- *   - H.264 video + input share one WebSocket at `<base>/ws?frame-meta=1`.
+ *   - Encoded video + input share one WebSocket at `<base>/ws?frame-meta=1`.
  *     With WebRTC video, input stays on `<base>/ws?video=0`; signaling uses
  *     `<base>/webrtc/{offer,close}`. serve-emu is multi-device: `?device=<serial>`
  *     selects the target (omitted → first available).
- *   - Binary inbound messages are H.264 access units, each prefixed with a
- *     16-byte "SEMU" header (keyframe flag + PTS); decoded with WebCodecs into a
- *     `<canvas>`.
+ *   - Binary inbound messages are H.264, VP8, or VP9 access units, each prefixed
+ *     with a versioned "SEMU" header (keyframe flag + PTS); decoded with
+ *     WebCodecs into a `<canvas>`. H.264 retains an MSE fallback.
  *   - Outbound input is JSON on the same socket: `{type:'touch',action,x,y}`,
  *     `{type:'home'|'back'|'recents'|'power'}`, `{type:'reset-video'}`.
  *   - Screen size comes from the decoded frames; logcat is an SSE feed at
@@ -36,14 +36,22 @@ import {
   parseAndroidStreamSettings,
 } from './android-stream-settings';
 import {
+  androidStreamSourceSupportsWebRtc,
   androidStreamSourceErrorMessage,
   parseAndroidStreamSource,
 } from './android-stream-source';
 import {
+  fixedWebCodecsCodec,
+  grpcVideoCodecLabel,
+  parseAndroidVideoSession,
+  resolveVideoKeyFrame,
+  webCodecsCodec,
+} from './android-video-codec';
+import {
   DeviceSettingWriteTracker,
   mergeAuthoritativeDeviceSetting,
 } from './device-setting-writes';
-import { buildCodecString, isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
+import { isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
 import { useStreamSettingsResource } from './useStreamSettingsResource';
@@ -56,6 +64,7 @@ import {
   type DeviceConnectionOptions,
   type DeviceEvent,
   type DeviceGrpcImageMode,
+  type DeviceGrpcVideoCodec,
   type DeviceInputSource,
   type DeviceLog,
   type DeviceSettingKey,
@@ -162,6 +171,7 @@ type ServeEmuStreamSettings =
 type ServeEmuApiInfo = {
   size?: { width?: unknown; height?: unknown };
   stream?: unknown;
+  viewerTransports?: unknown;
 };
 
 function isIceServer(value: unknown): value is WebRtcIceServer {
@@ -196,6 +206,24 @@ export function parseServeEmuStreamSettings(value: unknown): ServeEmuStreamSetti
     iceServers: candidate.iceServers,
     iceTransportPolicy: candidate.iceTransportPolicy,
   };
+}
+
+/** Prefer the active source's viewer catalog over the host's configured default transport. */
+export function parseServeEmuViewerTransports(value: unknown): ServeEmuStreamSettings | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    !Array.isArray(candidate.available) ||
+    !candidate.available.every(
+      (transport) => transport === 'websocket' || transport === 'webrtc',
+    )
+  ) {
+    return null;
+  }
+  if (candidate.available.includes('webrtc')) {
+    return parseServeEmuStreamSettings(candidate.webrtc);
+  }
+  return candidate.available.includes('websocket') ? { transport: 'websocket' } : null;
 }
 
 export function useAndroidDeviceClient(options: DeviceConnectionOptions): DeviceClient {
@@ -453,6 +481,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       mode: DeviceStreamSource;
       grpcImageMode?: DeviceGrpcImageMode;
       inputSource?: DeviceInputSource;
+      grpcVideoCodec?: DeviceGrpcVideoCodec;
     }) => {
       if (!streamSourceUrl || streamSourcePendingRef.current) return;
       const request = ++streamSourceRequestRef.current;
@@ -534,6 +563,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         mode: previous.mode,
         grpcImageMode,
         inputSource: previous.inputSource,
+        grpcVideoCodec: previous.grpcVideoCodec,
       });
     },
     [putStreamMode],
@@ -554,6 +584,27 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         mode: previous.mode,
         grpcImageMode: previous.grpcImageMode,
         inputSource,
+        grpcVideoCodec: previous.grpcVideoCodec,
+      });
+    },
+    [putStreamMode],
+  );
+
+  const setGrpcVideoCodec = useCallback(
+    (grpcVideoCodec: DeviceGrpcVideoCodec) => {
+      const previous = streamSourceRef.current;
+      if (
+        !previous ||
+        previous.mode !== 'grpc-screenshot' ||
+        previous.grpcVideoCodec === grpcVideoCodec
+      ) {
+        return;
+      }
+      putStreamMode({
+        mode: previous.mode,
+        grpcImageMode: previous.grpcImageMode,
+        inputSource: previous.inputSource,
+        grpcVideoCodec,
       });
     },
     [putStreamMode],
@@ -585,6 +636,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
             current?.mode === next.mode &&
             current.grpcImageMode === next.grpcImageMode &&
             current.inputSource === next.inputSource &&
+            current.grpcVideoCodec === next.grpcVideoCodec &&
             current.sessionGeneration === next.sessionGeneration &&
             current.availableModes.join() === next.availableModes.join() &&
             current.availableInputSources.join() === next.availableInputSources.join()
@@ -671,7 +723,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         if (!response.ok) return;
         const info = (await response.json()) as ServeEmuApiInfo;
         if (cancelled) return;
-        const next = parseServeEmuStreamSettings(info.stream) ?? { transport: 'websocket' };
+        const next =
+          parseServeEmuViewerTransports(info.viewerTransports) ??
+          parseServeEmuStreamSettings(info.stream) ??
+          { transport: 'websocket' };
         setServerStreamSettings((current) =>
           JSON.stringify(current) === JSON.stringify(next) ? current : next,
         );
@@ -700,9 +755,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   }, [active, baseUrl, targetDevice]);
 
   const webRtcRequested = streamMode === 'webrtc';
-  const waitingForWebRtcMetadata = webRtcRequested && serverStreamSettings === null;
+  const sourceSupportsWebRtc = androidStreamSourceSupportsWebRtc(streamSource);
+  const waitingForWebRtcMetadata =
+    webRtcRequested && sourceSupportsWebRtc && serverStreamSettings === null;
   const useWebRtc =
-    webRtcRequested && serverStreamSettings?.transport === 'webrtc';
+    webRtcRequested && sourceSupportsWebRtc && serverStreamSettings?.transport === 'webrtc';
   const requestWebRtcKeyframe = useCallback(() => {
     send({ type: 'reset-video' });
   }, [send]);
@@ -833,7 +890,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     };
   }, [useWebRtc, webRtcStream, webRtcVideoElement, markWebRtcFrameDecoded]);
 
-  // ── H.264 video + input WebSocket (with reconnect) ──
+  // ── Encoded video + input WebSocket (with reconnect) ──
   useEffect(() => {
     if (!active || !baseUrl) {
       setStatus('idle');
@@ -870,6 +927,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     let reconnectDelay = 500;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let decoder: VideoDecoder | null = null;
+    let activeCodec: DeviceGrpcVideoCodec | null = null;
+    let decoderConfigFailed = false;
     let sawKeyframe = false;
     let droppingUntilKeyframe = false;
     let lastKeyframeRequestAt = 0;
@@ -925,8 +984,9 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       }
     };
 
-    const ensureDecoder = (spsBytes: Uint8Array): boolean => {
+    const ensureDecoder = (codec: string): boolean => {
       if (decoder?.state === 'configured') return true;
+      if (decoderConfigFailed) return false;
       closeDecoder();
       const created = new VideoDecoder({
         output: (frame) => {
@@ -946,22 +1006,33 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         },
       });
       try {
-        created.configure({ codec: buildCodecString(spsBytes), optimizeForLatency: true });
+        created.configure({ codec, optimizeForLatency: true });
         decoder = created;
         return true;
       } catch {
+        decoderConfigFailed = true;
         try {
           created.close();
         } catch {}
-        requestKeyframe();
+        setStatus('error');
+        setError(
+          activeCodec
+            ? `This browser cannot decode ${grpcVideoCodecLabel(activeCodec)}.`
+            : 'This browser cannot configure the video decoder.',
+        );
         return false;
       }
     };
 
     const feedFrame = (raw: ArrayBuffer) => {
+      const codec = activeCodec;
+      // Codec switches share a socket. Never guess while waiting for the
+      // generation boundary or bytes could enter a decoder for the old codec.
+      if (!codec) return;
       const packet = parseFramePacket(raw);
 
       if (useMse) {
+        if (codec !== 'h264') return;
         const isKey = packet.isKey ?? scanAU(packet.data).isKey;
         if (!msePlayer) {
           const canvas = canvasRef.current;
@@ -996,13 +1067,21 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         return;
       }
 
-      const needsScan =
-        packet.isKey === null ||
-        (packet.isKey && (!decoder || decoder.state !== 'configured' || droppingUntilKeyframe));
-      const scanned = needsScan ? scanAU(packet.data) : null;
-      const isKey = packet.isKey ?? scanned?.isKey ?? false;
-      const spsBytes = scanned?.spsBytes ?? null;
-      if (spsBytes && !ensureDecoder(spsBytes)) return;
+      const needsH264Scan =
+        codec === 'h264' &&
+        (packet.isKey === null ||
+          (packet.isKey && (!decoder || decoder.state !== 'configured' || droppingUntilKeyframe)));
+      const scanned = needsH264Scan ? scanAU(packet.data) : null;
+      const isKey = resolveVideoKeyFrame(
+        codec,
+        packet.isKey ?? scanned?.isKey ?? null,
+        packet.data,
+      );
+      const decoderCodec = webCodecsCodec(codec, scanned?.spsBytes ?? null);
+      if ((!decoder || decoder.state !== 'configured') && decoderCodec) {
+        if (!ensureDecoder(decoderCodec)) return;
+      }
+      if (decoderConfigFailed) return;
 
       if (droppingUntilKeyframe) {
         if (!isKey) return;
@@ -1053,6 +1132,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
     const connect = () => {
       if (cancelled) return;
+      activeCodec = null;
+      decoderConfigFailed = false;
       let ws: WebSocket;
       try {
         ws = new WebSocket(androidWsUrlFor(baseUrl, targetDevice, true));
@@ -1081,6 +1162,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         closeDecoder();
         msePlayer?.destroy();
         msePlayer = null;
+        activeCodec = null;
+        decoderConfigFailed = false;
         sawKeyframe = false;
         frameIdx = 0;
         // A drop before the first frame is normal while the emulator is still
@@ -1097,27 +1180,32 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       ws.onmessage = (event) => {
         if (cancelled) return;
         if (typeof event.data === 'string') {
-          // serve-emu announces an encoder restart with a new size (device
-          // rotation) as a JSON "video-session" message. Drop the old decoder
-          // and resync onto the new stream from a fresh keyframe.
+          // Every encoded generation begins with an authoritative codec + size
+          // announcement. Drop the old decoder and resync from a fresh keyframe.
           try {
-            const msg = JSON.parse(event.data) as {
-              type?: string;
-              size?: { width: number; height: number };
-            };
-            if (
-              msg.type === 'video-session' &&
-              msg.size &&
-              Number.isFinite(msg.size.width) &&
-              Number.isFinite(msg.size.height)
-            ) {
+            const msg = parseAndroidVideoSession(JSON.parse(event.data));
+            if (msg) {
               closeDecoder();
               msePlayer?.destroy();
               msePlayer = null;
+              activeCodec = msg.codec;
+              decoderConfigFailed = false;
               frameIdx = 0;
               sawKeyframe = false;
               droppingUntilKeyframe = true;
               setScreen({ width: msg.size.width, height: msg.size.height });
+              setFps(0);
+              if (useMse && msg.codec !== 'h264') {
+                setStatus('error');
+                setError(
+                  `${grpcVideoCodecLabel(msg.codec)} WebSocket video requires WebCodecs.`,
+                );
+                return;
+              }
+              setStatus('connecting');
+              setError(null);
+              const fixedCodec = fixedWebCodecsCodec(msg.codec);
+              if (fixedCodec && !ensureDecoder(fixedCodec)) return;
               requestKeyframe();
             }
           } catch {}
@@ -1505,6 +1593,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     setStreamSource,
     setGrpcImageMode,
     setGrpcInputSource,
+    setGrpcVideoCodec,
     streamStats,
     setStreamStatsEnabled,
     webRtcCodec: 'h264',

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -1361,6 +1361,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     setStreamSource: () => {},
     setGrpcImageMode: () => {},
     setGrpcInputSource: () => {},
+    setGrpcVideoCodec: () => {},
     streamStats,
     setStreamStatsEnabled,
     webRtcCodec,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -33,6 +33,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   setStreamSource: () => {},
   setGrpcImageMode: () => {},
   setGrpcInputSource: () => {},
+  setGrpcVideoCodec: () => {},
   streamStats: null,
   setStreamStatsEnabled: () => {},
   webRtcCodec: 'h264',

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import {
   type DeviceClient,
   type DeviceGrpcImageMode,
+  type DeviceGrpcVideoCodec,
   type DeviceHttpCodec,
   type DeviceInputSource,
   type DeviceStreamCapabilities,
@@ -74,6 +75,14 @@ const GRPC_INPUT_SOURCE_OPTIONS: ReadonlyArray<{
 }> = [
   { value: 'scrcpy', label: 'scrcpy' },
   { value: 'grpc', label: 'gRPC' },
+];
+const GRPC_VIDEO_CODEC_OPTIONS: ReadonlyArray<{
+  value: DeviceGrpcVideoCodec;
+  label: string;
+}> = [
+  { value: 'h264', label: 'H.264' },
+  { value: 'vp8', label: 'VP8' },
+  { value: 'vp9', label: 'VP9' },
 ];
 const STREAM_SETTING_ORDER: readonly (keyof DeviceStreamEncoderSettings)[] = [
   'maxDimension',
@@ -150,10 +159,18 @@ export function StreamOptionsSection({
   const [open, setOpen] = useState(defaultOpen);
   const backend: DeviceStreamCapabilities =
     client.streamCapabilities ?? DEFAULT_STREAM_CAPABILITIES;
+  const streamSource = client.streamSource;
+  const grpcVideoUsesWebSocket =
+    client.platform === 'android' &&
+    streamSource?.mode === 'grpc-screenshot' &&
+    streamSource.grpcVideoCodec !== 'h264';
   const availability: StreamModeAvailability = {
     mjpeg: streamModeAvailability.mjpeg && backend.modeAvailability.mjpeg,
     h264: streamModeAvailability.h264 && backend.modeAvailability.h264,
-    webrtc: streamModeAvailability.webrtc && backend.modeAvailability.webrtc,
+    webrtc:
+      streamModeAvailability.webrtc &&
+      backend.modeAvailability.webrtc &&
+      !grpcVideoUsesWebSocket,
   };
   const activeStreamMode = availability[streamMode]
     ? streamMode
@@ -177,7 +194,6 @@ export function StreamOptionsSection({
     ? STREAM_SETTING_ORDER.filter((key) => settingsCapabilities[key])
     : [];
   const finalSettingKey = supportedSettingKeys.at(-1);
-  const streamSource = client.streamSource;
   const sourceOptions = STREAM_SOURCE_OPTIONS.filter((option) =>
     streamSource?.availableModes.includes(option.value),
   );
@@ -250,7 +266,9 @@ export function StreamOptionsSection({
     (backend.modeAvailability.h264 && !streamModeAvailability.h264) ||
     (backend.modeAvailability.webrtc && !streamModeAvailability.webrtc);
   const hostWebRtcDisabled =
-    client.platform === 'android' && !backend.modeAvailability.webrtc;
+    client.platform === 'android' &&
+    !backend.modeAvailability.webrtc &&
+    !grpcVideoUsesWebSocket;
 
   return (
     <CollapsibleSection title="Stream options" open={open} onOpenChange={setOpen}>
@@ -308,6 +326,29 @@ export function StreamOptionsSection({
               onChange={client.setGrpcImageMode}
             />
           </SidebarRow>
+          <SidebarRow label="gRPC codec">
+            <SegmentedControl
+              ariaLabel="gRPC video codec"
+              options={GRPC_VIDEO_CODEC_OPTIONS.map((option) => ({
+                ...option,
+                disabled:
+                  client.streamSourcePending ||
+                  (transport === 'webrtc' && option.value !== 'h264'),
+              }))}
+              value={streamSource.grpcVideoCodec}
+              onChange={client.setGrpcVideoCodec}
+            />
+          </SidebarRow>
+          <span
+            style={{
+              ...textSize.xs,
+              display: 'block',
+              padding: '0 0 8px',
+              color: text.tertiary,
+            }}
+          >
+            VP8 and VP9 gRPC video require WebSocket.
+          </span>
         </>
       )}
       <SidebarRow label="Transport">
@@ -323,7 +364,7 @@ export function StreamOptionsSection({
           onChange={changeTransport}
         />
       </SidebarRow>
-      {httpCodecOptions.length > 0 && (
+      {client.platform !== 'android' && httpCodecOptions.length > 0 && (
         <SidebarRow label={`${primaryTransportLabel} codec`}>
           <SegmentedControl
             ariaLabel={`${primaryTransportLabel} codec`}

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -65,10 +65,12 @@ while the emulator writes RGB pixels to a shared file-backed memory region:
 npx expo-device-hub --platform android --transport webrtc
 ```
 
-Use `--stream-source scrcpy` to select scrcpy at startup, or `--grpc-image-mode png` to
-send a compressed image in each gRPC message. The same source and PNG/MMAP choices are
-available at runtime under **Stream options**. Run `npx expo-device-hub --help` for the
-full option list.
+Use `--stream-source scrcpy` to select scrcpy at startup, `--grpc-image-mode png` to
+send a compressed image in each gRPC message, or `--grpc-video-codec vp8` (also `vp9`)
+to change the host encoder for WebSocket streaming. The same source, PNG/MMAP, and
+H.264/VP8/VP9 choices are available at runtime under **Stream options**. VP8 and VP9
+require WebCodecs and are unavailable with WebRTC. Run `npx expo-device-hub --help`
+for the full option list.
 
 MMAP support is experimental and depends on the Android Emulator build. Google
 tracks an Apple Silicon `streamScreenshot` MMAP fix as issue

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -73,6 +73,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
           grpcImageMode: 'png',
           inputSource: 'scrcpy',
           availableInputSources: ['scrcpy'],
+          grpcVideoCodec: 'h264',
           availableModes: ['scrcpy', 'grpc-screenshot'],
           sessionGeneration: 0,
         },
@@ -81,6 +82,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
     setStreamSource: () => {},
     setGrpcImageMode: () => {},
     setGrpcInputSource: () => {},
+    setGrpcVideoCodec: () => {},
     streamStats: null,
     setStreamStatsEnabled: () => {},
     webRtcCodec: 'h264',
@@ -326,7 +328,7 @@ test('shows Android resolution while omitting encoder settings serve-emu cannot 
 
   expect(segmentedControlMarkup(html, 'Stream transport')).toContain('>WebSocket</button>');
   expect(segmentedControlMarkup(html, 'Stream transport')).toContain('>WebRTC</button>');
-  expect(segmentedControlMarkup(html, 'WebSocket codec')).toContain('>H.264</button>');
+  expect(html).not.toContain('aria-label="WebSocket codec"');
   expect(segmentedControlMarkup(html, 'WebRTC codec')).toContain('>H.264</button>');
   expect(html).not.toContain('>HTTP</button>');
   expect(html).not.toContain('>MJPEG</button>');
@@ -353,11 +355,12 @@ test('shows the Android emulator capture source switch', () => {
   expect(source).not.toContain('disabled=""');
 });
 
-test('shows PNG and MMAP only while the gRPC source is active', () => {
+test('shows image and video codec controls only while the gRPC source is active', () => {
   const scrcpyHtml = renderToStaticMarkup(
     <StreamOptionsSection client={inspectorClient('android')} defaultOpen />,
   );
   expect(scrcpyHtml).not.toContain('aria-label="gRPC image mode"');
+  expect(scrcpyHtml).not.toContain('aria-label="gRPC video codec"');
 
   const grpcClient = {
     ...inspectorClient('android'),
@@ -366,6 +369,7 @@ test('shows PNG and MMAP only while the gRPC source is active', () => {
       grpcImageMode: 'mmap',
       inputSource: 'scrcpy',
       availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'vp9',
       availableModes: ['scrcpy', 'grpc-screenshot'],
       sessionGeneration: 1,
     },
@@ -384,6 +388,90 @@ test('shows PNG and MMAP only while the gRPC source is active', () => {
   expect(imageMode).toContain('>PNG</button>');
   expect(imageMode).toContain('>MMAP</button>');
   expect(imageMode).toMatch(/aria-pressed="true"[^>]*>MMAP<\/button>/);
+  const codec = segmentedControlMarkup(grpcHtml, 'gRPC video codec');
+  expect(grpcHtml).toContain('>gRPC codec</span>');
+  expect(codec).toContain('>H.264</button>');
+  expect(codec).toContain('>VP8</button>');
+  expect(codec).toContain('>VP9</button>');
+  expect(codec).toMatch(/aria-pressed="true"[^>]*>VP9<\/button>/);
+  expect(grpcHtml).toContain('VP8 and VP9 gRPC video require WebSocket.');
+});
+
+test('keeps VPx gRPC video on WebSocket', () => {
+  const client = {
+    ...inspectorClient('android'),
+    streamSource: {
+      mode: 'grpc-screenshot',
+      grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'vp9',
+      availableModes: ['scrcpy', 'grpc-screenshot'],
+      sessionGeneration: 1,
+    },
+  } satisfies DeviceClient;
+  const html = renderToStaticMarkup(
+    <StreamOptionsSection
+      client={client}
+      defaultOpen
+      streamMode="webrtc"
+      streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
+      onStreamModeChange={() => {}}
+    />,
+  );
+  const transport = segmentedControlMarkup(html, 'Stream transport');
+
+  expect(transport).toMatch(/aria-pressed="true"[^>]*>WebSocket<\/button>/);
+  expect(transport).toMatch(/<button[^>]*disabled=""[^>]*>WebRTC<\/button>/);
+  expect(html).toContain('VP8 and VP9 gRPC video require WebSocket.');
+});
+
+test('disables VPx gRPC codecs while WebRTC is active', () => {
+  const client = {
+    ...inspectorClient('android'),
+    streamSource: {
+      mode: 'grpc-screenshot',
+      grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'h264',
+      availableModes: ['scrcpy', 'grpc-screenshot'],
+      sessionGeneration: 1,
+    },
+  } satisfies DeviceClient;
+  const html = renderToStaticMarkup(
+    <StreamOptionsSection
+      client={client}
+      defaultOpen
+      streamMode="webrtc"
+      streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
+      onStreamModeChange={() => {}}
+    />,
+  );
+  const codec = segmentedControlMarkup(html, 'gRPC video codec');
+
+  expect(codec).toMatch(/aria-pressed="true"[^>]*>H\.264<\/button>/);
+  expect(codec.match(/disabled=""/g)).toHaveLength(2);
+});
+
+test('disables gRPC image and codec controls while source replacement is pending', () => {
+  const client = {
+    ...inspectorClient('android'),
+    streamSource: {
+      mode: 'grpc-screenshot',
+      grpcImageMode: 'mmap',
+      inputSource: 'scrcpy',
+      availableInputSources: ['scrcpy', 'grpc'],
+      grpcVideoCodec: 'vp8',
+      availableModes: ['scrcpy', 'grpc-screenshot'],
+      sessionGeneration: 1,
+    },
+    streamSourcePending: true,
+  } satisfies DeviceClient;
+  const html = renderToStaticMarkup(<StreamOptionsSection client={client} defaultOpen />);
+
+  expect(segmentedControlMarkup(html, 'gRPC image mode').match(/disabled=""/g)).toHaveLength(2);
+  expect(segmentedControlMarkup(html, 'gRPC video codec').match(/disabled=""/g)).toHaveLength(3);
 });
 
 test('disables the Android capture source switch while replacement is pending', () => {
@@ -418,6 +506,7 @@ test('hides the Android capture source row when gRPC is unavailable', () => {
       grpcImageMode: 'png',
       inputSource: 'scrcpy',
       availableInputSources: ['scrcpy'],
+      grpcVideoCodec: 'h264',
       availableModes: ['scrcpy'],
       sessionGeneration: 0,
     },

--- a/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/cli-options.test.ts
@@ -16,6 +16,7 @@ describe('parseCliOptions', () => {
       videoFps: undefined,
       streamSource: undefined,
       grpcImageMode: undefined,
+      grpcVideoCodec: undefined,
       stunUrls: undefined,
       turnUrls: undefined,
       turnUsername: undefined,
@@ -98,7 +99,7 @@ describe('parseCliOptions', () => {
     });
   });
 
-  test('selects the Android gRPC source and its explicit image mode', () => {
+  test('selects the Android gRPC source, image mode, and normalized video codec', () => {
     expect(
       parseCliOptions([
         '--platform',
@@ -107,10 +108,13 @@ describe('parseCliOptions', () => {
         'GRPC-SCREENSHOT',
         '--grpc-image-mode',
         'MMAP',
+        '--grpc-video-codec',
+        'VP9',
       ]),
     ).toMatchObject({
       streamSource: 'grpc-screenshot',
       grpcImageMode: 'mmap',
+      grpcVideoCodec: 'vp9',
     });
   });
 
@@ -121,9 +125,36 @@ describe('parseCliOptions', () => {
     expect(() => parseCliOptions(['--grpc-image-mode', 'rgb'])).toThrow(
       'Invalid --grpc-image-mode: rgb',
     );
+    expect(() => parseCliOptions(['--grpc-video-codec', 'av1'])).toThrow(
+      'Invalid --grpc-video-codec: av1',
+    );
     expect(() =>
       parseCliOptions(['--platform', 'ios', '--stream-source', 'grpc-screenshot'])
-    ).toThrow('--stream-source and --grpc-image-mode are supported only for Android');
+    ).toThrow(
+      '--stream-source, --grpc-image-mode, and --grpc-video-codec are supported only for Android',
+    );
+    expect(() =>
+      parseCliOptions(['--platform', 'ios', '--grpc-video-codec', 'vp8'])
+    ).toThrow(
+      '--stream-source, --grpc-image-mode, and --grpc-video-codec are supported only for Android',
+    );
+  });
+
+  test('rejects VP8 and VP9 gRPC encoding with the WebRTC transport', () => {
+    for (const codec of ['vp8', 'vp9']) {
+      expect(() =>
+        parseCliOptions([
+          '--platform',
+          'android',
+          '--transport',
+          'webrtc',
+          '--grpc-video-codec',
+          codec,
+        ])
+      ).toThrow(
+        `--grpc-video-codec ${codec} is incompatible with --transport webrtc; use --transport h264 (WebSocket)`
+      );
+    }
   });
 
   test('validates serve-sim option ranges and values', () => {
@@ -201,6 +232,7 @@ describe('parseCliOptions', () => {
       '--video-fps',
       '--stream-source',
       '--grpc-image-mode',
+      '--grpc-video-codec',
       '--stun-url',
       '--turn-url',
       '--turn-username',
@@ -218,6 +250,8 @@ describe('parseCliOptions', () => {
     expect(HELP).toContain('(default: grpc-screenshot)');
     expect(HELP).toContain('--grpc-image-mode <mode>');
     expect(HELP).toContain('default: mmap');
+    expect(HELP).toContain('--grpc-video-codec <codec>');
+    expect(HELP).toContain('default: h264');
   });
 
   test('hides the device list sidebar on request', () => {
@@ -251,6 +285,7 @@ describe('parseCliOptions', () => {
       videoFps: undefined,
       streamSource: undefined,
       grpcImageMode: undefined,
+      grpcVideoCodec: undefined,
       stunUrls: undefined,
       turnUrls: undefined,
       turnUsername: undefined,

--- a/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
@@ -12,6 +12,7 @@ import {
 const DEFAULT_ANDROID_STREAM = {
   streamMode: 'grpc-screenshot',
   grpcImageMode: 'mmap',
+  grpcVideoCodec: 'h264',
 } as const;
 
 describe('standaloneServeEmuOptions', () => {
@@ -66,8 +67,31 @@ describe('standaloneServeEmuOptions', () => {
     ).toEqual({
       streamMode: 'scrcpy',
       grpcImageMode: 'png',
+      grpcVideoCodec: 'h264',
       streamSettings: { transport: 'websocket' },
     });
+  });
+
+  test('maps VP8 and VP9 gRPC codecs onto WebSocket startup options', () => {
+    for (const codec of ['vp8', 'vp9'] as const) {
+      expect(
+        standaloneServeEmuOptions(
+          parseCliOptions([
+            '--platform',
+            'android',
+            '--transport',
+            'h264',
+            '--grpc-video-codec',
+            codec.toUpperCase(),
+          ]),
+        ),
+      ).toEqual({
+        streamMode: 'grpc-screenshot',
+        grpcImageMode: 'mmap',
+        grpcVideoCodec: codec,
+        streamSettings: { transport: 'websocket' },
+      });
+    }
   });
 
   test('maps host WebRTC settings while keeping Android on H.264', () => {

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -22,6 +22,9 @@ export const DEFAULT_ANDROID_STREAM_SOURCE: AndroidStreamSource = 'grpc-screensh
 export const GRPC_IMAGE_MODES = ['png', 'mmap'] as const;
 export type GrpcImageMode = (typeof GRPC_IMAGE_MODES)[number];
 export const DEFAULT_GRPC_IMAGE_MODE: GrpcImageMode = 'mmap';
+export const GRPC_VIDEO_CODECS = ['h264', 'vp8', 'vp9'] as const;
+export type GrpcVideoCodec = (typeof GRPC_VIDEO_CODECS)[number];
+export const DEFAULT_GRPC_VIDEO_CODEC: GrpcVideoCodec = 'h264';
 
 export const HELP = `expo-device-hub — manage iOS simulators and Android emulators from the browser
 
@@ -39,6 +42,7 @@ Options:
       --video-fps <fps>      H.264/WebRTC frame rate (1-120)
       --stream-source <source> Android capture source: ${ANDROID_STREAM_SOURCES.join(', ')} (default: ${DEFAULT_ANDROID_STREAM_SOURCE})
       --grpc-image-mode <mode> gRPC frames: ${GRPC_IMAGE_MODES.join(', ')} (default: ${DEFAULT_GRPC_IMAGE_MODE}; used when the gRPC source is active)
+      --grpc-video-codec <codec> gRPC WebSocket video codec: ${GRPC_VIDEO_CODECS.join(', ')} (default: ${DEFAULT_GRPC_VIDEO_CODEC}; used when the gRPC source is active)
       --stun-url <urls>      Comma-separated STUN URL(s) for WebRTC ICE
       --turn-url <urls>      Comma-separated TURN URL(s) for WebRTC ICE
       --turn-username <name> TURN username (requires --turn-credential and --turn-url)
@@ -62,6 +66,7 @@ export type CliOptions = {
   videoFps?: number;
   streamSource?: AndroidStreamSource;
   grpcImageMode?: GrpcImageMode;
+  grpcVideoCodec?: GrpcVideoCodec;
   stunUrls?: string[];
   turnUrls?: string[];
   turnUsername?: string;
@@ -131,6 +136,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     'video-fps'?: string;
     'stream-source'?: string;
     'grpc-image-mode'?: string;
+    'grpc-video-codec'?: string;
     'stun-url'?: string;
     'turn-url'?: string;
     'turn-username'?: string;
@@ -159,6 +165,7 @@ export function parseCliOptions(args: string[]): CliOptions {
         'video-fps': { type: 'string' },
         'stream-source': { type: 'string' },
         'grpc-image-mode': { type: 'string' },
+        'grpc-video-codec': { type: 'string' },
         'stun-url': { type: 'string' },
         'turn-url': { type: 'string' },
         'turn-username': { type: 'string' },
@@ -231,8 +238,27 @@ export function parseCliOptions(args: string[]): CliOptions {
   if (values['grpc-image-mode'] !== undefined && grpcImageMode === undefined) {
     throw new Error(`Invalid --grpc-image-mode: ${values['grpc-image-mode']}\n\n${HELP}`);
   }
-  if ((streamSource !== undefined || grpcImageMode !== undefined) && platform === 'ios') {
-    throw new Error(`--stream-source and --grpc-image-mode are supported only for Android.\n\n${HELP}`);
+  const normalizedGrpcVideoCodec = values['grpc-video-codec']?.toLowerCase();
+  const grpcVideoCodec = GRPC_VIDEO_CODECS.includes(
+    normalizedGrpcVideoCodec as GrpcVideoCodec
+  )
+    ? (normalizedGrpcVideoCodec as GrpcVideoCodec)
+    : undefined;
+  if (values['grpc-video-codec'] !== undefined && grpcVideoCodec === undefined) {
+    throw new Error(`Invalid --grpc-video-codec: ${values['grpc-video-codec']}\n\n${HELP}`);
+  }
+  if (
+    (streamSource !== undefined || grpcImageMode !== undefined || grpcVideoCodec !== undefined) &&
+    platform === 'ios'
+  ) {
+    throw new Error(
+      `--stream-source, --grpc-image-mode, and --grpc-video-codec are supported only for Android.\n\n${HELP}`
+    );
+  }
+  if (grpcVideoCodec !== undefined && grpcVideoCodec !== 'h264' && transport === 'webrtc') {
+    throw new Error(
+      `--grpc-video-codec ${grpcVideoCodec} is incompatible with --transport webrtc; use --transport h264 (WebSocket).\n\n${HELP}`
+    );
   }
   const stunUrls = parseIceUrls(values['stun-url'], 'stun');
   const turnUrls = parseIceUrls(values['turn-url'], 'turn');
@@ -283,6 +309,7 @@ export function parseCliOptions(args: string[]): CliOptions {
     videoFps,
     streamSource,
     grpcImageMode,
+    grpcVideoCodec,
     stunUrls,
     turnUrls,
     turnUsername,

--- a/packages/expo-device-hub/src/server/serve-emu-options.ts
+++ b/packages/expo-device-hub/src/server/serve-emu-options.ts
@@ -1,10 +1,12 @@
 import {
   DEFAULT_ANDROID_STREAM_SOURCE,
   DEFAULT_GRPC_IMAGE_MODE,
+  DEFAULT_GRPC_VIDEO_CODEC,
   DEFAULT_WEBRTC_ICE_POLICY,
   type AndroidStreamSource,
   type CliOptions,
   type GrpcImageMode,
+  type GrpcVideoCodec,
   type WebRtcIcePolicy,
 } from './cli/options';
 
@@ -37,6 +39,7 @@ export type StandaloneServeEmuOptions = {
   maxSize?: number;
   streamMode?: AndroidStreamSource;
   grpcImageMode?: GrpcImageMode;
+  grpcVideoCodec?: GrpcVideoCodec;
   streamSettings: StandaloneServeEmuStreamSettings;
 };
 
@@ -44,6 +47,7 @@ function defaultServeEmuOptions(): StandaloneServeEmuOptions {
   return {
     streamMode: DEFAULT_ANDROID_STREAM_SOURCE,
     grpcImageMode: DEFAULT_GRPC_IMAGE_MODE,
+    grpcVideoCodec: DEFAULT_GRPC_VIDEO_CODEC,
     streamSettings: { transport: 'websocket' },
   };
 }
@@ -73,6 +77,7 @@ export function standaloneServeEmuOptions(options: CliOptions): StandaloneServeE
     ...(options.maxDimension !== undefined ? { maxSize: options.maxDimension } : {}),
     streamMode: options.streamSource ?? DEFAULT_ANDROID_STREAM_SOURCE,
     grpcImageMode: options.grpcImageMode ?? DEFAULT_GRPC_IMAGE_MODE,
+    grpcVideoCodec: options.grpcVideoCodec ?? DEFAULT_GRPC_VIDEO_CODEC,
     streamSettings:
       options.transport === 'webrtc'
         ? {


### PR DESCRIPTION
## Summary

- expose H.264, VP8, and VP9 controls for Android Emulator gRPC WebSocket streaming
- teach the Hub client to consume codec-bearing video generations and SEMU v1/v2 frame metadata, then configure WebCodecs for H.264, VP8, or VP9
- keep legacy H.264-only serve-emu connections working when codec announcements are absent
- route standalone CLI codec selection into serve-emu and reject VPx with the WebRTC transport
- automatically use WebSocket for VP8/VP9, disable the incompatible WebRTC control, and restore WebRTC availability for H.264
- compose codec selection with the newly merged gRPC input-source setting so either can change without resetting the other
- add documentation, focused contract/UI tests, and a release changeset
- pin the feature-only VP8/VP9 serve-emu head

Depends on [expo/serve-emu#21](https://github.com/expo/serve-emu/pull/21). The submodule is pinned to feature-only commit `3f5cbc8` from that branch.

The independent MMAP scheduler and encoder-write cadence correction is tracked in [expo/serve-emu#23](https://github.com/expo/serve-emu/pull/23) and [expo-device-hub#60](https://github.com/expo/expo-device-hub/pull/60); it is intentionally not included here.

The pinned scrcpy 4.0 server cannot emit VP8 or VP9, so those options remain scoped to the gRPC screenshot source.

## Validation

- `bun run typecheck` — 11/11 tasks passed
- `bun run lint` — 4/4 tasks passed with no errors or warnings
- `bun run test` — 5/5 package tasks passed
- `bun run build` — 7/7 tasks passed, including vendored serve-emu and the standalone Hub bundle
- focused root integration suite: 78 tests passed, 0 failed
- serve-emu `bun run check`
  - 868 tests passed, 0 failed, 4,702 assertions
  - coverage, all TypeScript checks, documentation sync, production build, and package smoke passed
- agent-browser CLI against a Pixel_10 AVD on Android 17 / Chrome
  - Android Emulator 37.2.7, including the Apple Silicon MMAP fix
  - verified live H.264, VP8, and VP9 switching and changing 436×980 WebCodecs frames over gRPC MMAP
  - verified VP8/VP9 disable WebRTC and H.264 re-enables it
- current head `ab281d3` is rebased on current `main` and is mergeable

## Feature-only 980px gRPC+MMAP comparison

These measurements were captured on the patch-equivalent pre-rebase serve-emu feature head `d5879f0` with a deterministic high-motion workload, one viewer, 8 Mbps, a 60 FPS target, and 436×980 output.

| Codec | Usable MMAP FPS | Encoded FPS | Viewer FPS |
| --- | ---: | ---: | ---: |
| H.264 | 37.793 | 39.890 | 37.800 |
| VP8 | 37.753 | 37.738 | 37.450 |
| VP9 | 37.065 | 37.118 | 36.325 |

All codecs were constrained by the same pre-existing, codec-independent MMAP pacing ceiling. The table therefore validates comparable codec behavior rather than final 60 FPS capacity. The pipeline diagnosis, measurements, tests, and fixes live in the standalone cadence PRs linked above.

## Review

The codec implementation, VP8 tuning, and the input-source integration were reviewed against the repository standards and request. Identified issues were fixed before the final rebase.
