### PR TITLE
feat(hub-client): read and replace emulator camera feeds

### DIFF
--- a/packages/@expo/hub-client/src/__tests__/android-camera.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-camera.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  androidCameraErrorMessage,
+  androidCameraImagePath,
+  applyCameraRead,
+  keepPendingCameraFeeds,
+  NO_ANDROID_CAMERA,
+  parseAndroidCameraStatus,
+  staleCameraFacings,
+} from "../android-camera";
+import { type DeviceCameraFacing } from "../types";
+
+const stubImageUrl = (facing: DeviceCameraFacing, digest: string | null) =>
+  `image:${facing}:${digest ?? "none"}`;
+
+describe("Android camera status contract", () => {
+  test("normalizes a full serve-emu payload", () => {
+    const parsed = parseAndroidCameraStatus(
+      {
+        ok: true,
+        camera: {
+          serial: "emulator-5554",
+          supported: true,
+          wiredAtLaunch: true,
+          feeds: [
+            {
+              facing: "back",
+              path: "/tmp/back.png",
+              present: true,
+              placeholder: true,
+              width: 640,
+              height: 480,
+              bytes: 1024,
+              digest: "abc",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+            {
+              facing: "front",
+              path: "/tmp/front.png",
+              present: false,
+              placeholder: false,
+              width: null,
+              height: null,
+              bytes: null,
+              digest: null,
+              updatedAt: null,
+            },
+          ],
+        },
+      },
+      stubImageUrl,
+    );
+
+    expect(parsed).toEqual({
+      supported: true,
+      status: {
+        wiredAtLaunch: true,
+        feeds: [
+          {
+            facing: "back",
+            placeholder: true,
+            width: 640,
+            height: 480,
+            bytes: 1024,
+            imageUrl: "image:back:abc",
+          },
+          {
+            facing: "front",
+            placeholder: false,
+            width: null,
+            height: null,
+            bytes: null,
+            imageUrl: null,
+          },
+        ],
+      },
+    });
+  });
+
+  test("rejects malformed payloads", () => {
+    const camera = { supported: true, wiredAtLaunch: false, feeds: [] };
+    expect(parseAndroidCameraStatus({ camera }, stubImageUrl)).toBeNull();
+    expect(parseAndroidCameraStatus({ ok: true }, stubImageUrl)).toBeNull();
+    expect(
+      parseAndroidCameraStatus({ ok: true, camera: { ...camera, feeds: {} } }, stubImageUrl),
+    ).toBeNull();
+    expect(
+      parseAndroidCameraStatus(
+        { ok: true, camera: { ...camera, wiredAtLaunch: "yes" } },
+        stubImageUrl,
+      ),
+    ).toBeNull();
+  });
+
+  test("drops a feed with an unknown facing and keeps its siblings", () => {
+    const parsed = parseAndroidCameraStatus(
+      {
+        ok: true,
+        camera: {
+          supported: true,
+          wiredAtLaunch: false,
+          feeds: [
+            { facing: "external", present: true, placeholder: false, digest: "zzz" },
+            { facing: "front", present: true, placeholder: false, digest: null },
+          ],
+        },
+      },
+      stubImageUrl,
+    );
+
+    expect(parsed?.status.feeds).toEqual([
+      {
+        facing: "front",
+        placeholder: false,
+        width: null,
+        height: null,
+        bytes: null,
+        imageUrl: "image:front:none",
+      },
+    ]);
+  });
+});
+
+describe("Android camera image path", () => {
+  test("adds the digest so a replaced image refetches", () => {
+    expect(androidCameraImagePath("back", "a b/c")).toBe(
+      "/api/camera/image?facing=back&v=a%20b%2Fc",
+    );
+    expect(androidCameraImagePath("front", null)).toBe("/api/camera/image?facing=front");
+  });
+});
+
+describe("Android camera error message", () => {
+  test("prefers the backend message over the HTTP status", () => {
+    expect(androidCameraErrorMessage(500, { error: "camera not wired at launch" })).toBe(
+      "camera not wired at launch",
+    );
+    expect(androidCameraErrorMessage(400, { error: 12 })).toBe("Camera update failed (400)");
+  });
+});
+
+describe("keepPendingCameraFeeds", () => {
+  const feed = (facing: "back" | "front", bytes: number) => ({
+    facing,
+    placeholder: false,
+    width: 4,
+    height: 3,
+    bytes,
+    imageUrl: `/img/${facing}/${bytes}`,
+  });
+  const current = { wiredAtLaunch: true, feeds: [feed("back", 1), feed("front", 1)] };
+  const next = { wiredAtLaunch: true, feeds: [feed("back", 2), feed("front", 2)] };
+
+  test("keeps the held feed for a pending facing and takes the rest from the new read", () => {
+    const merged = keepPendingCameraFeeds(current, next, new Set(["front"]));
+    expect(merged.feeds).toEqual([feed("back", 2), feed("front", 1)]);
+  });
+
+  test("returns the new read untouched when nothing is pending or nothing is held", () => {
+    expect(keepPendingCameraFeeds(current, next, new Set())).toBe(next);
+    expect(keepPendingCameraFeeds(null, next, new Set(["back"]))).toBe(next);
+  });
+});
+
+describe("staleCameraFacings", () => {
+  const none: ReadonlySet<DeviceCameraFacing> = new Set();
+  const steady = { back: 1, front: 1 };
+
+  test("holds a facing whose write was pending as the read started", () => {
+    expect([...staleCameraFacings(new Set(["front"]), none, steady, steady)]).toEqual(["front"]);
+  });
+
+  test("holds a facing whose write is pending now", () => {
+    expect([...staleCameraFacings(none, new Set(["front"]), steady, steady)]).toEqual(["front"]);
+  });
+
+  test("holds a facing whose write began and ended inside the read", () => {
+    expect([...staleCameraFacings(none, none, steady, { back: 1, front: 2 })]).toEqual(["front"]);
+  });
+
+  test("takes an untouched facing from the read", () => {
+    const held = staleCameraFacings(new Set(["front"]), new Set(["front"]), steady, {
+      back: 1,
+      front: 3,
+    });
+    expect(held.has("back")).toBe(false);
+    expect([...staleCameraFacings(none, none, steady, steady)]).toEqual([]);
+  });
+});
+
+describe("applyCameraRead", () => {
+  const feed = {
+    facing: "back" as const,
+    placeholder: false,
+    width: 4,
+    height: 3,
+    bytes: 9,
+    imageUrl: "/img/back",
+  };
+  const held = {
+    status: { wiredAtLaunch: true, feeds: [feed] },
+    supported: true,
+  };
+
+  test("keeps the last good state when the read failed or could not be parsed", () => {
+    expect(applyCameraRead(held, null, new Set())).toBe(held);
+    expect(applyCameraRead(NO_ANDROID_CAMERA, null, new Set())).toBe(NO_ANDROID_CAMERA);
+  });
+
+  test("turns support off only from a payload that says so", () => {
+    const read = { supported: false, status: { wiredAtLaunch: false, feeds: [] } };
+    expect(applyCameraRead(held, read, new Set())).toEqual({
+      status: read.status,
+      supported: false,
+    });
+  });
+
+  test("holds the feed of a facing with a write in flight", () => {
+    const replaced = { ...feed, bytes: 1, imageUrl: "/img/back/old" };
+    const read = { supported: true, status: { wiredAtLaunch: true, feeds: [replaced] } };
+    expect(applyCameraRead(held, read, new Set(["back"])).status?.feeds).toEqual([feed]);
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/device-setting-writes.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/device-setting-writes.test.ts
@@ -1,41 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from '../device-setting-writes';
-
-describe('DeviceSettingWriteTracker', () => {
-  test('allows different options concurrently while rejecting a repeated write to the same option', () => {
-    const tracker = new DeviceSettingWriteTracker();
-
-    const appearance = tracker.start('appearance');
-    const textSize = tracker.start('text-size');
-
-    expect(appearance).not.toBeNull();
-    expect(textSize).not.toBeNull();
-    expect(tracker.start('appearance')).toBeNull();
-    expect(tracker.pending).toEqual(new Set(['appearance', 'text-size']));
-
-    expect(tracker.finish(appearance!)).toBeTrue();
-    expect(tracker.pending).toEqual(new Set(['text-size']));
-    expect(tracker.finish(textSize!)).toBeTrue();
-    expect(tracker.pending).toEqual(new Set());
-  });
-
-  test('invalidates stale completions when the active device changes', () => {
-    const tracker = new DeviceSettingWriteTracker();
-    const oldDeviceRequest = tracker.start('appearance')!;
-
-    tracker.reset();
-    const newDeviceRequest = tracker.start('appearance')!;
-
-    expect(tracker.isCurrent(oldDeviceRequest)).toBeFalse();
-    expect(tracker.finish(oldDeviceRequest)).toBeFalse();
-    expect(tracker.pending).toEqual(new Set(['appearance']));
-    expect(tracker.isCurrent(newDeviceRequest)).toBeTrue();
-  });
-});
+import { mergeAuthoritativeDeviceSetting } from '../device-setting-writes';
 
 describe('mergeAuthoritativeDeviceSetting', () => {
   test('rolls back only the failed option without clobbering another optimistic write', () => {

--- a/packages/@expo/hub-client/src/__tests__/keyed-write-tracker.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/keyed-write-tracker.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { KeyedWriteTracker } from "../keyed-write-tracker";
+import { type DeviceSettingKey } from "../types";
+
+describe("KeyedWriteTracker", () => {
+  test("allows different options concurrently while rejecting a repeated write to the same option", () => {
+    const tracker = new KeyedWriteTracker<DeviceSettingKey>();
+
+    const appearance = tracker.start("appearance");
+    const textSize = tracker.start("text-size");
+
+    expect(appearance).not.toBeNull();
+    expect(textSize).not.toBeNull();
+    expect(tracker.start("appearance")).toBeNull();
+    expect(tracker.pending).toEqual(new Set(["appearance", "text-size"]));
+
+    expect(tracker.finish(appearance!)).toBeTrue();
+    expect(tracker.pending).toEqual(new Set(["text-size"]));
+    expect(tracker.finish(textSize!)).toBeTrue();
+    expect(tracker.pending).toEqual(new Set());
+  });
+
+  test("invalidates stale completions when the active device changes", () => {
+    const tracker = new KeyedWriteTracker<DeviceSettingKey>();
+    const oldDeviceRequest = tracker.start("appearance")!;
+
+    tracker.reset();
+    const newDeviceRequest = tracker.start("appearance")!;
+
+    expect(tracker.isCurrent(oldDeviceRequest)).toBeFalse();
+    expect(tracker.finish(oldDeviceRequest)).toBeFalse();
+    expect(tracker.pending).toEqual(new Set(["appearance"]));
+    expect(tracker.isCurrent(newDeviceRequest)).toBeTrue();
+  });
+});

--- a/packages/@expo/hub-client/src/android-api-url.ts
+++ b/packages/@expo/hub-client/src/android-api-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Join an API path onto the base URL, **preserving any path prefix** the base
+ * carries. `baseUrl` is the `expo-serve-emu` plugin mount
+ * (`…/_expo/plugins/serve-emu`), so `new URL('/ws', baseUrl)` would drop
+ * that prefix and miss the plugin; a plain string join keeps it (and still works
+ * for a bare `http://localhost:3300` standalone serve-emu).
+ */
+export function apiUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/$/, "")}${path}`;
+}
+
+/** Same join, with the target device carried as a query parameter. */
+export function deviceApiUrl(baseUrl: string, path: string, device: string | null): string {
+  const url = new URL(apiUrl(baseUrl, path));
+  if (device) url.searchParams.set("device", device);
+  return url.toString();
+}

--- a/packages/@expo/hub-client/src/android-camera.ts
+++ b/packages/@expo/hub-client/src/android-camera.ts
@@ -1,0 +1,135 @@
+import { type DeviceCameraFacing, type DeviceCameraFeed, type DeviceCameraStatus } from "./types";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseFeed(
+  payload: unknown,
+  imageUrl: (facing: DeviceCameraFacing, digest: string | null) => string,
+): DeviceCameraFeed | null {
+  const data = asRecord(payload);
+  if (!data) return null;
+  const facing = data.facing;
+  if (facing !== "back" && facing !== "front") return null;
+  const placeholder = data.placeholder;
+  const present = data.present;
+  if (typeof placeholder !== "boolean" || typeof present !== "boolean") return null;
+  const digest = typeof data.digest === "string" ? data.digest : null;
+  return {
+    facing,
+    placeholder,
+    width: finiteNumber(data.width),
+    height: finiteNumber(data.height),
+    bytes: finiteNumber(data.bytes),
+    imageUrl: present ? imageUrl(facing, digest) : null,
+  };
+}
+
+/** One accepted `/api/camera` payload. */
+export interface AndroidCameraRead {
+  supported: boolean;
+  status: DeviceCameraStatus;
+}
+
+export function parseAndroidCameraStatus(
+  payload: unknown,
+  imageUrl: (facing: DeviceCameraFacing, digest: string | null) => string,
+): AndroidCameraRead | null {
+  const data = asRecord(payload);
+  if (!data || data.ok !== true) return null;
+  const camera = asRecord(data.camera);
+  if (!camera) return null;
+  const supported = camera.supported;
+  const wiredAtLaunch = camera.wiredAtLaunch;
+  if (typeof supported !== "boolean" || typeof wiredAtLaunch !== "boolean") return null;
+  if (!Array.isArray(camera.feeds)) return null;
+
+  const feeds = camera.feeds
+    .map((feed) => parseFeed(feed, imageUrl))
+    .filter((feed): feed is DeviceCameraFeed => feed !== null);
+
+  return { supported, status: { wiredAtLaunch, feeds } };
+}
+
+export function androidCameraImagePath(facing: DeviceCameraFacing, digest: string | null): string {
+  const path = `/api/camera/image?facing=${facing}`;
+  return digest === null ? path : `${path}&v=${encodeURIComponent(digest)}`;
+}
+
+export function androidCameraErrorMessage(status: number, payload: unknown): string {
+  const data = asRecord(payload);
+  if (data && typeof data.error === "string") return data.error;
+  return `Camera update failed (${status})`;
+}
+
+/** A status read that overlaps a write is stale for that facing, so the written feed stays. */
+export function keepPendingCameraFeeds(
+  current: DeviceCameraStatus | null,
+  next: DeviceCameraStatus,
+  pendingFacings: ReadonlySet<DeviceCameraFacing>,
+): DeviceCameraStatus {
+  if (pendingFacings.size === 0 || !current) return next;
+  return {
+    ...next,
+    feeds: next.feeds.map((feed) =>
+      pendingFacings.has(feed.facing)
+        ? (current.feeds.find((held) => held.facing === feed.facing) ?? feed)
+        : feed,
+    ),
+  };
+}
+
+/** Every camera facing a feed can drive. */
+export const CAMERA_FACINGS: readonly DeviceCameraFacing[] = ["back", "front"];
+
+/**
+ * Facings a status read must not overwrite.
+ *
+ * A read is stale for a facing when a write was pending as the read started, is
+ * pending now, or started and finished while the read was in flight. The version
+ * counters catch that last case, which neither pending set sees.
+ */
+export function staleCameraFacings(
+  pendingAtStart: ReadonlySet<DeviceCameraFacing>,
+  pendingNow: ReadonlySet<DeviceCameraFacing>,
+  versionsAtStart: Readonly<Record<DeviceCameraFacing, number>>,
+  versionsNow: Readonly<Record<DeviceCameraFacing, number>>,
+): ReadonlySet<DeviceCameraFacing> {
+  const stale = new Set([...pendingAtStart, ...pendingNow]);
+  for (const facing of CAMERA_FACINGS) {
+    if (versionsAtStart[facing] !== versionsNow[facing]) stale.add(facing);
+  }
+  return stale;
+}
+
+/** Camera state held by the viewer between reads. */
+export interface AndroidCameraState {
+  status: DeviceCameraStatus | null;
+  supported: boolean;
+}
+
+export const NO_ANDROID_CAMERA: AndroidCameraState = { status: null, supported: false };
+
+/**
+ * Fold one `/api/camera` read into the held state.
+ *
+ * A failed or unreadable read keeps the last good state, so a transient error
+ * does not hide the camera controls. Only an accepted payload turns support off.
+ */
+export function applyCameraRead(
+  state: AndroidCameraState,
+  read: AndroidCameraRead | null,
+  pendingFacings: ReadonlySet<DeviceCameraFacing>,
+): AndroidCameraState {
+  if (!read) return state;
+  return {
+    status: keepPendingCameraFeeds(state.status, read.status, pendingFacings),
+    supported: read.supported,
+  };
+}

--- a/packages/@expo/hub-client/src/device-camera.ts
+++ b/packages/@expo/hub-client/src/device-camera.ts
@@ -1,0 +1,4 @@
+import { type DeviceCameraFacing } from "./types";
+
+/** Shared empty set so a client with no camera writes keeps a stable identity across renders. */
+export const NO_PENDING_CAMERA_WRITES: ReadonlySet<DeviceCameraFacing> = new Set();

--- a/packages/@expo/hub-client/src/device-setting-writes.ts
+++ b/packages/@expo/hub-client/src/device-setting-writes.ts
@@ -1,51 +1,5 @@
 import { type DeviceSettingKey, type DeviceSettings } from './types';
 
-/** Opaque identity for one in-flight option write. */
-export interface DeviceSettingWriteToken {
-  readonly key: DeviceSettingKey;
-  readonly generation: number;
-  readonly id: number;
-}
-
-/**
- * Tracks option writes independently by key.
- *
- * A key may have at most one live write, while different keys can be written
- * concurrently. Resetting advances the generation so completions from a
- * previous device/configuration cannot affect the current one.
- */
-export class DeviceSettingWriteTracker {
-  readonly #active = new Map<DeviceSettingKey, DeviceSettingWriteToken>();
-  #generation = 0;
-  #nextId = 0;
-
-  start(key: DeviceSettingKey): DeviceSettingWriteToken | null {
-    if (this.#active.has(key)) return null;
-    const token = { key, generation: this.#generation, id: ++this.#nextId };
-    this.#active.set(key, token);
-    return token;
-  }
-
-  isCurrent(token: DeviceSettingWriteToken): boolean {
-    return token.generation === this.#generation && this.#active.get(token.key) === token;
-  }
-
-  finish(token: DeviceSettingWriteToken): boolean {
-    if (!this.isCurrent(token)) return false;
-    this.#active.delete(token.key);
-    return true;
-  }
-
-  reset(): void {
-    this.#generation++;
-    this.#active.clear();
-  }
-
-  get pending(): ReadonlySet<DeviceSettingKey> {
-    return new Set(this.#active.keys());
-  }
-}
-
 /**
  * Apply the authoritative value for one failed option write without replacing
  * unrelated optimistic values that may still be in flight.

--- a/packages/@expo/hub-client/src/keyed-write-tracker.ts
+++ b/packages/@expo/hub-client/src/keyed-write-tracker.ts
@@ -1,0 +1,45 @@
+/** Opaque identity for one in-flight write. */
+export interface KeyedWriteToken<Key extends string> {
+  readonly key: Key;
+  readonly generation: number;
+  readonly id: number;
+}
+
+/**
+ * Tracks writes independently by key.
+ *
+ * A key may have at most one live write, while different keys can be written
+ * concurrently. Resetting advances the generation so completions from a
+ * previous device/configuration cannot affect the current one.
+ */
+export class KeyedWriteTracker<Key extends string> {
+  readonly #active = new Map<Key, KeyedWriteToken<Key>>();
+  #generation = 0;
+  #nextId = 0;
+
+  start(key: Key): KeyedWriteToken<Key> | null {
+    if (this.#active.has(key)) return null;
+    const token = { key, generation: this.#generation, id: ++this.#nextId };
+    this.#active.set(key, token);
+    return token;
+  }
+
+  isCurrent(token: KeyedWriteToken<Key>): boolean {
+    return token.generation === this.#generation && this.#active.get(token.key) === token;
+  }
+
+  finish(token: KeyedWriteToken<Key>): boolean {
+    if (!this.isCurrent(token)) return false;
+    this.#active.delete(token.key);
+    return true;
+  }
+
+  reset(): void {
+    this.#generation++;
+    this.#active.clear();
+  }
+
+  get pending(): ReadonlySet<Key> {
+    return new Set(this.#active.keys());
+  }
+}

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -109,6 +109,28 @@ export type DeviceSettingKey =
 /** Current backend-reported values. Missing keys are unavailable; `unsupported` keys are hidden. */
 export type DeviceSettings = Partial<Record<DeviceSettingKey, string>>;
 
+/** Which emulator camera a feed drives. */
+export type DeviceCameraFacing = 'back' | 'front';
+
+/** One emulator camera fed from a PNG on the host. */
+export interface DeviceCameraFeed {
+  facing: DeviceCameraFacing;
+  /** True while the feed still holds the backend's "no image set" test card. */
+  placeholder: boolean;
+  width: number | null;
+  height: number | null;
+  bytes: number | null;
+  /** Same-origin URL of the current PNG, or null when no file exists yet. Embeds the digest so a changed image refetches. */
+  imageUrl: string | null;
+}
+
+/** Host-side still-image camera feeds for an Android emulator. */
+export interface DeviceCameraStatus {
+  /** True when the emulator was launched with the feed files attached. False means images are stored but never shown. */
+  wiredAtLaunch: boolean;
+  feeds: readonly DeviceCameraFeed[];
+}
+
 /** One live CPU, memory, and network sample for the foreground iOS app. */
 export interface DeviceActivitySample {
   /** Milliseconds since the backend sampler started. */
@@ -287,6 +309,8 @@ export interface DeviceCapabilities {
   deviceSettings: boolean;
   activity: boolean;
   events: boolean;
+  /** Host-fed emulator camera images that the backend can read and replace. */
+  camera: boolean;
   /** Runtime encoder settings that can be read and patched. */
   streamSettings: DeviceStreamSettingCapabilities;
 }
@@ -461,6 +485,17 @@ export interface DeviceClient {
   deviceSettingsPending: ReadonlySet<DeviceSettingKey>;
   /** Change one simulator/device option. Unsupported keys are ignored by each backend. */
   setDeviceSetting: (key: DeviceSettingKey, value: string) => void;
+
+  /** Emulator camera feeds, or null before the first read or when the backend has none. */
+  camera: DeviceCameraStatus | null;
+  /** Facings with an image write or reset in flight. */
+  cameraPending: ReadonlySet<DeviceCameraFacing>;
+  /** Last failed camera write, cleared when the next write starts. */
+  cameraError: string | null;
+  /** Replace one facing's picture with a PNG. The backend refuses other formats. */
+  setCameraImage: (facing: DeviceCameraFacing, png: Blob) => void;
+  /** Restore the backend's "no image set" card for one facing. */
+  clearCameraImage: (facing: DeviceCameraFacing) => void;
 
   /** Backend-supported viewer transport and codec choices; null hides stream controls. */
   streamCapabilities: DeviceStreamCapabilities | null;

--- a/packages/@expo/hub-client/src/useAndroidCamera.ts
+++ b/packages/@expo/hub-client/src/useAndroidCamera.ts
@@ -1,0 +1,171 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+import { deviceApiUrl } from "./android-api-url";
+import {
+  androidCameraErrorMessage,
+  androidCameraImagePath,
+  applyCameraRead,
+  CAMERA_FACINGS,
+  NO_ANDROID_CAMERA,
+  parseAndroidCameraStatus,
+  staleCameraFacings,
+} from "./android-camera";
+import { NO_PENDING_CAMERA_WRITES } from "./device-camera";
+import { KeyedWriteTracker } from "./keyed-write-tracker";
+import { type DeviceCameraFacing } from "./types";
+
+const CAMERA_POLL_MS = 3000;
+
+interface UseAndroidCameraOptions {
+  active: boolean;
+  baseUrl: string | null;
+  device: string | null;
+  /** Identity of the current connection. A change invalidates in-flight reads and writes. */
+  scope: string;
+  scopeRef: RefObject<string>;
+}
+
+function cameraImageUrl(baseUrl: string, device: string | null) {
+  return (facing: DeviceCameraFacing, digest: string | null) =>
+    deviceApiUrl(baseUrl, androidCameraImagePath(facing, digest), device);
+}
+
+/** Host-fed emulator camera images: polls serve-emu for the feeds and replaces them. */
+export function useAndroidCamera({
+  active,
+  baseUrl,
+  device,
+  scope,
+  scopeRef,
+}: UseAndroidCameraOptions) {
+  const [camera, setCamera] = useState(NO_ANDROID_CAMERA);
+  const [cameraPending, setCameraPending] =
+    useState<ReadonlySet<DeviceCameraFacing>>(NO_PENDING_CAMERA_WRITES);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const writeTrackerRef = useRef(new KeyedWriteTracker<DeviceCameraFacing>());
+  // Bumped as a write starts, so a poll that spans an entire write still holds its facing.
+  const writeVersionsRef = useRef<Record<DeviceCameraFacing, number>>({ back: 0, front: 0 });
+
+  const writeCameraImage = useCallback(
+    (facing: DeviceCameraFacing, init: RequestInit) => {
+      if (!baseUrl) return;
+      const tracker = writeTrackerRef.current;
+      const request = tracker.start(facing);
+      if (!request) return;
+      writeVersionsRef.current[facing]++;
+      const imageUrl = cameraImageUrl(baseUrl, device);
+      const statusUrl = deviceApiUrl(baseUrl, "/api/camera", device);
+      const heldFacings = new Set(CAMERA_FACINGS.filter((other) => other !== facing));
+
+      // A write response is authoritative for its own facing only. Another facing
+      // may already hold a later write, so the response never replaces it.
+      const applyStatus = (payload: unknown) => {
+        setCamera((current) =>
+          applyCameraRead(current, parseAndroidCameraStatus(payload, imageUrl), heldFacings),
+        );
+      };
+
+      setCameraError(null);
+      setCameraPending(tracker.pending);
+
+      void fetch(deviceApiUrl(baseUrl, androidCameraImagePath(facing, null), device), init)
+        .then(async (response) => {
+          const payload: unknown = await response.json().catch(() => null);
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          if (response.ok) {
+            applyStatus(payload);
+            return;
+          }
+          setCameraError(androidCameraErrorMessage(response.status, payload));
+          const refreshed: unknown = await fetch(statusUrl, { cache: "no-store" })
+            .then((refresh) => (refresh.ok ? refresh.json() : null))
+            .catch(() => null);
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          applyStatus(refreshed);
+        })
+        .catch(() => {
+          if (!tracker.isCurrent(request) || scopeRef.current !== scope) return;
+          setCameraError("Camera update failed");
+        })
+        .finally(() => {
+          if (tracker.finish(request)) setCameraPending(tracker.pending);
+        });
+    },
+    [baseUrl, device, scope, scopeRef],
+  );
+
+  const setCameraImage = useCallback(
+    (facing: DeviceCameraFacing, png: Blob) =>
+      writeCameraImage(facing, {
+        method: "POST",
+        headers: { "Content-Type": "image/png" },
+        body: png,
+      }),
+    [writeCameraImage],
+  );
+
+  const clearCameraImage = useCallback(
+    (facing: DeviceCameraFacing) => writeCameraImage(facing, { method: "DELETE" }),
+    [writeCameraImage],
+  );
+
+  useEffect(() => {
+    const tracker = writeTrackerRef.current;
+    tracker.reset();
+    for (const facing of CAMERA_FACINGS) writeVersionsRef.current[facing]++;
+    setCameraPending(NO_PENDING_CAMERA_WRITES);
+    setCamera(NO_ANDROID_CAMERA);
+    setCameraError(null);
+    if (!active || !baseUrl) {
+      return;
+    }
+
+    let cancelled = false;
+    let polling = false;
+    let controller: AbortController | null = null;
+    const imageUrl = cameraImageUrl(baseUrl, device);
+    const url = deviceApiUrl(baseUrl, "/api/camera", device);
+
+    const poll = async () => {
+      if (cancelled || polling) return;
+      polling = true;
+      const pendingAtStart = tracker.pending;
+      const versionsAtStart = { ...writeVersionsRef.current };
+      const next = new AbortController();
+      controller = next;
+      try {
+        const response = await fetch(url, { cache: "no-store", signal: next.signal });
+        const read = response.ok ? parseAndroidCameraStatus(await response.json(), imageUrl) : null;
+        if (cancelled || scopeRef.current !== scope) return;
+        const heldFacings = staleCameraFacings(
+          pendingAtStart,
+          tracker.pending,
+          versionsAtStart,
+          writeVersionsRef.current,
+        );
+        setCamera((current) => applyCameraRead(current, read, heldFacings));
+      } catch {
+      } finally {
+        polling = false;
+      }
+    };
+
+    void poll();
+    const timer = setInterval(() => void poll(), CAMERA_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      controller?.abort();
+      tracker.reset();
+    };
+  }, [active, baseUrl, device, scope, scopeRef]);
+
+  return {
+    camera: camera.status,
+    cameraSupported: camera.supported,
+    cameraPending,
+    cameraError,
+    setCameraImage,
+    clearCameraImage,
+  };
+}

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -18,6 +18,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+import { apiUrl, deviceApiUrl } from './android-api-url';
 import {
   type AndroidSessionEvent,
   clearAndroidEventCursor,
@@ -39,11 +40,9 @@ import {
   androidStreamSourceErrorMessage,
   parseAndroidStreamSource,
 } from './android-stream-source';
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from './device-setting-writes';
+import { mergeAuthoritativeDeviceSetting } from './device-setting-writes';
 import { buildCodecString, isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
+import { KeyedWriteTracker } from './keyed-write-tracker';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
 import {
@@ -59,6 +58,7 @@ import {
   type StreamSwitchState,
   streamSwitchTimeoutMs,
 } from './stream-switch';
+import { useAndroidCamera } from './useAndroidCamera';
 import { useStreamSettingsResource } from './useStreamSettingsResource';
 import { type WebRtcIceServer, useWebRtcStream } from './useWebRtcStream';
 import { presentedVideoFrameDelta } from './video-frame-metadata';
@@ -131,23 +131,6 @@ const BUTTON_MESSAGE: Record<HardwareButton, Record<string, unknown> | null> = {
 };
 
 const TOUCH_ACTION = { begin: 'down', move: 'move', end: 'up' } as const;
-
-/**
- * Join an API path onto the base URL, **preserving any path prefix** the base
- * carries. `baseUrl` is the `expo-serve-emu` plugin mount
- * (`…/_expo/plugins/serve-emu`), so `new URL('/ws', baseUrl)` would drop
- * that prefix and miss the plugin; a plain string join keeps it (and still works
- * for a bare `http://localhost:3300` standalone serve-emu).
- */
-function apiUrl(baseUrl: string, path: string): string {
-  return `${baseUrl.replace(/\/$/, '')}${path}`;
-}
-
-function deviceApiUrl(baseUrl: string, path: string, device: string | null): string {
-  const url = new URL(apiUrl(baseUrl, path));
-  if (device) url.searchParams.set('device', device);
-  return url.toString();
-}
 
 export function androidWsUrlFor(
   baseUrl: string,
@@ -269,17 +252,17 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const logSeqRef = useRef(0);
   // Clear is viewer-local so it does not erase serve-emu's replayable session.
   const eventCursorRef = useRef(createAndroidEventCursor());
-  const deviceSettingWriteTrackerRef = useRef(new DeviceSettingWriteTracker());
+  const deviceSettingWriteTrackerRef = useRef(new KeyedWriteTracker<DeviceSettingKey>());
   const deviceSettingVersionsRef = useRef<Record<AndroidDeviceSettingKey, number>>({
     appearance: 0,
     network: 0,
     'text-size': 0,
   });
-  const deviceSettingScope = `${active ? 'active' : 'inactive'}\0${baseUrl ?? ''}\0${targetDevice ?? ''}`;
-  const deviceSettingScopeRef = useRef(deviceSettingScope);
+  const deviceScope = `${active ? 'active' : 'inactive'}\0${baseUrl ?? ''}\0${targetDevice ?? ''}`;
+  const deviceScopeRef = useRef(deviceScope);
   useLayoutEffect(() => {
-    deviceSettingScopeRef.current = deviceSettingScope;
-  }, [deviceSettingScope]);
+    deviceScopeRef.current = deviceScope;
+  }, [deviceScope]);
   const streamSourceRequestRef = useRef(0);
   const streamSourceRef = useRef<DeviceStreamSourceStatus | null>(null);
   const streamSourceLoadingRef = useRef(false);
@@ -437,7 +420,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       const request = tracker.start(key);
       if (!request) return;
       deviceSettingVersionsRef.current[settingKey]++;
-      const scope = deviceSettingScope;
+      const scope = deviceScope;
       const previous = deviceSettings?.[key];
       const url = deviceApiUrl(baseUrl, requestOptions.path, targetDevice);
 
@@ -455,12 +438,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           const payload: unknown = await response.json();
           const authoritative = parseAndroidDeviceSetting(settingKey, payload);
           if (authoritative === null) throw new Error('Device option update was rejected');
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           setDeviceSettings((current) => ({ ...(current ?? {}), [key]: authoritative }));
           if (key === 'appearance') setAppearanceState(authoritative as DeviceAppearance);
         })
         .catch(async () => {
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           let authoritative: string | null = null;
           try {
             const response = await fetch(url, { cache: 'no-store' });
@@ -473,7 +456,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
             // Restore the last rendered value if both write and refresh fail.
             authoritative = previous ?? null;
           }
-          if (!tracker.isCurrent(request) || deviceSettingScopeRef.current !== scope) return;
+          if (!tracker.isCurrent(request) || deviceScopeRef.current !== scope) return;
           setDeviceSettings((current) =>
             mergeAuthoritativeDeviceSetting(
               current,
@@ -491,13 +474,22 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           if (tracker.finish(request)) setDeviceSettingsPending(tracker.pending);
         });
     },
-    [baseUrl, deviceSettingScope, deviceSettings, targetDevice],
+    [baseUrl, deviceScope, deviceSettings, targetDevice],
   );
 
   const setAppearance = useCallback(
     (mode: DeviceAppearance) => setDeviceSetting('appearance', mode),
     [setDeviceSetting],
   );
+
+  const { camera, cameraSupported, cameraPending, cameraError, setCameraImage, clearCameraImage } =
+    useAndroidCamera({
+      active,
+      baseUrl: baseUrl ?? null,
+      device: targetDevice,
+      scope: deviceScope,
+      scopeRef: deviceScopeRef,
+    });
 
   const streamSettingsUrl =
     active && baseUrl ? deviceApiUrl(baseUrl, '/api/stream-settings', targetDevice) : null;
@@ -1573,7 +1565,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     let cancelled = false;
     let polling = false;
     let controllers: AbortController[] = [];
-    const scope = deviceSettingScope;
+    const scope = deviceScope;
 
     const poll = async (keys: readonly AndroidDeviceSettingKey[]) => {
       if (cancelled || polling) return;
@@ -1605,7 +1597,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         }),
       );
       polling = false;
-      if (cancelled || deviceSettingScopeRef.current !== scope) return;
+      if (cancelled || deviceScopeRef.current !== scope) return;
       if (!results.some((result) => result.handled)) return;
       setDeviceSettings((current) => {
         const next = { ...(current ?? {}) };
@@ -1645,7 +1637,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       for (const controller of controllers) controller.abort();
       tracker.reset();
     };
-  }, [active, baseUrl, deviceSettingScope, targetDevice]);
+  }, [active, baseUrl, deviceScope, targetDevice]);
 
   return {
     platform: 'android',
@@ -1668,6 +1660,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    camera,
+    cameraPending,
+    cameraError,
+    setCameraImage,
+    clearCameraImage,
     streamSettings,
     streamSettingsPending,
     updateStreamSettings,
@@ -1694,6 +1691,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       deviceSettings: true,
       activity: false,
       events: true,
+      camera: cameraSupported,
       streamSettings: { maxDimension: true },
     },
     foregroundApp,

