### PR TITLE
fix(expo-device-hub): wait for the emulator to leave adb before shutdown reports success

### DIFF
--- a/packages/@expo/hub-android-utils/src/__tests__/adb.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/adb.test.ts
@@ -1,8 +1,45 @@
-import { describe, expect, test } from "bun:test";
-import { buildEmuKillArgs } from "../adb";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildEmuKillArgs, runAdbDevices } from "../adb";
 
 describe("buildEmuKillArgs", () => {
   test("targets the serial and kills the emulator", () => {
     expect(buildEmuKillArgs("emulator-5554")).toEqual(["-s", "emulator-5554", "emu", "kill"]);
+  });
+});
+
+describe("runAdbDevices", () => {
+  let stalledAdb = "";
+  let directory = "";
+
+  beforeAll(() => {
+    directory = mkdtempSync(join(tmpdir(), "hub-adb-"));
+    stalledAdb = join(directory, "stalled-adb.sh");
+    writeFileSync(stalledAdb, "#!/bin/sh\nsleep 60\n");
+    chmodSync(stalledAdb, 0o755);
+  });
+
+  afterAll(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("kills a stalled adb once timeoutMs elapses", async () => {
+    const started = Date.now();
+    const listed = await runAdbDevices(stalledAdb, { timeoutMs: 150 });
+    expect(listed.value).toBeNull();
+    expect(listed.error?.message).toBe("[android-utils] Failed to run `adb devices -l`:");
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  test("kills a stalled adb as soon as the signal aborts", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 50);
+    const started = Date.now();
+    const listed = await runAdbDevices(stalledAdb, { signal: controller.signal });
+    expect(listed.value).toBeNull();
+    expect(listed.error).not.toBeNull();
+    expect(Date.now() - started).toBeLessThan(5000);
   });
 });

--- a/packages/@expo/hub-android-utils/src/__tests__/wait-for-adb-offline.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/wait-for-adb-offline.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { waitForAdbOffline } from "../wait-for-adb-offline";
+
+const listed = (value: string[]) => ({ value, error: null });
+
+describe("waitForAdbOffline", () => {
+  test("resolves true on the first poll when the serial is already gone", async () => {
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      return listed(["emulator-5556"]);
+    };
+    expect((await waitForAdbOffline("emulator-5554", 1000, { listSerialsFn })).value).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test("keeps polling until the serial leaves adb", async () => {
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      return listed(calls >= 3 ? [] : ["emulator-5554"]);
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 1000, {
+      listSerialsFn,
+      pollIntervalMs: 1,
+    });
+    expect(offline.value).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  test("a failed listing does not count as gone, then resolves true once it succeeds", async () => {
+    let calls = 0;
+    const error = {
+      message: "[android-utils] Failed to run `adb devices -l`:",
+      error: new Error("adb server killed"),
+    };
+    const listSerialsFn = async () => {
+      calls++;
+      return calls >= 3 ? listed([]) : { value: [], error };
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 1000, {
+      listSerialsFn,
+      pollIntervalMs: 1,
+    });
+    expect(offline).toEqual({ value: true, error: null });
+    expect(calls).toBe(3);
+  });
+
+  test("resolves false once the timeout elapses while the serial is still listed", async () => {
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      return listed(["emulator-5554"]);
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 30, {
+      listSerialsFn,
+      pollIntervalMs: 10,
+    });
+    expect(offline.value).toBe(false);
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("reports the last listing failure alongside false on timeout", async () => {
+    const error = {
+      message: "[android-utils] Failed to run `adb devices -l`:",
+      error: new Error("adb server killed"),
+    };
+    const listSerialsFn = async () => ({ value: [], error });
+    const offline = await waitForAdbOffline("emulator-5554", 30, {
+      listSerialsFn,
+      pollIntervalMs: 10,
+    });
+    expect(offline).toEqual({ value: false, error });
+  });
+
+  test("reports a thrown lister failure alongside false on timeout", async () => {
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      throw new Error("adb unavailable");
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 30, {
+      listSerialsFn,
+      pollIntervalMs: 10,
+    });
+    expect(offline.value).toBe(false);
+    expect(offline.error).not.toBeNull();
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("ignores other serials still attached to adb", async () => {
+    const listSerialsFn = async () => listed(["emulator-5556", "27151JEGR11854"]);
+    const offline = await waitForAdbOffline("emulator-5554", 30, {
+      listSerialsFn,
+      pollIntervalMs: 10,
+    });
+    expect(offline.value).toBe(true);
+  });
+
+  test("resolves false without polling when the signal is already aborted", async () => {
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      return listed([]);
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 1000, {
+      listSerialsFn,
+      pollIntervalMs: 1,
+      signal: AbortSignal.abort(),
+    });
+    expect(offline.value).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  test("stops polling once the signal aborts", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const listSerialsFn = async () => {
+      calls++;
+      controller.abort();
+      return listed(["emulator-5554"]);
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 1000, {
+      listSerialsFn,
+      pollIntervalMs: 1,
+      signal: controller.signal,
+    });
+    expect(offline.value).toBe(false);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/@expo/hub-android-utils/src/__tests__/wait-for-adb-offline.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/wait-for-adb-offline.test.ts
@@ -112,6 +112,62 @@ describe("waitForAdbOffline", () => {
     expect(calls).toBe(0);
   });
 
+  test("gives up at the deadline when a listing never resolves", async () => {
+    const started = Date.now();
+    const offline = await waitForAdbOffline("emulator-5554", 40, {
+      listSerialsFn: () => new Promise(() => {}),
+      pollIntervalMs: 10,
+    });
+    expect(offline.value).toBe(false);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  test("returns false as soon as the signal aborts mid-listing", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 10);
+    const started = Date.now();
+    const offline = await waitForAdbOffline("emulator-5554", 5000, {
+      listSerialsFn: () => new Promise((resolve) => setTimeout(() => resolve(listed([])), 1000)),
+      pollIntervalMs: 10,
+      signal: controller.signal,
+    });
+    expect(offline.value).toBe(false);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test("does not accept an empty listing that finishes after the deadline", async () => {
+    const listSerialsFn = async () => {
+      const until = Date.now() + 60;
+      while (Date.now() < until) {
+        // Hold the event loop so the listing wins its race despite the deadline passing.
+      }
+      return listed([]);
+    };
+    const offline = await waitForAdbOffline("emulator-5554", 20, {
+      listSerialsFn,
+      pollIntervalMs: 5,
+    });
+    expect(offline.value).toBe(false);
+  });
+
+  test("hands the lister the remaining budget and the signal", async () => {
+    const controller = new AbortController();
+    const seen: { timeoutMs: number; signal?: AbortSignal }[] = [];
+    const listSerialsFn = async (options: { timeoutMs: number; signal?: AbortSignal }) => {
+      seen.push(options);
+      return listed([]);
+    };
+    await waitForAdbOffline("emulator-5554", 50, {
+      listSerialsFn,
+      pollIntervalMs: 1,
+      signal: controller.signal,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.signal).toBe(controller.signal);
+    expect(seen[0]?.timeoutMs).toBeGreaterThan(0);
+    expect(seen[0]?.timeoutMs).toBeLessThanOrEqual(50);
+  });
+
   test("stops polling once the signal aborts", async () => {
     const controller = new AbortController();
     let calls = 0;

--- a/packages/@expo/hub-android-utils/src/adb.ts
+++ b/packages/@expo/hub-android-utils/src/adb.ts
@@ -6,11 +6,20 @@ const execFileAsync = promisify(execFile);
 
 /**
  * Run `adb devices -l` and return its stdout, or `null` on failure.
- * Never throws.
+ *
+ * `timeoutMs` kills the child once it elapses, and `signal` kills it as soon as
+ * the caller aborts. Both leave the failure in `error`. Without them a stalled
+ * `adb` never returns. Never throws.
  */
-export async function runAdbDevices(adbPath: string): Promise<AndroidUtilsResult<string | null>> {
+export async function runAdbDevices(
+  adbPath: string,
+  { timeoutMs, signal }: { timeoutMs?: number; signal?: AbortSignal } = {},
+): Promise<AndroidUtilsResult<string | null>> {
   try {
-    const { stdout } = await execFileAsync(adbPath, ["devices", "-l"]);
+    const { stdout } = await execFileAsync(adbPath, ["devices", "-l"], {
+      timeout: timeoutMs,
+      signal,
+    });
     return result(stdout);
   } catch (error) {
     return result(null, reportError("[android-utils] Failed to run `adb devices -l`:", error));

--- a/packages/@expo/hub-android-utils/src/index.ts
+++ b/packages/@expo/hub-android-utils/src/index.ts
@@ -6,6 +6,7 @@ export { listDevices } from "./list-devices";
 export { listSystemImages } from "./list-system-images";
 export { removeDevice } from "./remove-device";
 export { shutdownDevice } from "./shutdown-device";
+export { waitForAdbOffline } from "./wait-for-adb-offline";
 export { waitForAdbOnline } from "./wait-for-adb-online";
 export type {
   AndroidDevice,

--- a/packages/@expo/hub-android-utils/src/wait-for-adb-offline.ts
+++ b/packages/@expo/hub-android-utils/src/wait-for-adb-offline.ts
@@ -1,0 +1,59 @@
+import { homedir } from "node:os";
+import { runAdbDevices } from "./adb";
+import { type AndroidUtilsError, type AndroidUtilsResult, reportError, result } from "./errors";
+import { parseAdbDevices } from "./parse-adb-devices";
+import { resolveAdbPath } from "./sdk-paths";
+
+export const SHUTDOWN_POLL_INTERVAL_MS = 1500;
+
+async function listAdbSerials(): Promise<AndroidUtilsResult<string[]>> {
+  const adb = resolveAdbPath(process.env, homedir());
+  const listed = await runAdbDevices(adb);
+  if (listed.error) return result([], listed.error);
+  return result(listed.value ? parseAdbDevices(listed.value).map((device) => device.serial) : []);
+}
+
+export interface WaitForAdbOfflineOptions {
+  listSerialsFn?: () => Promise<AndroidUtilsResult<string[]>>;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Poll `adb devices -l` until `serial` is gone from it, or time out.
+ *
+ * Its result `value` becomes `true` on the first successful listing that no
+ * longer carries `serial`, or `false` once the timeout elapses or the signal
+ * aborts. A failed listing does not end the wait; the last failure is returned
+ * in `error` alongside `false`.
+ */
+export async function waitForAdbOffline(
+  serial: string,
+  timeoutMs: number,
+  {
+    listSerialsFn = listAdbSerials,
+    pollIntervalMs = SHUTDOWN_POLL_INTERVAL_MS,
+    signal,
+  }: WaitForAdbOfflineOptions = {},
+): Promise<AndroidUtilsResult<boolean>> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: AndroidUtilsError | null = null;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) return result(false, lastError);
+    try {
+      const listed = await listSerialsFn();
+      if (listed.error) {
+        lastError = listed.error;
+      } else if (!listed.value.includes(serial)) {
+        return result(true);
+      }
+    } catch (error) {
+      lastError = reportError(
+        "[android-utils] Failed to poll adb while waiting for it to release the serial:",
+        error,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  return result(false, lastError);
+}

--- a/packages/@expo/hub-android-utils/src/wait-for-adb-offline.ts
+++ b/packages/@expo/hub-android-utils/src/wait-for-adb-offline.ts
@@ -6,17 +6,77 @@ import { resolveAdbPath } from "./sdk-paths";
 
 export const SHUTDOWN_POLL_INTERVAL_MS = 1500;
 
-async function listAdbSerials(): Promise<AndroidUtilsResult<string[]>> {
+/** Lists the serials adb currently sees. Must finish within `timeoutMs` and stop on `signal`. */
+export type ListAdbSerialsFn = (options: {
+  timeoutMs: number;
+  signal?: AbortSignal;
+}) => Promise<AndroidUtilsResult<string[]>>;
+
+const listAdbSerials: ListAdbSerialsFn = async (options) => {
   const adb = resolveAdbPath(process.env, homedir());
-  const listed = await runAdbDevices(adb);
+  const listed = await runAdbDevices(adb, options);
   if (listed.error) return result([], listed.error);
   return result(listed.value ? parseAdbDevices(listed.value).map((device) => device.serial) : []);
-}
+};
 
 export interface WaitForAdbOfflineOptions {
-  listSerialsFn?: () => Promise<AndroidUtilsResult<string[]>>;
+  listSerialsFn?: ListAdbSerialsFn;
   pollIntervalMs?: number;
   signal?: AbortSignal;
+}
+
+/** Resolve `null` after `ms`, or as soon as `signal` aborts. `cancel` drops the timer and listener. */
+function startExpiry(
+  ms: number,
+  signal: AbortSignal | undefined,
+): { promise: Promise<null>; cancel: () => void } {
+  let cancel = () => {};
+  const promise = new Promise<null>((resolve) => {
+    const expire = () => {
+      cancel();
+      resolve(null);
+    };
+    const timer = setTimeout(expire, ms);
+    cancel = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", expire);
+    };
+    signal?.addEventListener("abort", expire, { once: true });
+  });
+  return { promise, cancel };
+}
+
+/** Run one listing and turn any throw into a failed result, so it never rejects. */
+async function listSafely(
+  listSerialsFn: ListAdbSerialsFn,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): Promise<AndroidUtilsResult<string[]>> {
+  try {
+    return await listSerialsFn({ timeoutMs, signal });
+  } catch (error) {
+    return result<string[]>(
+      [],
+      reportError(
+        "[android-utils] Failed to poll adb while waiting for it to release the serial:",
+        error,
+      ),
+    );
+  }
+}
+
+/** Await one listing, or give up with `null` once `timeoutMs` elapses or `signal` aborts. */
+async function listWithinBudget(
+  listSerialsFn: ListAdbSerialsFn,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): Promise<AndroidUtilsResult<string[]> | null> {
+  const expiry = startExpiry(timeoutMs, signal);
+  try {
+    return await Promise.race([listSafely(listSerialsFn, timeoutMs, signal), expiry.promise]);
+  } finally {
+    expiry.cancel();
+  }
 }
 
 /**
@@ -26,6 +86,11 @@ export interface WaitForAdbOfflineOptions {
  * longer carries `serial`, or `false` once the timeout elapses or the signal
  * aborts. A failed listing does not end the wait; the last failure is returned
  * in `error` alongside `false`.
+ *
+ * Each listing gets the remaining budget and the signal, so a stalled adb
+ * cannot hold the wait open. A listing that arrives after the deadline or after
+ * an abort is discarded rather than accepted, so the wait never reports `true`
+ * on stale output.
  */
 export async function waitForAdbOffline(
   serial: string,
@@ -40,20 +105,16 @@ export async function waitForAdbOffline(
   let lastError: AndroidUtilsError | null = null;
   while (Date.now() < deadline) {
     if (signal?.aborted) return result(false, lastError);
-    try {
-      const listed = await listSerialsFn();
-      if (listed.error) {
-        lastError = listed.error;
-      } else if (!listed.value.includes(serial)) {
-        return result(true);
-      }
-    } catch (error) {
-      lastError = reportError(
-        "[android-utils] Failed to poll adb while waiting for it to release the serial:",
-        error,
-      );
+    const listed = await listWithinBudget(listSerialsFn, deadline - Date.now(), signal);
+    if (listed === null || signal?.aborted || Date.now() >= deadline) {
+      return result(false, listed?.error ?? lastError);
     }
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    if (listed.error) {
+      lastError = listed.error;
+    } else if (!listed.value.includes(serial)) {
+      return result(true);
+    }
+    await startExpiry(Math.min(pollIntervalMs, deadline - Date.now()), signal).promise;
   }
   return result(false, lastError);
 }

--- a/packages/expo-device-hub/src/server/device-actions.ts
+++ b/packages/expo-device-hub/src/server/device-actions.ts
@@ -13,6 +13,7 @@ import {
   freeEmulatorPort,
   removeDevice as removeAndroidDevice,
   shutdownDevice as shutdownAndroidDevice,
+  waitForAdbOffline,
   waitForAdbOnline,
 } from '@expo/hub-android-utils';
 import {
@@ -115,6 +116,24 @@ function errorList(error: SerializableError | null): SerializableError[] {
   return error ? [error] : [];
 }
 
+const ANDROID_EXIT_TIMEOUT_MS = 30_000;
+
+async function shutdownAndroidHubDevice(serial: string): Promise<DeviceActionResult> {
+  const shutdown = await shutdownAndroidDevice({ serial });
+  if (shutdown.error || !shutdown.value) {
+    return { ok: false, errors: errorList(toSerializableError(shutdown.error)) };
+  }
+
+  const offline = await waitForAdbOffline(serial, ANDROID_EXIT_TIMEOUT_MS);
+  if (offline.value) return { ok: true, errors: [] };
+
+  const timedOut = {
+    message: `${serial} did not exit within ${ANDROID_EXIT_TIMEOUT_MS / 1000}s of the shutdown`,
+    error: offline.error?.error ?? null,
+  };
+  return { ok: false, errors: errorList(toSerializableError(timedOut)) };
+}
+
 /** Shut a running simulator/emulator down. Resolves to whether it succeeded. */
 export async function shutdownHubDevice({
   platform,
@@ -125,8 +144,7 @@ export async function shutdownHubDevice({
     return { ok: result.value, errors: errorList(toSerializableError(result.error)) };
   }
 
-  const result = await shutdownAndroidDevice({ serial: id });
-  return { ok: result.value, errors: errorList(toSerializableError(result.error)) };
+  return shutdownAndroidHubDevice(id);
 }
 
 /**
@@ -155,13 +173,8 @@ export async function removeHubDevice({
     };
   }
 
-  const shutdown = await shutdownAndroidDevice({ serial: id });
-  if (shutdown.error || !shutdown.value) {
-    return {
-      ok: false,
-      errors: errorList(toSerializableError(shutdown.error)),
-    };
-  }
+  const shutdown = await shutdownAndroidHubDevice(id);
+  if (!shutdown.ok) return shutdown;
 
   const removed = await removeAndroidDevice({ name });
   return {


### PR DESCRIPTION
## Why

`adb emu kill` returns in under 20 ms while the emulator is still exiting, and adb keeps serving the dying serial for around ten seconds. A boot started in that window fails with "Failed to allocate an emulator port", because `freeEmulatorPort` lists devices and `getprop` against the exiting serial errors. Shutdown followed by a boot from the picker hits this today on `main`.

## Scope

- `@expo/hub-android-utils`: new `waitForAdbOffline(serial, timeoutMs)`, exported next to `waitForAdbOnline`. It polls `adb devices -l` until the serial is gone or the timeout elapses. Each listing runs with the remaining budget and the abort signal, so a stalled adb cannot hold the wait open, and a listing that arrives after the deadline or an abort is discarded rather than accepted. `runAdbDevices` takes `timeoutMs` and `signal` and passes them to `execFile`, so the child is killed too.
- `expo-device-hub` server: `shutdownHubDevice` and `removeHubDevice` call `shutdownAndroidHubDevice`, which runs `adb emu kill` and then waits up to 30 seconds for adb to release the serial. A serial that stays listed makes the action fail with a timeout error instead of reporting success.

The wait reads only the raw listing. `listDevices` runs a `getprop` per device and fails the whole listing when any one device is locked or on its way out, which is exactly the window this waits through.

## Blast Radius

Android shutdown and remove now block for up to 30 seconds while the emulator exits, and fail instead of reporting success if it does not. iOS paths are untouched. The boot command is unchanged.

## Verification

- `bun test` in `hub-android-utils` (118, with cases for a listing that never resolves, an abort during a listing, an empty listing after the deadline, and the child timeout) and `expo-device-hub` (161): all pass. `bun run typecheck` and `bun run lint` at the root pass.
- Runtime, on the Hub dev server: `POST /api/devices/shutdown` for a running emulator returned `ok: true` after 4.6 seconds, and `adb devices` was already empty when it returned. A `POST /api/devices/boot` for the same AVD fired right after came online on the same serial. On `main` that second call fails with "Failed to allocate an emulator port".

The camera passthrough PR stacks on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
