### PR TITLE
feat(hub-android-utils): accept extra emulator flags on boot

### DIFF
--- a/packages/@expo/hub-android-utils/README.md
+++ b/packages/@expo/hub-android-utils/README.md
@@ -84,6 +84,7 @@ if (created) {
   detached so it keeps running after the parent exits. Returns as soon as the
   process is spawned — not once Android has finished booting — so wait for boot
   with adb using the returned `value.serial` (`emulator-<port>`).
+  `extraArgs` appends emulator flags after `-port`, verbatim.
 
 All four resolve their binaries the same way as `listDevices()` and return
 `{ value, error }`: the listers use `[]`, `createDevice` uses `false`, and

--- a/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
+++ b/packages/@expo/hub-android-utils/src/__tests__/emulator.test.ts
@@ -34,6 +34,21 @@ describe("buildEmulatorArgs", () => {
     const args = buildEmulatorArgs({ name: "x", port: 5556 });
     expect(args[args.indexOf("-port") + 1]).toBe("5556");
   });
+
+  test("appends extraArgs verbatim after the port", () => {
+    const args = buildEmulatorArgs({
+      name: "x",
+      port: 5554,
+      extraArgs: ["-camera-back", "imagefile:/tmp/a.png"],
+    });
+    expect(args.slice(-4)).toEqual(["-port", "5554", "-camera-back", "imagefile:/tmp/a.png"]);
+  });
+
+  test("adds nothing when extraArgs is empty or omitted", () => {
+    const plain = buildEmulatorArgs({ name: "x", port: 5554 });
+    expect(buildEmulatorArgs({ name: "x", port: 5554, extraArgs: [] })).toEqual(plain);
+    expect(plain.at(-1)).toBe("5554");
+  });
 });
 
 describe("formatEmulatorCommand", () => {
@@ -41,6 +56,15 @@ describe("formatEmulatorCommand", () => {
     const command = formatEmulatorCommand("/sdk/emulator/emulator", { name: "x", port: 5556 });
     expect(command.startsWith("/sdk/emulator/emulator ")).toBe(true);
     expect(command).toContain("-port 5556");
+  });
+
+  test("includes the extra args", () => {
+    const command = formatEmulatorCommand("/sdk/emulator/emulator", {
+      name: "x",
+      port: 5554,
+      extraArgs: ["-camera-back", "imagefile:/tmp/a.png"],
+    });
+    expect(command.endsWith("-port 5554 -camera-back imagefile:/tmp/a.png")).toBe(true);
   });
 
   test("quotes parts containing whitespace", () => {

--- a/packages/@expo/hub-android-utils/src/emulator.ts
+++ b/packages/@expo/hub-android-utils/src/emulator.ts
@@ -22,6 +22,7 @@ export function buildEmulatorArgs(options: BootDeviceOptions): string[] {
     "-no-boot-anim",
     "-port",
     String(options.port),
+    ...(options.extraArgs ?? []),
   ];
 }
 

--- a/packages/@expo/hub-android-utils/src/index.ts
+++ b/packages/@expo/hub-android-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { bootDevice } from "./boot-device";
 export { createDevice } from "./create-device";
+export { emulatorSerial } from "./emulator";
 export { freeEmulatorPort } from "./free-emulator-port";
 export { listDeviceProfiles } from "./list-device-profiles";
 export { listDevices } from "./list-devices";

--- a/packages/@expo/hub-android-utils/src/types.ts
+++ b/packages/@expo/hub-android-utils/src/types.ts
@@ -106,6 +106,8 @@ export interface BootDeviceOptions {
   name: string;
   /** Console port → `emulator -port <port>`; the serial becomes `emulator-<port>`. */
   port: number;
+  /** Extra `emulator` flags appended after `-port <port>`, passed through verbatim. */
+  extraArgs?: readonly string[];
 }
 
 /** How a spawned emulator process ended (see {@link BootedDevice.exited}). */


### PR DESCRIPTION
## Why

The Hub boots Android emulators itself. The camera feed work that follows in this stack needs to append emulator flags to that boot command, and a later caller needs the serial before the process exists.

## Scope

- `BootDeviceOptions.extraArgs` appends flags after `-port <port>`, passed through verbatim. `formatEmulatorCommand` shows them in the reproduce command.
- `emulatorSerial` is exported from the package index.

No caller passes `extraArgs` yet. The default command is unchanged.

## Blast Radius

`@expo/hub-android-utils` only. An omitted or empty `extraArgs` produces the same argument list as before.

## Verification

`bun test` in `hub-android-utils`: 115 pass, three new for the appended args and the reproduce command. `bun run typecheck` and `bun run lint` at the root pass.

Second PR of the emulator camera stack, on top of the adb shutdown wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