--- a/packages/@expo/hub-client/src/useIosDevice.ts
+++ b/packages/@expo/hub-client/src/useIosDevice.ts
@@ -68,10 +68,9 @@ import {
   type ScreenSize,
   type TouchSample,
 } from './types';
-import {
-  DeviceSettingWriteTracker,
-  mergeAuthoritativeDeviceSetting,
-} from './device-setting-writes';
+import { NO_PENDING_CAMERA_WRITES } from './device-camera';
+import { mergeAuthoritativeDeviceSetting } from './device-setting-writes';
+import { KeyedWriteTracker } from './keyed-write-tracker';
 import { proxyPreviewConfigForBrowser } from './proxy-preview-config';
 import { normalizeDeviceStreamSettings } from './stream-settings';
 import { useAvccStream } from './useAvccStream';
@@ -413,7 +412,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
   const [webRtcCodec, setWebRtcCodecState] = useState<DeviceWebRtcCodec>('h264');
   const [activeWebRtcCodec, setActiveWebRtcCodec] = useState<WebRtcCodec>('h264');
   const [webRtcHttpFallback, setWebRtcHttpFallback] = useState(false);
-  const deviceSettingWriteTrackerRef = useRef(new DeviceSettingWriteTracker());
+  const deviceSettingWriteTrackerRef = useRef(new KeyedWriteTracker<DeviceSettingKey>());
   // Async option writes capture their config. Track only committed config so
   // an interrupted concurrent render cannot invalidate a legitimate rollback.
   const deviceSettingConfigRef = useRef(config);
