### PR TITLE
feat(expo-device-hub): add a Camera section for Android emulators

### DIFF
--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -34,6 +34,21 @@ describe("buildEmulatorArgs", () => {
     const args = buildEmulatorArgs({ name: "x", port: 5556 });
     expect(args[args.indexOf("-port") + 1]).toBe("5556");
   });
+
+  test("appends extraArgs verbatim after the port", () => {
+    const args = buildEmulatorArgs({
+      name: "x",
+      port: 5554,
+      extraArgs: ["-camera-back", "imagefile:/tmp/a.png"],
+    });
+    expect(args.slice(-4)).toEqual(["-port", "5554", "-camera-back", "imagefile:/tmp/a.png"]);
+  });
+
+  test("adds nothing when extraArgs is empty or omitted", () => {
+    const plain = buildEmulatorArgs({ name: "x", port: 5554 });
+    expect(buildEmulatorArgs({ name: "x", port: 5554, extraArgs: [] })).toEqual(plain);
+    expect(plain.at(-1)).toBe("5554");
+  });
 });
 
 describe("formatEmulatorCommand", () => {
@@ -41,6 +56,15 @@ describe("formatEmulatorCommand", () => {
     const command = formatEmulatorCommand("/sdk/emulator/emulator", { name: "x", port: 5556 });
     expect(command.startsWith("/sdk/emulator/emulator ")).toBe(true);
     expect(command).toContain("-port 5556");
+  });
+
+  test("includes the extra args", () => {
+    const command = formatEmulatorCommand("/sdk/emulator/emulator", {
+      name: "x",
+      port: 5554,
+      extraArgs: ["-camera-back", "imagefile:/tmp/a.png"],
+    });
+    expect(command.endsWith("-port 5554 -camera-back imagefile:/tmp/a.png")).toBe(true);
   });
 
   test("quotes parts containing whitespace", () => {

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -22,6 +22,7 @@ export function buildEmulatorArgs(options: BootDeviceOptions): string[] {
     "-no-boot-anim",
     "-port",
     String(options.port),
+    ...(options.extraArgs ?? []),
   ];
 }
 

--- a/packages/@expo/hub-android-utils/src/index.ts
+++ b/packages/@expo/hub-android-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { bootDevice } from "./boot-device";
 export { createDevice } from "./create-device";
+export { emulatorSerial } from "./emulator";
 export { freeEmulatorPort } from "./free-emulator-port";
 export { listDeviceProfiles } from "./list-device-profiles";
 export { listDevices } from "./list-devices";

--- a/packages/@expo/hub-android-utils/src/types.ts
+++ b/packages/@expo/hub-android-utils/src/types.ts
@@ -106,6 +106,8 @@ export interface BootDeviceOptions {
   name: string;
   /** Console port → `emulator -port <port>`; the serial becomes `emulator-<port>`. */
   port: number;
+  /** Extra `emulator` flags appended after `-port <port>`, passed through verbatim. */
+  extraArgs?: readonly string[];
 }
 
 /** How a spawned emulator process ended (see {@link BootedDevice.exited}). */

--- a/packages/@expo/hub-client/src/__tests__/android-camera.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-camera.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  androidCameraErrorMessage,
+  androidCameraImagePath,
+  applyCameraRead,
+  keepPendingCameraFeeds,
+  NO_ANDROID_CAMERA,
+  parseAndroidCameraStatus,
+} from "../android-camera";
+import { type DeviceCameraFacing } from "../types";
+
+const stubImageUrl = (facing: DeviceCameraFacing, digest: string | null) =>
+  `image:${facing}:${digest ?? "none"}`;
+
+describe("Android camera status contract", () => {
+  test("normalizes a full serve-emu payload", () => {
+    const parsed = parseAndroidCameraStatus(
+      {
+        ok: true,
+        camera: {
+          serial: "emulator-5554",
+          supported: true,
+          wiredAtLaunch: true,
+          feeds: [
+            {
+              facing: "back",
+              path: "/tmp/back.png",
+              present: true,
+              placeholder: true,
+              width: 640,
+              height: 480,
+              bytes: 1024,
+              digest: "abc",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            {
+              facing: "front",
+              path: "/tmp/front.png",
+              present: false,
+              placeholder: false,
+              width: null,
+              height: null,
+              bytes: null,
+              digest: null,
+              updatedAt: null,
+            },
+          ],
+        },
+      },
+      stubImageUrl,
+    );
+
+    expect(parsed).toEqual({
+      supported: true,
+      status: {
+        wiredAtLaunch: true,
+        feeds: [
+          {
+            facing: "back",
+            placeholder: true,
+            width: 640,
+            height: 480,
+            bytes: 1024,
+            imageUrl: "image:back:abc",
+          },
+          {
+            facing: "front",
+            placeholder: false,
+            width: null,
+            height: null,
+            bytes: null,
+            imageUrl: null,
+          },
+        ],
+      },
+    });
+  });
+
+  test("rejects malformed payloads", () => {
+    const camera = { supported: true, wiredAtLaunch: false, feeds: [] };
+    expect(parseAndroidCameraStatus({ camera }, stubImageUrl)).toBeNull();
+    expect(parseAndroidCameraStatus({ ok: true }, stubImageUrl)).toBeNull();
+    expect(
+      parseAndroidCameraStatus({ ok: true, camera: { ...camera, feeds: {} } }, stubImageUrl),
+    ).toBeNull();
+    expect(
+      parseAndroidCameraStatus(
+        { ok: true, camera: { ...camera, wiredAtLaunch: "yes" } },
+        stubImageUrl,
+      ),
+    ).toBeNull();
+  });
+
+  test("drops a feed with an unknown facing and keeps its siblings", () => {
+    const parsed = parseAndroidCameraStatus(
+      {
+        ok: true,
+        camera: {
+          supported: true,
+          wiredAtLaunch: false,
+          feeds: [
+            { facing: "external", present: true, placeholder: false, digest: "zzz" },
+            { facing: "front", present: true, placeholder: false, digest: null },
+          ],
+        },
+      },
+      stubImageUrl,
+    );
+
+    expect(parsed?.status.feeds).toEqual([
+      {
+        facing: "front",
+        placeholder: false,
+        width: null,
+        height: null,
+        bytes: null,
+        imageUrl: "image:front:none",
+      },
+    ]);
+  });
+});
+
+describe("Android camera image path", () => {
+  test("adds the digest so a replaced image refetches", () => {
+    expect(androidCameraImagePath("back", "a b/c")).toBe(
+      "/api/camera/image?facing=back&v=a%20b%2Fc",
+    );
+    expect(androidCameraImagePath("front", null)).toBe("/api/camera/image?facing=front");
+  });
+});
+
+describe("Android camera error message", () => {
+  test("prefers the backend message over the HTTP status", () => {
+    expect(androidCameraErrorMessage(500, { error: "camera not wired at launch" })).toBe(
+      "camera not wired at launch",
+    );
+    expect(androidCameraErrorMessage(400, { error: 12 })).toBe("Camera update failed (400)");
+  });
+});
+
+describe("keepPendingCameraFeeds", () => {
+  const feed = (facing: "back" | "front", bytes: number) => ({
+    facing,
+    placeholder: false,
+    width: 4,
+    height: 3,
+    bytes,
+    imageUrl: `/img/${facing}/${bytes}`,
+  });
+  const current = { wiredAtLaunch: true, feeds: [feed("back", 1), feed("front", 1)] };
+  const next = { wiredAtLaunch: true, feeds: [feed("back", 2), feed("front", 2)] };
+
+  test("keeps the held feed for a pending facing and takes the rest from the new read", () => {
+    const merged = keepPendingCameraFeeds(current, next, new Set(["front"]));
+    expect(merged.feeds).toEqual([feed("back", 2), feed("front", 1)]);
+  });
+
+  test("returns the new read untouched when nothing is pending or nothing is held", () => {
+    expect(keepPendingCameraFeeds(current, next, new Set())).toBe(next);
+    expect(keepPendingCameraFeeds(null, next, new Set(["back"]))).toBe(next);
+  });
+});
+
+describe("applyCameraRead", () => {
+  const feed = {
+    facing: "back" as const,
+    placeholder: false,
+    width: 4,
+    height: 3,
+    bytes: 9,
+    imageUrl: "/img/back",
+  };
+  const held = {
+    status: { wiredAtLaunch: true, feeds: [feed] },
+    supported: true,
+  };
+
+  test("keeps the last good state when the read failed or could not be parsed", () => {
+    expect(applyCameraRead(held, null, new Set())).toBe(held);
+    expect(applyCameraRead(NO_ANDROID_CAMERA, null, new Set())).toBe(NO_ANDROID_CAMERA);
+  });
+
+  test("turns support off only from a payload that says so", () => {
+    const read = { supported: false, status: { wiredAtLaunch: false, feeds: [] } };
+    expect(applyCameraRead(held, read, new Set())).toEqual({
+      status: read.status,
+      supported: false,
+    });
+  });
+
+  test("holds the feed of a facing with a write in flight", () => {
+    const replaced = { ...feed, bytes: 1, imageUrl: "/img/back/old" };
+    const read = { supported: true, status: { wiredAtLaunch: true, feeds: [replaced] } };
+    expect(applyCameraRead(held, read, new Set(["back"])).status?.feeds).toEqual([feed]);
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/device-setting-writes.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/device-setting-writes.test.ts
@@ -1,41 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from '../device-setting-writes';
-
-describe('DeviceSettingWriteTracker', () => {
-  test('allows different options concurrently while rejecting a repeated write to the same option', () => {
-    const tracker = new DeviceSettingWriteTracker();
-
-    const appearance = tracker.start('appearance');
-    const textSize = tracker.start('text-size');
-
-    expect(appearance).not.toBeNull();
-    expect(textSize).not.toBeNull();
-    expect(tracker.start('appearance')).toBeNull();
-    expect(tracker.pending).toEqual(new Set(['appearance', 'text-size']));
-
-    expect(tracker.finish(appearance!)).toBeTrue();
-    expect(tracker.pending).toEqual(new Set(['text-size']));
-    expect(tracker.finish(textSize!)).toBeTrue();
-    expect(tracker.pending).toEqual(new Set());
-  });
-
-  test('invalidates stale completions when the active device changes', () => {
-    const tracker = new DeviceSettingWriteTracker();
-    const oldDeviceRequest = tracker.start('appearance')!;
-
-    tracker.reset();
-    const newDeviceRequest = tracker.start('appearance')!;
-
-    expect(tracker.isCurrent(oldDeviceRequest)).toBeFalse();
-    expect(tracker.finish(oldDeviceRequest)).toBeFalse();
-    expect(tracker.pending).toEqual(new Set(['appearance']));
-    expect(tracker.isCurrent(newDeviceRequest)).toBeTrue();
-  });
-});
+import { mergeAuthoritativeDeviceSetting } from '../device-setting-writes';
 
 describe('mergeAuthoritativeDeviceSetting', () => {
   test('rolls back only the failed option without clobbering another optimistic write', () => {

--- a/packages/@expo/hub-client/src/__tests__/keyed-write-tracker.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/keyed-write-tracker.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { KeyedWriteTracker } from "../keyed-write-tracker";
+import { type DeviceSettingKey } from "../types";
+
+describe("KeyedWriteTracker", () => {
+  test("allows different options concurrently while rejecting a repeated write to the same option", () => {
+    const tracker = new KeyedWriteTracker<DeviceSettingKey>();
+
+    const appearance = tracker.start("appearance");
+    const textSize = tracker.start("text-size");
+
+    expect(appearance).not.toBeNull();
+    expect(textSize).not.toBeNull();
+    expect(tracker.start("appearance")).toBeNull();
+    expect(tracker.pending).toEqual(new Set(["appearance", "text-size"]));
+
+    expect(tracker.finish(appearance!)).toBeTrue();
+    expect(tracker.pending).toEqual(new Set(["text-size"]));
+    expect(tracker.finish(textSize!)).toBeTrue();
+    expect(tracker.pending).toEqual(new Set());
+  });
+
+  test("invalidates stale completions when the active device changes", () => {
+    const tracker = new KeyedWriteTracker<DeviceSettingKey>();
+    const oldDeviceRequest = tracker.start("appearance")!;
+
+    tracker.reset();
+    const newDeviceRequest = tracker.start("appearance")!;
+
+    expect(tracker.isCurrent(oldDeviceRequest)).toBeFalse();
+    expect(tracker.finish(oldDeviceRequest)).toBeFalse();
+    expect(tracker.pending).toEqual(new Set(["appearance"]));
+    expect(tracker.isCurrent(newDeviceRequest)).toBeTrue();
+  });
+});

--- a/packages/@expo/hub-client/src/android-api-url.ts
+++ b/packages/@expo/hub-client/src/android-api-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Join an API path onto the base URL, **preserving any path prefix** the base
+ * carries. `baseUrl` is the `expo-serve-emu` plugin mount
+ * (`…/_expo/plugins/serve-emu`), so `new URL('/ws', baseUrl)` would drop
+ * that prefix and miss the plugin; a plain string join keeps it (and still works
+ * for a bare `http://localhost:3300` standalone serve-emu).
+ */
+export function apiUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/$/, "")}${path}`;
+}
+
+/** Same join, with the target device carried as a query parameter. */
+export function deviceApiUrl(baseUrl: string, path: string, device: string | null): string {
+  const url = new URL(apiUrl(baseUrl, path));
+  if (device) url.searchParams.set("device", device);
+  return url.toString();
+}

--- a/packages/@expo/hub-client/src/android-camera.ts
+++ b/packages/@expo/hub-client/src/android-camera.ts
@@ -1,0 +1,112 @@
+import { type DeviceCameraFacing, type DeviceCameraFeed, type DeviceCameraStatus } from "./types";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseFeed(
+  payload: unknown,
+  imageUrl: (facing: DeviceCameraFacing, digest: string | null) => string,
+): DeviceCameraFeed | null {
+  const data = asRecord(payload);
+  if (!data) return null;
+  const facing = data.facing;
+  if (facing !== "back" && facing !== "front") return null;
+  const placeholder = data.placeholder;
+  const present = data.present;
+  if (typeof placeholder !== "boolean" || typeof present !== "boolean") return null;
+  const digest = typeof data.digest === "string" ? data.digest : null;
+  return {
+    facing,
+    placeholder,
+    width: finiteNumber(data.width),
+    height: finiteNumber(data.height),
+    bytes: finiteNumber(data.bytes),
+    imageUrl: present ? imageUrl(facing, digest) : null,
+  };
+}
+
+/** One accepted `/api/camera` payload. */
+export interface AndroidCameraRead {
+  supported: boolean;
+  status: DeviceCameraStatus;
+}
+
+export function parseAndroidCameraStatus(
+  payload: unknown,
+  imageUrl: (facing: DeviceCameraFacing, digest: string | null) => string,
+): AndroidCameraRead | null {
+  const data = asRecord(payload);
+  if (!data || data.ok !== true) return null;
+  const camera = asRecord(data.camera);
+  if (!camera) return null;
+  const supported = camera.supported;
+  const wiredAtLaunch = camera.wiredAtLaunch;
+  if (typeof supported !== "boolean" || typeof wiredAtLaunch !== "boolean") return null;
+  if (!Array.isArray(camera.feeds)) return null;
+
+  const feeds = camera.feeds
+    .map((feed) => parseFeed(feed, imageUrl))
+    .filter((feed): feed is DeviceCameraFeed => feed !== null);
+
+  return { supported, status: { wiredAtLaunch, feeds } };
+}
+
+export function androidCameraImagePath(facing: DeviceCameraFacing, digest: string | null): string {
+  const path = `/api/camera/image?facing=${facing}`;
+  return digest === null ? path : `${path}&v=${encodeURIComponent(digest)}`;
+}
+
+export function androidCameraErrorMessage(status: number, payload: unknown): string {
+  const data = asRecord(payload);
+  if (data && typeof data.error === "string") return data.error;
+  return `Camera update failed (${status})`;
+}
+
+/** A status read that overlaps a write is stale for that facing, so the written feed stays. */
+export function keepPendingCameraFeeds(
+  current: DeviceCameraStatus | null,
+  next: DeviceCameraStatus,
+  pendingFacings: ReadonlySet<DeviceCameraFacing>,
+): DeviceCameraStatus {
+  if (pendingFacings.size === 0 || !current) return next;
+  return {
+    ...next,
+    feeds: next.feeds.map((feed) =>
+      pendingFacings.has(feed.facing)
+        ? (current.feeds.find((held) => held.facing === feed.facing) ?? feed)
+        : feed,
+    ),
+  };
+}
+
+/** Camera state held by the viewer between reads. */
+export interface AndroidCameraState {
+  status: DeviceCameraStatus | null;
+  supported: boolean;
+}
+
+export const NO_ANDROID_CAMERA: AndroidCameraState = { status: null, supported: false };
+
+/**
+ * Fold one `/api/camera` read into the held state.
+ *
+ * A failed or unreadable read keeps the last good state, so a transient error
+ * does not hide the camera controls. Only an accepted payload turns support off.
+ */
+export function applyCameraRead(
+  state: AndroidCameraState,
+  read: AndroidCameraRead | null,
+  pendingFacings: ReadonlySet<DeviceCameraFacing>,
+): AndroidCameraState {
+  if (!read) return state;
+  return {
+    status: keepPendingCameraFeeds(state.status, read.status, pendingFacings),
+    supported: read.supported,
+  };
+}

--- a/packages/@expo/hub-client/src/device-camera.ts
+++ b/packages/@expo/hub-client/src/device-camera.ts
@@ -1,0 +1,4 @@
+import { type DeviceCameraFacing } from "./types";
+
+/** Shared empty set so a client with no camera writes keeps a stable identity across renders. */
+export const NO_PENDING_CAMERA_WRITES: ReadonlySet<DeviceCameraFacing> = new Set();

--- a/packages/@expo/hub-client/src/device-setting-writes.ts
+++ b/packages/@expo/hub-client/src/device-setting-writes.ts
@@ -1,51 +1,5 @@
 import { type DeviceSettingKey, type DeviceSettings } from './types';
 
-/** Opaque identity for one in-flight option write. */
-export interface DeviceSettingWriteToken {
-  readonly key: DeviceSettingKey;
-  readonly generation: number;
-  readonly id: number;
-}
-
-/**
- * Tracks option writes independently by key.
- *
- * A key may have at most one live write, while different keys can be written
- * concurrently. Resetting advances the generation so completions from a
- * previous device/configuration cannot affect the current one.
- */
-export class DeviceSettingWriteTracker {
-  readonly #active = new Map<DeviceSettingKey, DeviceSettingWriteToken>();
-  #generation = 0;
-  #nextId = 0;
-
-  start(key: DeviceSettingKey): DeviceSettingWriteToken | null {
-    if (this.#active.has(key)) return null;
-    const token = { key, generation: this.#generation, id: ++this.#nextId };
-    this.#active.set(key, token);
-    return token;
-  }
-
-  isCurrent(token: DeviceSettingWriteToken): boolean {
-    return token.generation === this.#generation && this.#active.get(token.key) === token;
-  }
-
-  finish(token: DeviceSettingWriteToken): boolean {
-    if (!this.isCurrent(token)) return false;
-    this.#active.delete(token.key);
-    return true;
-  }
-
-  reset(): void {
-    this.#generation++;
-    this.#active.clear();
-  }
-
-  get pending(): ReadonlySet<DeviceSettingKey> {
-    return new Set(this.#active.keys());
-  }
-}
-
 /**
  * Apply the authoritative value for one failed option write without replacing
  * unrelated optimistic values that may still be in flight.

--- a/packages/@expo/hub-client/src/keyed-write-tracker.ts
+++ b/packages/@expo/hub-client/src/keyed-write-tracker.ts
@@ -1,0 +1,45 @@
+/** Opaque identity for one in-flight write. */
+export interface KeyedWriteToken<Key extends string> {
+  readonly key: Key;
+  readonly generation: number;
+  readonly id: number;
+}
+
+/**
+ * Tracks writes independently by key.
+ *
+ * A key may have at most one live write, while different keys can be written
+ * concurrently. Resetting advances the generation so completions from a
+ * previous device/configuration cannot affect the current one.
+ */
+export class KeyedWriteTracker<Key extends string> {
+  readonly #active = new Map<Key, KeyedWriteToken<Key>>();
+  #generation = 0;
+  #nextId = 0;
+
+  start(key: Key): KeyedWriteToken<Key> | null {
+    if (this.#active.has(key)) return null;
+    const token = { key, generation: this.#generation, id: ++this.#nextId };
+    this.#active.set(key, token);
+    return token;
+  }
+
+  isCurrent(token: KeyedWriteToken<Key>): boolean {
+    return token.generation === this.#generation && this.#active.get(token.key) === token;
+  }
+
+  finish(token: KeyedWriteToken<Key>): boolean {
+    if (!this.isCurrent(token)) return false;
+    this.#active.delete(token.key);
+    return true;
+  }
+
+  reset(): void {
+    this.#generation++;
+    this.#active.clear();
+  }
+
+  get pending(): ReadonlySet<Key> {
+    return new Set(this.#active.keys());
+  }
+}

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -109,6 +109,28 @@ export type DeviceSettingKey =
 /** Current backend-reported values. Missing keys are unavailable; `unsupported` keys are hidden. */
 export type DeviceSettings = Partial<Record<DeviceSettingKey, string>>;
 
+/** Which emulator camera a feed drives. */
+export type DeviceCameraFacing = 'back' | 'front';
+
+/** One emulator camera fed from a PNG on the host. */
+export interface DeviceCameraFeed {
+  facing: DeviceCameraFacing;
+  /** True while the feed still holds the backend's "no image set" test card. */
+  placeholder: boolean;
+  width: number | null;
+  height: number | null;
+  bytes: number | null;
+  /** Same-origin URL of the current PNG, or null when no file exists yet. Embeds the digest so a changed image refetches. */
+  imageUrl: string | null;
+}
+
+/** Host-side still-image camera feeds for an Android emulator. */
+export interface DeviceCameraStatus {
+  /** True when the emulator was launched with the feed files attached. False means images are stored but never shown. */
+  wiredAtLaunch: boolean;
+  feeds: readonly DeviceCameraFeed[];
+}
+
 /** One live CPU, memory, and network sample for the foreground iOS app. */
 export interface DeviceActivitySample {
   /** Milliseconds since the backend sampler started. */
@@ -287,6 +309,8 @@ export interface DeviceCapabilities {
   deviceSettings: boolean;
   activity: boolean;
   events: boolean;
+  /** Host-fed emulator camera images that the backend can read and replace. */
+  camera: boolean;
   /** Runtime encoder settings that can be read and patched. */
   streamSettings: DeviceStreamSettingCapabilities;
 }
@@ -461,6 +485,17 @@ export interface DeviceClient {
   deviceSettingsPending: ReadonlySet<DeviceSettingKey>;
   /** Change one simulator/device option. Unsupported keys are ignored by each backend. */
   setDeviceSetting: (key: DeviceSettingKey, value: string) => void;
+
+  /** Emulator camera feeds, or null before the first read or when the backend has none. */
+  camera: DeviceCameraStatus | null;
+  /** Facings with an image write or reset in flight. */
+  cameraPending: ReadonlySet<DeviceCameraFacing>;
+  /** Last failed camera write, cleared when the next write starts. */
+  cameraError: string | null;
+  /** Replace one facing's picture with a PNG. The backend refuses other formats. */
+  setCameraImage: (facing: DeviceCameraFacing, png: Blob) => void;
+  /** Restore the backend's "no image set" card for one facing. */
+  clearCameraImage: (facing: DeviceCameraFacing) => void;
 
   /** Backend-supported viewer transport and codec choices; null hides stream controls. */
   streamCapabilities: DeviceStreamCapabilities | null;

--- a/packages/@expo/hub-client/src/useAndroidCamera.ts
+++ b/packages/@expo/hub-client/src/useAndroidCamera.ts
@@ -1,0 +1,161 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+import { deviceApiUrl } from "./android-api-url";
+import {
+  androidCameraErrorMessage,
+  androidCameraImagePath,
+  applyCameraRead,
+  NO_ANDROID_CAMERA,
+  parseAndroidCameraStatus,
+} from "./android-camera";
+import { NO_PENDING_CAMERA_WRITES } from "./device-camera";
+import { KeyedWriteTracker } from "./keyed-write-tracker";
+import { type DeviceCameraFacing } from "./types";
+
+const CAMERA_POLL_MS = 3000;
+
+interface UseAndroidCameraOptions {
+  active: boolean;
+  baseUrl: string | null;
+  device: string | null;
+  /** Identity of the current connection. A change invalidates in-flight reads and writes. */
+  scope: string;
+  scopeRef: RefObject<string>;
+}
+
+function cameraImageUrl(baseUrl: string, device: string | null) {
+  return (facing: DeviceCameraFacing, digest: string | null) =>
+    deviceApiUrl(baseUrl, androidCameraImagePath(facing, digest), device);
+}
+
+/** Host-fed emulator camera images: polls serve-emu for the feeds and replaces them. */
+export function useAndroidCamera({
+  active,
+  baseUrl,
+  device,
+  scope,
+  scopeRef,
+}: UseAndroidCameraOptions) {
+  const [camera, setCamera] = useState(NO_ANDROID_CAMERA);
+  const [cameraPending, setCameraPending] =
+    useState<ReadonlySet<DeviceCameraFacing>>(NO_PENDING_CAMERA_WRITES);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const writeTrackerRef = useRef(new KeyedWriteTracker<DeviceCameraFacing>());
+
+  const writeCameraImage = useCallback(
+    (facing: DeviceCameraFacing, init: RequestInit) => {
+      if (!baseUrl) return;
+      const tracker = writeTrackerRef.current;
+      const request = tracker.start(facing);
+      if (!request) return;
+      const imageUrl = cameraImageUrl(baseUrl, device);
+      const statusUrl = deviceApiUrl(baseUrl, "/api/camera", device);
+
+      // A write response is authoritative for its own facing, so nothing is held back.
+      const applyStatus = (payload: unknown) => {
+        setCamera((current) =>
+          applyCameraRead(
+            current,
+            parseAndroidCameraStatus(payload, imageUrl),
+            NO_PENDING_CAMERA_WRITES,
+          ),
+        );
+      };
+
+      setCameraError(null);
+      setCameraPending(tracker.pending);
+
+      void fetch(deviceApiUrl(baseUrl, androidCameraImagePath(facing, null), device), init)
+        .then(async (response) => {
+          const payload: unknown = await response.json().catch(() => null);
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          if (response.ok) {
+            applyStatus(payload);
+            return;
+          }
+          setCameraError(androidCameraErrorMessage(response.status, payload));
+          const refreshed: unknown = await fetch(statusUrl, { cache: "no-store" })
+            .then((refresh) => (refresh.ok ? refresh.json() : null))
+            .catch(() => null);
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          applyStatus(refreshed);
+        })
+        .catch(() => {
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          setCameraError("Camera update failed");
+        })
+        .finally(() => {
+          if (tracker.finish(request)) setCameraPending(tracker.pending);
+        });
+    },
+    [baseUrl, device, scope, scopeRef],
+  );
+
+  const setCameraImage = useCallback(
+    (facing: DeviceCameraFacing, png: Blob) =>
+      writeCameraImage(facing, {
+        method: "POST",
+        headers: { "Content-Type": "image/png" },
+        body: png,
+      }),
+    [writeCameraImage],
+  );
+
+  const clearCameraImage = useCallback(
+    (facing: DeviceCameraFacing) => writeCameraImage(facing, { method: "DELETE" }),
+    [writeCameraImage],
+  );
+
+  useEffect(() => {
+    const tracker = writeTrackerRef.current;
+    tracker.reset();
+    setCameraPending(NO_PENDING_CAMERA_WRITES);
+    setCamera(NO_ANDROID_CAMERA);
+    setCameraError(null);
+    if (!active || !baseUrl) {
+      return;
+    }
+
+    let cancelled = false;
+    let polling = false;
+    let controller: AbortController | null = null;
+    const imageUrl = cameraImageUrl(baseUrl, device);
+    const url = deviceApiUrl(baseUrl, "/api/camera", device);
+
+    const poll = async () => {
+      if (cancelled || polling) return;
+      polling = true;
+      const pendingAtStart = tracker.pending;
+      const next = new AbortController();
+      controller = next;
+      try {
+        const response = await fetch(url, { cache: "no-store", signal: next.signal });
+        const read = response.ok ? parseAndroidCameraStatus(await response.json(), imageUrl) : null;
+        if (cancelled || scopeRef.current !== scope) return;
+        const pendingFacings = new Set([...pendingAtStart, ...tracker.pending]);
+        setCamera((current) => applyCameraRead(current, read, pendingFacings));
+      } catch {
+      } finally {
+        polling = false;
+      }
+    };
+
+    void poll();
+    const timer = setInterval(() => void poll(), CAMERA_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      controller?.abort();
+      tracker.reset();
+    };
+  }, [active, baseUrl, device, scope, scopeRef]);
+
+  return {
+    camera: camera.status,
+    cameraSupported: camera.supported,
+    cameraPending,
+    cameraError,
+    setCameraImage,
+    clearCameraImage,
+  };
+}

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -18,6 +18,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+import { apiUrl, deviceApiUrl } from './android-api-url';
 import {
   type AndroidSessionEvent,
   clearAndroidEventCursor,
@@ -39,11 +40,9 @@ import {
   androidStreamSourceErrorMessage,
   parseAndroidStreamSource,
 } from './android-stream-source';
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from './device-setting-writes';
+import { mergeAuthoritativeDeviceSetting } from './device-setting-writes';
 import { buildCodecString, isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
+import { KeyedWriteTracker } from './keyed-write-tracker';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
 import {
@@ -59,6 +58,7 @@ import {
   type StreamSwitchState,
   streamSwitchTimeoutMs,
 } from './stream-switch';
+import { useAndroidCamera } from './useAndroidCamera';
 import { useStreamSettingsResource } from './useStreamSettingsResource';
 import { type WebRtcIceServer, useWebRtcStream } from './useWebRtcStream';
 import { presentedVideoFrameDelta } from './video-frame-metadata';
@@ -131,23 +131,6 @@ const BUTTON_MESSAGE: Record<HardwareButton, Record<string, unknown> | null> = {
 };
 
 const TOUCH_ACTION = { begin: 'down', move: 'move', end: 'up' } as const;
-
-/**
- * Join an API path onto the base URL, **preserving any path prefix** the base
- * carries. `baseUrl` is the `expo-serve-emu` plugin mount
- * (`…/_expo/plugins/serve-emu`), so `new URL('/ws', baseUrl)` would drop
- * that prefix and miss the plugin; a plain string join keeps it (and still works
- * for a bare `http://localhost:3300` standalone serve-emu).
- */
-function apiUrl(baseUrl: string, path: string): string {
-  return `${baseUrl.replace(/\/$/, '')}${path}`;
-}
-
-function deviceApiUrl(baseUrl: string, path: string, device: string | null): string {
-  const url = new URL(apiUrl(baseUrl, path));
-  if (device) url.searchParams.set('device', device);
-  return url.toString();
-}
 
 export function androidWsUrlFor(
   baseUrl: string,
@@ -269,17 +252,17 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const logSeqRef = useRef(0);
   // Clear is viewer-local so it does not erase serve-emu's replayable session.
   const eventCursorRef = useRef(createAndroidEventCursor());
-  const deviceSettingWriteTrackerRef = useRef(new DeviceSettingWriteTracker());
+  const deviceSettingWriteTrackerRef = useRef(new KeyedWriteTracker<DeviceSettingKey>());
   const deviceSettingVersionsRef = useRef<Record<AndroidDeviceSettingKey, number>>({
     appearance: 0,
     network: 0,
     'text-size': 0,
   });
-  const deviceSettingScope = `${active ? 'active' : 'inactive'}\0${baseUrl ?? ''}\0${targetDevice ?? ''}`;
-  const deviceSettingScopeRef = useRef(deviceSettingScope);
+  const deviceScope = `${active ? 'active' : 'inactive'}\0${baseUrl ?? ''}\0${targetDevice ?? ''}`;
+  const deviceScopeRef = useRef(deviceScope);
   useLayoutEffect(() => {
-    deviceSettingScopeRef.current = deviceSettingScope;
-  }, [deviceSettingScope]);
+    deviceScopeRef.current = deviceScope;
+  }, [deviceScope]);
   const streamSourceRequestRef = useRef(0);
   const streamSourceRef = useRef<DeviceStreamSourceStatus | null>(null);
   const streamSourceLoadingRef = useRef(false);
@@ -437,7 +420,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       const request = tracker.start(key);
       if (!request) return;
       deviceSettingVersionsRef.current[settingKey]++;
-      const scope = deviceSettingScope;
+      const scope = deviceScope;
       const previous = deviceSettings?.[key];
       const url = deviceApiUrl(baseUrl, requestOptions.path, targetDevice);
 
@@ -455,12 +438,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           const payload: unknown = await response.json();
           const authoritative = parseAndroidDeviceSetting(settingKey, payload);
           if (authoritative === null) throw new Error('Device option update was rejected');
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           setDeviceSettings((current) => ({ ...(current ?? {}), [key]: authoritative }));
           if (key === 'appearance') setAppearanceState(authoritative as DeviceAppearance);
         })
         .catch(async () => {
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           let authoritative: string | null = null;
           try {
             const response = await fetch(url, { cache: 'no-store' });
@@ -473,7 +456,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
             // Restore the last rendered value if both write and refresh fail.
             authoritative = previous ?? null;
           }
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           setDeviceSettings((current) =>
             mergeAuthoritativeDeviceSetting(
               current,
@@ -491,13 +474,22 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           if (tracker.finish(request)) setDeviceSettingsPending(tracker.pending);
         });
     },
-    [baseUrl, deviceSettingScope, deviceSettings, targetDevice],
+    [baseUrl, deviceScope, deviceSettings, targetDevice],
   );
 
   const setAppearance = useCallback(
     (mode: DeviceAppearance) => setDeviceSetting('appearance', mode),
     [setDeviceSetting],
   );
+
+  const { camera, cameraSupported, cameraPending, cameraError, setCameraImage, clearCameraImage } =
+    useAndroidCamera({
+      active,
+      baseUrl: baseUrl ?? null,
+      device: targetDevice,
+      scope: deviceScope,
+      scopeRef: deviceScopeRef,
+    });
 
   const streamSettingsUrl =
     active && baseUrl ? deviceApiUrl(baseUrl, '/api/stream-settings', targetDevice) : null;
@@ -1573,7 +1565,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     let cancelled = false;
     let polling = false;
     let controllers: AbortController[] = [];
-    const scope = deviceSettingScope;
+    const scope = deviceScope;
 
     const poll = async (keys: readonly AndroidDeviceSettingKey[]) => {
       if (cancelled || polling) return;
@@ -1605,7 +1597,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         }),
       );
       polling = false;
-      if (cancelled || deviceSettingScopeRef.current !== scope) return;
+      if (cancelled || deviceScopeRef.current !== scope) return;
       if (!results.some((result) => result.handled)) return;
       setDeviceSettings((current) => {
         const next = { ...(current ?? {}) };
@@ -1645,7 +1637,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       for (const controller of controllers) controller.abort();
       tracker.reset();
     };
-  }, [active, baseUrl, deviceSettingScope, targetDevice]);
+  }, [active, baseUrl, deviceScope, targetDevice]);
 
   return {
     platform: 'android',
@@ -1668,6 +1660,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    camera,
+    cameraPending,
+    cameraError,
+    setCameraImage,
+    clearCameraImage,
     streamSettings,
     streamSettingsPending,
     updateStreamSettings,
@@ -1694,6 +1691,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       deviceSettings: true,
       activity: false,
       events: true,
+      camera: cameraSupported,
       streamSettings: { maxDimension: true },
     },
     foregroundApp,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -68,10 +68,9 @@ import {
   type ScreenSize,
   type TouchSample,
 } from './types';
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from './device-setting-writes';
+import { NO_PENDING_CAMERA_WRITES } from './device-camera';
+import { mergeAuthoritativeDeviceSetting } from './device-setting-writes';
+import { KeyedWriteTracker } from './keyed-write-tracker';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
 import { normalizeDeviceStreamSettings } from './stream-settings';
 import { useAvccStream } from './useAvccStream';
@@ -413,7 +412,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   const [webRtcCodec, setWebRtcCodecState] = useState<DeviceWebRtcCodec>('h264');
   const [activeWebRtcCodec, setActiveWebRtcCodec] = useState<WebRtcCodec>('h264');
   const [webRtcHttpFallback, setWebRtcHttpFallback] = useState(false);
-  const deviceSettingWriteTrackerRef = useRef(new DeviceSettingWriteTracker());
+  const deviceSettingWriteTrackerRef = useRef(new KeyedWriteTracker<DeviceSettingKey>());
   // Async option writes capture their config. Track only committed config so
   // an interrupted concurrent render cannot invalidate a legitimate rollback.
   const deviceSettingConfigRef = useRef(config);
@@ -1351,6 +1350,11 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    camera: null,
+    cameraPending: NO_PENDING_CAMERA_WRITES,
+    cameraError: null,
+    setCameraImage: () => {},
+    clearCameraImage: () => {},
     streamCapabilities: IOS_STREAM_CAPABILITIES,
     streamSettings,
     streamSettingsPending,
@@ -1369,6 +1373,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       deviceSettings: !!execWsUrl && !!execToken && !!deviceUdid,
       activity: !!metricsPath,
       events: !!eventsPath,
+      camera: false,
       streamSettings: streamSettingsUrl
         ? {
             mjpegFps: true,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -1,3 +1,4 @@
+import { NO_PENDING_CAMERA_WRITES } from './device-camera';
 import { DeviceClient } from './types';
 
 /** Inert client returned while no device is selected — module-level so its
@@ -23,6 +24,11 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   deviceSettings: null,
   deviceSettingsPending: new Set(),
   setDeviceSetting: () => {},
+  camera: null,
+  cameraPending: NO_PENDING_CAMERA_WRITES,
+  cameraError: null,
+  setCameraImage: () => {},
+  clearCameraImage: () => {},
   streamCapabilities: null,
   streamSettings: null,
   streamSettingsPending: false,
@@ -41,6 +47,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
     deviceSettings: false,
     activity: false,
     events: false,
+    camera: false,
     streamSettings: false,
   },
   foregroundApp: null,

--- a/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import { type DeviceCameraStatus, type DeviceClient } from "@expo/hub-client";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CameraSection } from "../dashboard/CameraSection";
+
+const BASE_CLIENT: DeviceClient = {
+  platform: "android",
+  status: "streaming",
+  error: null,
+  screen: { width: 1080, height: 2400 },
+  fps: 60,
+  devices: [],
+  logs: [],
+  logsEnabled: false,
+  attachLogs: () => {},
+  detachLogs: () => {},
+  clearLogs: () => {},
+  events: [],
+  eventsEnabled: false,
+  attachEvents: () => {},
+  detachEvents: () => {},
+  clearEvents: () => {},
+  activity: null,
+  deviceSettings: null,
+  deviceSettingsPending: new Set(),
+  setDeviceSetting: () => {},
+  camera: null,
+  cameraPending: new Set(),
+  cameraError: null,
+  setCameraImage: () => {},
+  clearCameraImage: () => {},
+  streamCapabilities: null,
+  streamSettings: null,
+  streamSettingsPending: false,
+  updateStreamSettings: () => {},
+  streamSource: null,
+  streamSourcePending: false,
+  streamSourceError: null,
+  setStreamSource: () => {},
+  setGrpcImageMode: () => {},
+  setGrpcInputSource: () => {},
+  streamStats: null,
+  setStreamStatsEnabled: () => {},
+  webRtcCodec: "h264",
+  setWebRtcCodec: () => {},
+  capabilities: {
+    deviceSettings: false,
+    activity: false,
+    events: false,
+    camera: true,
+    streamSettings: {},
+  },
+  foregroundApp: null,
+  videoKind: "img",
+  attachVideo: () => {},
+  sendTouch: () => {},
+  sendKey: () => false,
+  pressButton: () => {},
+  reload: () => {},
+  rotate: () => {},
+  screenshot: async () => null,
+  appearance: "light",
+  setAppearance: () => {},
+  hardwareKeyboardConnected: null,
+  setHardwareKeyboardConnected: () => {},
+  toggleSoftwareKeyboard: () => {},
+};
+
+function cameraClient(overrides: Partial<DeviceClient> = {}): DeviceClient {
+  return { ...BASE_CLIENT, ...overrides };
+}
+
+function cameraStatus(wiredAtLaunch: boolean): DeviceCameraStatus {
+  return {
+    wiredAtLaunch,
+    feeds: [
+      {
+        facing: "back",
+        placeholder: false,
+        width: 1280,
+        height: 960,
+        bytes: 204_800,
+        imageUrl: "/camera/back.png",
+      },
+      {
+        facing: "front",
+        placeholder: true,
+        width: 640,
+        height: 480,
+        bytes: 1_024,
+        imageUrl: "/camera/front.png",
+      },
+    ],
+  };
+}
+
+const FEED_LABELS = ["Back camera", "Front camera"];
+
+function feedMarkup(html: string, label: string) {
+  const start = html.indexOf(`>${label}<`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const following = FEED_LABELS.filter((other) => other !== label)
+    .map((other) => html.indexOf(`>${other}<`, start + 1))
+    .filter((index) => index > start);
+  return html.slice(start, following.length > 0 ? Math.min(...following) : html.length);
+}
+
+function buttonTag(markup: string, label: string) {
+  const labelIndex = markup.indexOf(`>${label}</span>`);
+  expect(labelIndex).toBeGreaterThanOrEqual(0);
+
+  const start = markup.lastIndexOf("<button", labelIndex);
+  return markup.slice(start, markup.indexOf(">", start) + 1);
+}
+
+function render(client: DeviceClient) {
+  return renderToStaticMarkup(<CameraSection client={client} defaultOpen />);
+}
+
+describe("CameraSection", () => {
+  test("shows both feeds and keeps Reset available only for a replaced image", () => {
+    const html = render(cameraClient({ camera: cameraStatus(true) }));
+
+    const back = feedMarkup(html, "Back camera");
+    const front = feedMarkup(html, "Front camera");
+    expect(back).toContain('src="/camera/back.png"');
+    expect(back).toContain("1280×960 · 200.0 KB");
+    expect(front).toContain("640×480 · Test card");
+    expect(buttonTag(back, "Reset")).not.toContain("disabled");
+    expect(buttonTag(front, "Reset")).toContain('disabled=""');
+  });
+
+  test("explains an emulator booted without camera feeds and disables every control", () => {
+    const html = render(cameraClient({ camera: cameraStatus(false) }));
+
+    expect(html).toContain(
+      "This emulator started without camera feeds. Shut it down and boot it from Hub to attach them.",
+    );
+    for (const label of FEED_LABELS) {
+      const feed = feedMarkup(html, label);
+      expect(buttonTag(feed, "Choose PNG…")).toContain('disabled=""');
+      expect(buttonTag(feed, "Reset")).toContain('disabled=""');
+      expect(feed).toContain('aria-disabled="true"');
+    }
+  });
+
+  test("reports a failed write as an alert", () => {
+    const html = render(
+      cameraClient({ camera: cameraStatus(true), cameraError: "The emulator rejected the image." }),
+    );
+
+    const alert = html.match(/<span role="alert"[^>]*>([^<]*)<\/span>/);
+    expect(alert?.[1]).toBe("The emulator rejected the image.");
+  });
+});

--- a/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
@@ -1,0 +1,175 @@
+import { type DragEvent, type KeyboardEvent, useRef, useState } from "react";
+
+import {
+  type DeviceCameraFacing,
+  type DeviceCameraFeed,
+  type DeviceClient,
+} from "@expo/hub-client";
+import { Button, bg, border, radius, text, textSize } from "../primitives";
+import { CollapsibleSection } from "./CollapsibleSection";
+import { SectionNote } from "./SectionNote";
+
+const CAMERA_FACING_ORDER: readonly DeviceCameraFacing[] = ["back", "front"];
+const FACING_LABELS: Record<DeviceCameraFacing, string> = {
+  back: "Back camera",
+  front: "Front camera",
+};
+
+const UNWIRED_NOTE =
+  "This emulator started without camera feeds. Shut it down and boot it from Hub to attach them.";
+const CLOSING_NOTE = "PNG only. The app sees a new image after it reopens the camera.";
+
+function formatBytes(value: number) {
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 ** 2).toFixed(1)} MB`;
+}
+
+function feedStatus(feed: DeviceCameraFeed) {
+  if (feed.imageUrl === null) return "No image";
+
+  const parts: string[] = [];
+  if (feed.width !== null && feed.height !== null) parts.push(`${feed.width}×${feed.height}`);
+  if (feed.placeholder) parts.push("Test card");
+  else if (feed.bytes !== null) parts.push(formatBytes(feed.bytes));
+  return parts.join(" · ") || "Image set";
+}
+
+/** Host-fed emulator camera images: one preview, picker, and reset per facing. */
+export function CameraSection({
+  client,
+  defaultOpen = false,
+}: {
+  client: DeviceClient;
+  /** Whether the section is initially expanded. */
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const inputs = useRef<Record<DeviceCameraFacing, HTMLInputElement | null>>({
+    back: null,
+    front: null,
+  });
+  const camera = client.camera;
+  const wired = camera?.wiredAtLaunch ?? false;
+
+  function openPicker(facing: DeviceCameraFacing) {
+    inputs.current[facing]?.click();
+  }
+
+  return (
+    <CollapsibleSection title="Camera" open={open} onOpenChange={setOpen}>
+      {camera === null ? (
+        <SectionNote>Reading camera feeds…</SectionNote>
+      ) : (
+        <>
+          {!wired && <SectionNote>{UNWIRED_NOTE}</SectionNote>}
+          {CAMERA_FACING_ORDER.map((facing) => {
+            const feed = camera.feeds.find((item) => item.facing === facing);
+            if (!feed) return null;
+
+            const label = FACING_LABELS[facing];
+            const pending = client.cameraPending.has(facing);
+            const disabled = pending || !wired;
+            const pickerHandlers = disabled
+              ? {}
+              : {
+                  onDragOver: (event: DragEvent<HTMLDivElement>) => event.preventDefault(),
+                  onDrop: (event: DragEvent<HTMLDivElement>) => {
+                    event.preventDefault();
+                    const file = event.dataTransfer.files[0];
+                    if (file) client.setCameraImage(facing, file);
+                  },
+                  onClick: () => openPicker(facing),
+                  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    openPicker(facing);
+                  },
+                };
+            return (
+              <div key={facing} style={{ padding: "0 0 12px" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    padding: "0 0 6px",
+                  }}
+                >
+                  <span style={{ ...textSize.sm, fontWeight: 500, color: text.secondary }}>
+                    {label}
+                  </span>
+                  <span style={{ ...textSize.xs, color: text.tertiary }}>{feedStatus(feed)}</span>
+                </div>
+                <div
+                  role="button"
+                  tabIndex={disabled ? -1 : 0}
+                  aria-disabled={disabled || undefined}
+                  aria-label={`Choose a PNG for the ${facing} camera`}
+                  {...pickerHandlers}
+                  style={{
+                    aspectRatio: "4 / 3",
+                    width: "100%",
+                    boxSizing: "border-box",
+                    backgroundColor: bg.subtle,
+                    border: `1px solid ${border.default}`,
+                    borderRadius: radius.md,
+                    overflow: "hidden",
+                    cursor: disabled ? "default" : "pointer",
+                  }}
+                >
+                  {feed.imageUrl && (
+                    <img
+                      src={feed.imageUrl}
+                      alt={`${label} image`}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        display: "block",
+                      }}
+                    />
+                  )}
+                </div>
+                <div style={{ display: "flex", gap: 8, padding: "8px 0 0" }}>
+                  <Button
+                    theme="secondary"
+                    size="xs"
+                    disabled={disabled}
+                    onClick={() => openPicker(facing)}
+                  >
+                    Choose PNG…
+                  </Button>
+                  <Button
+                    theme="tertiary"
+                    size="xs"
+                    disabled={disabled || feed.placeholder}
+                    onClick={() => client.clearCameraImage(facing)}
+                  >
+                    Reset
+                  </Button>
+                </div>
+                {pending && <SectionNote role="status">{`Updating ${facing} camera…`}</SectionNote>}
+                <input
+                  ref={(node) => {
+                    inputs.current[facing] = node;
+                  }}
+                  type="file"
+                  accept="image/png"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) client.setCameraImage(facing, file);
+                    event.target.value = "";
+                  }}
+                  style={{ display: "none" }}
+                />
+              </div>
+            );
+          })}
+          {client.cameraError && <SectionNote role="alert">{client.cameraError}</SectionNote>}
+          <SectionNote>{CLOSING_NOTE}</SectionNote>
+        </>
+      )}
+    </CollapsibleSection>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -4,6 +4,7 @@ import {
   type DeviceStreamMode,
 } from '@expo/hub-client';
 import { SidebarToggle, bg } from '../primitives';
