### PR TITLE
Pin the standalone gRPC MMAP cadence fix

### DIFF
--- a/.changeset/tidy-mmap-cadence.md
+++ b/.changeset/tidy-mmap-cadence.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Preserve 60 FPS Android gRPC MMAP capture under normal notification and encoder-timer jitter.


### PR DESCRIPTION
## Summary

- advance the `serve-emu` submodule from the transport baseline in #56 to the isolated gRPC MMAP cadence fix in [expo/serve-emu#23](https://github.com/expo/serve-emu/pull/23)
- add the required patch changeset for `expo-device-hub`
- keep the cadence correction independent of the VP8/VP9 feature work

This PR is stacked on [expo-device-hub#56](https://github.com/expo/expo-device-hub/pull/56) because that PR advances the vendored transport baseline. It also depends on [expo/serve-emu#23](https://github.com/expo/serve-emu/pull/23). Relative to #56, the gitlink moves from `5483995` to `405c98e`; the only intervening upstream change is removal of an orphaned internal API-boundary module. No VP8/VP9 feature commit is included.

## Measured effect

The 436×980, 60 FPS gRPC MMAP profile showed that stable MMAP copying was not the bottleneck: two reads plus comparison measured 0.209 ms p50 and 0.478 ms p95 offline, and 0.6–0.9 ms p95 live.

| State | Raw notifications | Selected/usable | Fresh encoder writes | Encoded/WS |
| --- | ---: | ---: | ---: | ---: |
| Before fixes, H.264 mean | 60.005 | 37.637 | 37.637 | 40.237 |
| Scheduler fix only | 59.983 | 59.983 | 57.320 | 57.334 |
| Both fixes, H.264 mean | ~59.990 | 60.003 | 60.000 | 60.015 |

The original hard 16.67 ms admission deadline coalesced 895 of 2,401 notifications (37.3%). Once that alias was removed, accumulated timer lateness in the encoder-write pacer exposed the second codec-independent ~57.4 FPS ceiling. The isolated fix uses bounded frame credit for MMAP selection and a nominal phase grid for encoder writes.

All final codec runs recorded zero scheduler coalescing, encoder rejection, WebSocket loss/backpressure, MMAP retries, or torn reads.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- serve-emu `bun run check`: 850 tests passed, 0 failed, 4,797 assertions; coverage, all TypeScript checks, production build, and package smoke passed
- two-axis review: zero spec findings; standards review resolved by stacking this release diff on #56