@@ -1351,6 +1350,11 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
     deviceSettings,
     deviceSettingsPending,
     setDeviceSetting,
+    camera: null,
+    cameraPending: NO_PENDING_CAMERA_WRITES,
+    cameraError: null,
+    setCameraImage: () => {},
+    clearCameraImage: () => {},
     streamCapabilities: IOS_STREAM_CAPABILITIES,
     streamSettings,
     streamSettingsPending,
@@ -1369,6 +1373,7 @@ export function useIosDeviceClient(options: DeviceConnectionOptions): DeviceClie
       deviceSettings: !!execWsUrl && !!execToken && !!deviceUdid,
       activity: !!metricsPath,
       events: !!eventsPath,
+      camera: false,
       streamSettings: streamSettingsUrl
         ? {
             mjpegFps: true,

--- a/packages/@expo/hub-client/src/useNoopDeviceClient.ts
+++ b/packages/@expo/hub-client/src/useNoopDeviceClient.ts
@@ -1,3 +1,4 @@
+import { NO_PENDING_CAMERA_WRITES } from './device-camera';
 import { DeviceClient } from './types';
 
 /** Inert client returned while no device is selected — module-level so its
@@ -23,6 +24,11 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
   deviceSettings: null,
   deviceSettingsPending: new Set(),
   setDeviceSetting: () => {},
+  camera: null,
+  cameraPending: NO_PENDING_CAMERA_WRITES,
+  cameraError: null,
+  setCameraImage: () => {},
+  clearCameraImage: () => {},
   streamCapabilities: null,
   streamSettings: null,
   streamSettingsPending: false,
@@ -41,6 +47,7 @@ export const NOOP_DEVICE_CLIENT: DeviceClient = {
     deviceSettings: false,
     activity: false,
     events: false,
+    camera: false,
     streamSettings: false,
   },
   foregroundApp: null,

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -46,6 +46,11 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       : { appearance: 'light', network: 'on', 'text-size': 'medium' },
     deviceSettingsPending: new Set(),
     setDeviceSetting: () => {},
+    camera: null,
+    cameraPending: new Set(),
+    cameraError: null,
+    setCameraImage: () => {},
+    clearCameraImage: () => {},
     streamCapabilities: ios
       ? {
           modeAvailability: { mjpeg: true, h264: true, webrtc: true },
@@ -89,6 +94,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
       deviceSettings: true,
       activity: ios,
       events: true,
+      camera: false,
       streamSettings: ios
         ? {
             mjpegFps: true,
@@ -1146,9 +1152,10 @@ test('keeps the frame option disabled with an explanation for unsupported device
         deviceSettings: false,
         activity: false,
         events: true,
+        camera: false,
         streamSettings: false,
       },
-    };
+    } satisfies DeviceClient;
     const html = renderToStaticMarkup(
       <LogSidebar
         client={client}
@@ -1173,10 +1180,11 @@ test('shows only the viewer-local frame option while iOS device settings are una
       deviceSettings: false,
       activity: false,
       events: true,
+      camera: false,
       streamSettings: false,
     },
     deviceSettings: null,
-  };
+  } satisfies DeviceClient;
   const html = renderToStaticMarkup(
     <LogSidebar
       client={client}


### PR DESCRIPTION
## Why

serve-emu can feed an Android emulator's camera from a PNG on the host (expo/serve-emu#18, with the middleware routes in expo/serve-emu#22). The Hub's device client needs to read that state and post images before the inspector can show a Camera section. This PR adds the client half. Nothing renders yet.

## Scope

- `useAndroidCamera` polls `GET /api/camera` every three seconds and exposes the result. The Android client spreads it into `DeviceClient` as `camera`, `cameraPending`, `cameraError`, `setCameraImage`, and `clearCameraImage`. `capabilities.camera` turns true once the backend reports a supported emulator.
- `parseAndroidCameraStatus` is the one trust boundary. `applyCameraRead` folds every read into the held state, so a failed or unreadable read keeps the last good status and only an accepted payload can turn support off. A feed's `imageUrl` embeds the digest so a changed image refetches.
- Writes go through `KeyedWriteTracker`, serialized per facing and never optimistic. The backend's response is the authoritative status for the written facing only, so a rejected PNG cannot leave a picture on screen that the emulator does not hold, and a back response cannot overwrite a newer front feed. A per-facing version counter marks a poll stale for any facing written while it was in flight; `staleCameraFacings` is the one rule for that.
- `KeyedWriteTracker` in `keyed-write-tracker.ts` replaces `DeviceSettingWriteTracker`, with the key type named at each call site. `apiUrl` and `deviceApiUrl` move to `android-api-url.ts`. iOS and noop clients report `camera: null`.

Out of scope: the UI, the Hub server wiring, and iOS. Against today's pinned serve-emu the status route does not exist, so `capabilities.camera` stays false and nothing changes for users until the rest of the stack lands.

## Blast Radius

`DeviceClient` gains required members, so any consumer that builds one by hand (the website) must add them. The Hub's own fixtures are updated here. No runtime behaviour changes until the serve-emu pin and the Camera section land.

## Verification

`bun test` in `hub-client`: 167 pass, with new cases for the parser, the read fold, the pending-feed merge, the image path, and the tracker. `bun test` in `hub-components` and `expo-device-hub` pass with the updated fixtures. `bun run typecheck` and `bun run lint` at the root pass.

Third PR of the emulator camera stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