+import { CameraSection } from './CameraSection';
 import { SIDEBAR_SECTION_INSET } from './CollapsibleSection';
 import { CurrentAppSection } from './CurrentAppSection';
 import { DeviceOptionsSection } from './DeviceOptionsSection';
@@ -45,9 +46,6 @@ export type LogSidebarProps = {
 /**
  * Right column: a compact inspector for the selected device, rendered directly
  * on the dashboard canvas so it matches the existing sidebar treatment.
- *
- * Section order: Current app (with its activity charts), Device options,
- * Stream options, Events, Logs. The first two start open.
  */
 export function LogSidebar({
   onToggle,
@@ -130,6 +128,7 @@ export function LogSidebar({
             onHttpCodecChange={onHttpCodecChange}
           />
         )}
+        {client?.capabilities.camera && <CameraSection client={client} />}
         {client?.capabilities.events && <EventsSection client={client} />}
         <LogsSection client={client} />
       </div>

--- a/packages/@expo/hub-components/src/dashboard/SectionNote.tsx
+++ b/packages/@expo/hub-components/src/dashboard/SectionNote.tsx
@@ -1,0 +1,18 @@
+import { text, textSize } from "../primitives";
+
+export function SectionNote({ children, role }: { children: string; role?: "alert" | "status" }) {
+  return (
+    <span
+      role={role}
+      aria-live={role === "status" ? "polite" : undefined}
+      style={{
+        ...textSize.xs,
+        display: "block",
+        padding: "0 0 8px",
+        color: role === "alert" ? text.danger : text.tertiary,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -11,8 +11,9 @@ import {
   type DeviceStreamSource,
   type DeviceWebRtcCodec,
 } from '@expo/hub-client';
-import { Select, type SelectOption, text, textSize } from '../primitives';
+import { Select, type SelectOption } from '../primitives';
 import { CollapsibleSection } from './CollapsibleSection';
+import { SectionNote } from './SectionNote';
 import { SidebarRow } from './SidebarRow';
 import { type StreamModeAvailability } from './StreamSection';
 import { StreamStatistics } from './StreamStatistics';
@@ -115,29 +116,6 @@ function withCurrentValue(
   return options.some((option) => option.value === current)
     ? options
     : [{ value: current, label: label(value) }, ...options];
-}
-
-function SectionNote({
-  children,
-  role,
-}: {
-  children: string;
-  role?: 'alert' | 'status';
-}) {
-  return (
-    <span
-      role={role}
-      aria-live={role === 'status' ? 'polite' : undefined}
-      style={{
-        ...textSize.xs,
-        display: 'block',
-        padding: '0 0 8px',
-        color: role === 'alert' ? text.danger : text.tertiary,
-      }}
-    >
-      {children}
-    </span>
-  );
 }
 
 /** Viewer transport, backend-supported codecs, and optional runtime encoder controls. */

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -70,6 +70,7 @@ export {
   type DeviceFrameOption,
 } from './dashboard/DeviceOptionsSection';
 export { ActivityCharts, ActivitySection } from './dashboard/ActivitySection';
+export { CameraSection } from './dashboard/CameraSection';
 export { EventsSection } from './dashboard/EventsSection';
 export { LogsSection } from './dashboard/LogsSection';
 export { CollapsibleSection } from './dashboard/CollapsibleSection';

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -46,6 +46,11 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       : { appearance: 'light', network: 'on', 'text-size': 'medium' },
     deviceSettingsPending: new Set(),
     setDeviceSetting: () => {},
+    camera: null,
+    cameraPending: new Set(),
+    cameraError: null,
+    setCameraImage: () => {},
+    clearCameraImage: () => {},
     streamCapabilities: ios
       ? {
           modeAvailability: { mjpeg: true, h264: true, webrtc: true },
@@ -89,6 +94,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       deviceSettings: true,
       activity: ios,
       events: true,
+      camera: false,
       streamSettings: ios
         ? {
             mjpegFps: true,
@@ -1146,9 +1152,10 @@ test('keeps the frame option disabled with an explanation for unsupported device
         deviceSettings: false,
         activity: false,
         events: true,
+        camera: false,
         streamSettings: false,
       },
-    };
+    } satisfies DeviceClient;
     const html = renderToStaticMarkup(
       <LogSidebar
         client={client}
@@ -1173,10 +1180,11 @@ test('shows only the viewer-local frame option while iOS device settings are una
       deviceSettings: false,
       activity: false,
       events: true,
+      camera: false,
       streamSettings: false,
     },
     deviceSettings: null,
-  };
+  } satisfies DeviceClient;
   const html = renderToStaticMarkup(
     <LogSidebar
       client={client}

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -379,6 +379,30 @@ test('renders Android stream options while omitting unsupported and iOS-only sec
   }
 });
 
+test('shows the Camera section only when the client reports camera feeds', () => {
+  const android = inspectorClient('android');
+  const html = renderToStaticMarkup(
+    <LogSidebar
+      client={{
+        ...android,
+        camera: { wiredAtLaunch: true, feeds: [] },
+        capabilities: { ...android.capabilities, camera: true },
+      }}
+    />,
+  );
+
+  expect(html).toContain('<section aria-label="Camera"');
+  const camera = sectionMarkup(html, 'Camera');
+  expect(camera).toContain('>Camera</span>');
+  expect(camera).toContain('aria-expanded="false"');
+  const cameraIndex = html.indexOf('<section aria-label="Camera"');
+  expect(cameraIndex).toBeGreaterThan(html.indexOf('<section aria-label="Stream options"'));
+  expect(cameraIndex).toBeLessThan(html.indexOf('<section aria-label="Events"'));
+
+  const iosHtml = renderToStaticMarkup(<LogSidebar client={inspectorClient('ios')} />);
+  expect(iosHtml).not.toContain('<section aria-label="Camera"');
+});
+
 test('shows Android resolution while omitting encoder settings serve-emu cannot change', () => {
   const html = renderToStaticMarkup(
     <StreamOptionsSection


### PR DESCRIPTION
## Why

serve-emu can now feed an Android emulator's camera from a PNG on the host (expo/serve-emu#18, with the middleware routes in expo/serve-emu#22). The Hub boots emulators itself, so nothing in serve-emu can attach the feeds for it. This PR does the wiring on the Hub side and gives the inspector a Camera section, so a person or an agent can hand the app under test a known picture without leaving the dashboard.

The feed path is fixed at emulator launch. That is why every emulator the Hub boots gets the feeds attached, with no toggle. An opt-in would leave the panel dead until a restart, and serve-emu's test card is a fair default for an app under test.

## Scope

- `packages/serve-emu` is pinned to `dbd0174`, the head of expo/serve-emu#22, which stacks on #18. Re-pin once both land.
- `@expo/hub-android-utils`: `BootDeviceOptions.extraArgs` appends emulator flags after `-port`. `emulatorSerial` is exported.
- `expo-device-hub` server: `bootAndroidHubDevice` seeds both feeds, boots with `cameraLaunchArgs(serial)`, and calls `router.setCameraWired(serial, true)` right after the spawn. The claim clears when the process exits, through `booted.exited`, and on shutdown and remove. A seed failure boots the emulator without the camera flags and reports the failure in `errors`. `device-actions.ts` depends on one `EmulatorCameraFeeds` collaborator, and `serve-emu.ts` supplies it from the vendored middleware.
- `@expo/hub-client`: `useAndroidCamera` polls `GET /api/camera` and the Android client exposes `camera`, `cameraPending`, `cameraError`, `setCameraImage`, and `clearCameraImage` on `DeviceClient`. `capabilities.camera` is true once the backend reports a supported emulator. `parseAndroidCameraStatus` is the one trust boundary and `applyCameraRead` folds every read into the held state, so a failed read keeps the last good status. `KeyedWriteTracker` in `keyed-write-tracker.ts` replaces `DeviceSettingWriteTracker` so device settings and camera facings share it. `apiUrl` and `deviceApiUrl` move to `android-api-url.ts`.
- `@expo/hub-components`: `CameraSection` renders one 4:3 preview per facing with a PNG picker, a drop target, and Reset. `LogSidebar` places it between Stream options and Events. `SectionNote` moves out of `StreamOptionsSection`.

Out of scope: iOS. serve-sim's camera is CLI only and has no mutating middleware route yet.

## Tradeoffs

- Camera writes are not optimistic. The backend's response is the authoritative status. A rejected upload must not show a picture the emulator does not hold, so the UI waits for the answer.
- The wiring claim lives in the router process. A Hub restart loses it, so a wired emulator that outlives the Hub shows as unwired until it is rebooted. Fixing that means deriving the claim in serve-emu's `readCameraStatus`, which is an upstream follow-up on expo/serve-emu#22.
- An emulator started outside the Hub has no wiring claim. The section still shows, with the controls disabled and a note to boot it from the Hub, instead of accepting uploads the emulator would never display.

## Blast Radius

Every Android emulator the Hub boots now runs with `-camera-back imagefile:… -camera-front imagefile:…`. Its camera shows serve-emu's checkerboard test card instead of the emulator's virtual scene until an image is posted. Emulators booted elsewhere, physical devices, and iOS simulators are untouched. `DeviceClient` gains required members, so any consumer that builds one by hand (the website) must add them.

## Verification

- `bun test` in `hub-android-utils` (106), `hub-client` (163), `hub-components` (23), and `expo-device-hub` (171): all pass. `bun run typecheck` and `bun run lint` at the root: 11 and 4 tasks pass. `bun run build:server` bundles.
- Ran the Hub dev server from this worktree with the vendored serve-emu at the pinned commit. Booted the `serve_emu_cam` AVD through `POST /api/devices/boot`. The emulator process carries both camera flags and `GET /vendor/serve-emu/api/camera?device=emulator-5556` reports `wiredAtLaunch: true`.
- A script against the Hub mount: status reads, a posted 1280x960 PNG comes back with a matching digest and identical bytes, a JPEG body is refused with 400 and the other feed stays untouched.
- Opened the camera app on that emulator over adb and captured the screen. The preview shows the posted fixture.
- In the dashboard, the Camera section for that emulator showed the posted back image and the front test card with the controls enabled. A drop of a PNG onto the front box updated it. A drop of a JPEG showed the backend's PNG-only message as an alert. A click on Reset restored the test card.
- For the emulator booted outside the Hub, the section showed the unwired note with every control disabled.
- After `POST /api/devices/shutdown`, the status for that serial reports `wiredAtLaunch: false`.
- Exit watcher: booted an emulator through the Hub (claim true), killed it with `adb emu kill` outside the Hub, then started a flagless emulator on the same serial outside the Hub. The status for that serial reports `wiredAtLaunch: false`.
- A three-model adversarial review ran over the diff. Its seven act-on findings are resolved in these commits.

Stacks on #62, which makes shutdown wait for adb to release the serial. Depends on expo/serve-emu#18 and expo/serve-emu#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
