### PR TITLE
feat(expo-device-hub): attach camera feeds to every emulator the Hub boots

### DIFF
--- a/.changeset/emulator-camera-feeds.md
+++ b/.changeset/emulator-camera-feeds.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add camera image passthrough for Android emulators.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ with it, and manage which devices are running from one place.
 - Interact directly — tap, swipe, scroll, and type into the device.
 - Boot, shut down, and add devices without opening Xcode or Android Studio.
 - Follows your system light/dark theme, and can flip the device's appearance too.
+- Feed an Android emulator's camera a PNG from the inspector's Camera section.
 
 > iOS simulators require macOS with Xcode. Android emulators require the Android SDK
 > (`emulator`, `adb`).

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -21,6 +21,7 @@ with it, and manage which devices are running from one place.
 - Interact directly — tap, swipe, scroll, and type into the device.
 - Boot, shut down, and add devices without opening Xcode or Android Studio.
 - Follows your system light/dark theme, and can flip the device's appearance too.
+- Feed an Android emulator's camera a PNG from the inspector's Camera section.
 
 > iOS simulators require macOS with Xcode. Android emulators require the Android SDK
 > (`emulator`, `adb`).

--- a/packages/expo-device-hub/src/server/__tests__/boot-hub-device.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/boot-hub-device.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type {
+  AndroidUtilsResult,
+  BootDeviceOptions,
+  BootedDevice,
+  EmulatorExit,
+} from '@expo/hub-android-utils';
+
+import { bootHubDevice, shutdownHubDevice, type EmulatorCameraFeeds } from '../device-actions';
+
+const calls: string[] = [];
+
+function pending<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}
+
+function feedArgs(serial: string): string[] {
+  return ['-camera-back', `imagefile:/feeds/${serial}-back.png`];
+}
+
+interface Scenario {
+  port: number | null;
+  spawned: BootDeviceOptions | null;
+  exited: Promise<EmulatorExit>;
+  online: Promise<AndroidUtilsResult<boolean>>;
+  shutdownOk: boolean;
+}
+
+const scenario: Scenario = {
+  port: 5560,
+  spawned: null,
+  exited: pending(),
+  online: Promise.resolve({ value: true, error: null }),
+  shutdownOk: true,
+};
+
+const androidUtils = await import('@expo/hub-android-utils');
+
+mock.module('@expo/hub-android-utils', () => ({
+  ...androidUtils,
+  freeEmulatorPort: async () => {
+    calls.push('freeEmulatorPort');
+    return { value: scenario.port, error: null };
+  },
+  bootDevice: async (options: BootDeviceOptions) => {
+    calls.push(`spawn ${options.name}`);
+    scenario.spawned = options;
+    const booted: BootedDevice = {
+      serial: `emulator-${options.port}`,
+      pid: 4242,
+      command: `emulator -avd ${options.name}`,
+      exited: scenario.exited,
+    };
+    return { value: booted, error: null };
+  },
+  waitForAdbOnline: (serial: string) => {
+    calls.push(`waitForAdbOnline ${serial}`);
+    return scenario.online;
+  },
+  shutdownDevice: async ({ serial }: { serial: string }) => {
+    calls.push(`shutdownDevice ${serial}`);
+    return { value: scenario.shutdownOk, error: null };
+  },
+  waitForAdbOffline: async (serial: string) => {
+    calls.push(`waitForAdbOffline ${serial}`);
+    return { value: true, error: null };
+  },
+  removeDevice: async ({ name }: { name: string }) => {
+    calls.push(`removeDevice ${name}`);
+    return { value: true, error: null };
+  },
+  createDevice: async () => ({ value: true, error: null }),
+}));
+
+function cameraFeeds(seedFailure?: Error): EmulatorCameraFeeds {
+  return {
+    launchArgs(serial) {
+      calls.push(`launchArgs ${serial}`);
+      return feedArgs(serial);
+    },
+    async seedPlaceholders(serial) {
+      calls.push(`seedPlaceholders ${serial}`);
+      if (seedFailure) throw seedFailure;
+    },
+  };
+}
+
+function bootRequest() {
+  return { platform: 'android' as const, id: '', name: 'Pixel_9' };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  scenario.port = 5560;
+  scenario.spawned = null;
+  scenario.exited = pending();
+  scenario.online = Promise.resolve({ value: true, error: null });
+  scenario.shutdownOk = true;
+});
+
+describe('bootHubDevice camera feeds', () => {
+  test('seeds the allocated serial before it spawns the emulator', async () => {
+    const result = await bootHubDevice(bootRequest(), cameraFeeds());
+
+    expect(calls).toEqual([
+      'freeEmulatorPort',
+      'seedPlaceholders emulator-5560',
+      'launchArgs emulator-5560',
+      'spawn Pixel_9',
+      'waitForAdbOnline emulator-5560',
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      id: 'emulator-5560',
+      serial: 'emulator-5560',
+      errors: [],
+    });
+  });
+
+  test('spawns with the launch args for the allocated serial', async () => {
+    scenario.port = 5570;
+
+    await bootHubDevice(bootRequest(), cameraFeeds());
+
+    expect(scenario.spawned).toEqual({
+      name: 'Pixel_9',
+      port: 5570,
+      extraArgs: feedArgs('emulator-5570'),
+    });
+  });
+
+  test('boots without camera feeds when seeding fails', async () => {
+    const result = await bootHubDevice(bootRequest(), cameraFeeds(new Error('disk full')));
+
+    expect(calls).toEqual([
+      'freeEmulatorPort',
+      'seedPlaceholders emulator-5560',
+      'spawn Pixel_9',
+      'waitForAdbOnline emulator-5560',
+    ]);
+    expect(scenario.spawned?.extraArgs).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.errors[0]?.message).toBe('Failed to prepare camera feeds for Pixel_9');
+  });
+});
+
+describe('shutdownHubDevice', () => {
+  test('waits for the emulator to go offline after the shutdown', async () => {
+    const result = await shutdownHubDevice({
+      platform: 'android',
+      id: 'emulator-5560',
+      name: 'Pixel_9',
+    });
+
+    expect(calls).toEqual(['shutdownDevice emulator-5560', 'waitForAdbOffline emulator-5560']);
+    expect(result).toEqual({ ok: true, errors: [] });
+  });
+
+  test('does not wait for adb when the shutdown itself fails', async () => {
+    scenario.shutdownOk = false;
+
+    const result = await shutdownHubDevice({
+      platform: 'android',
+      id: 'emulator-5560',
+      name: 'Pixel_9',
+    });
+
+    expect(calls).toEqual(['shutdownDevice emulator-5560']);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/expo-device-hub/src/server/device-actions.ts
+++ b/packages/expo-device-hub/src/server/device-actions.ts
@@ -10,6 +10,7 @@
 import {
   bootDevice as bootAndroidEmulator,
   createDevice as createAndroidDevice,
+  emulatorSerial,
   freeEmulatorPort,
   removeDevice as removeAndroidDevice,
   shutdownDevice as shutdownAndroidDevice,
@@ -27,6 +28,11 @@ import { type HubDevicePlatform } from './devices';
 import { type SerializableError, toSerializableError } from './utility-errors';
 
 const ANDROID_AVD_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export interface EmulatorCameraFeeds {
+  launchArgs(serial: string): string[];
+  seedPlaceholders(serial: string): Promise<void>;
+}
 
 /** A parsed `POST /api/devices/{shutdown,remove}` request body. */
 export interface DeviceActionRequest {
@@ -207,11 +213,10 @@ export interface BootDeviceResult {
  * output isn't captured (the detached child outlives this server), so an early
  * exit reports the exit code plus the exact command to re-run for the details.
  */
-export async function bootHubDevice({
-  platform,
-  id,
-  name,
-}: DeviceActionRequest): Promise<BootDeviceResult> {
+export async function bootHubDevice(
+  { platform, id, name }: DeviceActionRequest,
+  cameraFeeds: EmulatorCameraFeeds
+): Promise<BootDeviceResult> {
   if (platform === 'ios') {
     const booted = await bootAppleSimulator({ udid: id });
     const errors = errorList(toSerializableError(booted.error));
@@ -223,16 +228,14 @@ export async function bootHubDevice({
   const avdName = name || id;
   if (!avdName) return { ok: false, error: 'Missing AVD name', errors: [] };
 
-  return bootAndroidHubDevice(avdName);
+  return bootAndroidHubDevice(avdName, cameraFeeds);
 }
 
 /** Create a new virtual device, then boot it through the same platform utility. */
-export async function createHubDevice({
-  platform,
-  name,
-  runtime,
-  deviceType,
-}: CreateDeviceActionRequest): Promise<BootDeviceResult> {
+export async function createHubDevice(
+  { platform, name, runtime, deviceType }: CreateDeviceActionRequest,
+  cameraFeeds: EmulatorCameraFeeds
+): Promise<BootDeviceResult> {
   if (platform === 'ios') {
     const created = await createAppleSimulator({ name, runtime, deviceType });
     const udid = created.value;
@@ -269,10 +272,20 @@ export async function createHubDevice({
     };
   }
 
-  return bootAndroidHubDevice(name);
+  return bootAndroidHubDevice(name, cameraFeeds);
 }
 
-async function bootAndroidHubDevice(avdName: string): Promise<BootDeviceResult> {
+/**
+ * Boot an emulator with camera feeds attached.
+ *
+ * Camera feeds are optional. A seeding failure only costs the fake camera, so
+ * the boot continues without the feed launch args and reports the failure in
+ * `errors` next to whatever the boot itself produced.
+ */
+async function bootAndroidHubDevice(
+  avdName: string,
+  cameraFeeds: EmulatorCameraFeeds
+): Promise<BootDeviceResult> {
   const allocated = await freeEmulatorPort();
   if (allocated.error || allocated.value === null) {
     return {
@@ -282,13 +295,29 @@ async function bootAndroidHubDevice(avdName: string): Promise<BootDeviceResult> 
     };
   }
 
-  const bootedResult = await bootAndroidEmulator({ name: avdName, port: allocated.value });
+  const serial = emulatorSerial(allocated.value);
+  let seedError: SerializableError | null = null;
+  try {
+    await cameraFeeds.seedPlaceholders(serial);
+  } catch (error) {
+    seedError = toSerializableError({
+      message: `Failed to prepare camera feeds for ${avdName}`,
+      error,
+    });
+  }
+  const seedErrors = errorList(seedError);
+
+  const bootedResult = await bootAndroidEmulator({
+    name: avdName,
+    port: allocated.value,
+    extraArgs: seedError === null ? cameraFeeds.launchArgs(serial) : undefined,
+  });
   const booted = bootedResult.value;
   if (bootedResult.error || !booted) {
     return {
       ok: false,
       error: `Failed to spawn emulator for ${avdName}`,
-      errors: errorList(toSerializableError(bootedResult.error)),
+      errors: [...seedErrors, ...errorList(toSerializableError(bootedResult.error))],
     };
   }
 
@@ -315,7 +344,7 @@ async function bootAndroidHubDevice(avdName: string): Promise<BootDeviceResult> 
       error:
         `The emulator process for "${avdName}" ${ended} before coming online.\n\n` +
         `For details, try running it manually:\n${booted.command}`,
-      errors: errorList(toSerializableError(outcome.exit.error)),
+      errors: [...seedErrors, ...errorList(toSerializableError(outcome.exit.error))],
     };
   }
 
@@ -325,17 +354,17 @@ async function bootAndroidHubDevice(avdName: string): Promise<BootDeviceResult> 
       id: booted.serial,
       serial: booted.serial,
       error: `Failed while waiting for ${avdName} to come online`,
-      errors: errorList(toSerializableError(outcome.online.error)),
+      errors: [...seedErrors, ...errorList(toSerializableError(outcome.online.error))],
     };
   }
 
   return outcome.online.value
-    ? { ok: true, id: booted.serial, serial: booted.serial, errors: [] }
+    ? { ok: true, id: booted.serial, serial: booted.serial, errors: seedErrors }
     : {
         ok: false,
         id: booted.serial,
         serial: booted.serial,
         error: 'Timed out waiting for the emulator to come online',
-        errors: [],
+        errors: seedErrors,
       };
 }

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -28,7 +28,7 @@ import { type HubDeviceList, listDevices } from './devices';
 import { handleEasEndpoint } from './eas-endpoints';
 import { MOUNT_PATH } from './mount';
 import { SERVER_PLATFORM_FILTER } from './platform-filter';
-import { EMU_PREFIX, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
+import { EMU_PREFIX, emuCameraFeeds, emuWebSocketHandler, handleEmuRequest } from './serve-emu';
 import { SIM_PREFIX, handleSimRequest, simWebSocketHandler } from './serve-sim';
 import { SERVER_HIDE_SIDEBAR } from './sidebar';
 import { listNewDeviceOptions } from './sim-options';
@@ -149,7 +149,7 @@ export default async function handler(request: Request): Promise<Response | null
     }
 
     try {
-      const result = await bootHubDevice(action);
+      const result = await bootHubDevice(action, emuCameraFeeds);
       if (result.ok) refreshDeviceList();
       return jsonResponse(result);
     } catch (error) {
@@ -171,7 +171,7 @@ export default async function handler(request: Request): Promise<Response | null
     }
 
     try {
-      const result = await createHubDevice(action);
+      const result = await createHubDevice(action, emuCameraFeeds);
       if (result.ok) refreshDeviceList();
       return jsonResponse(result);
     } catch (error) {

--- a/packages/expo-device-hub/src/server/serve-emu.ts
+++ b/packages/expo-device-hub/src/server/serve-emu.ts
@@ -1,6 +1,7 @@
 // @ts-ignore vendored module, absent until `bun run build:vendor`
-import { createRouter, fromWsSocket, type WsWebSocketLike } from '../../vendor/serve-emu/dist/middleware.js';
+import { cameraLaunchArgs, createRouter, fromWsSocket, seedCameraFeeds, type WsWebSocketLike } from '../../vendor/serve-emu/dist/middleware.js';
 
+import { type EmulatorCameraFeeds } from './device-actions';
 import {
   readStandaloneServeEmuOptions,
   SERVE_EMU_OPTIONS_ENV,
@@ -11,6 +12,11 @@ export const EMU_PREFIX = '/vendor/serve-emu';
 
 const serveEmuOptions = readStandaloneServeEmuOptions(process.env[SERVE_EMU_OPTIONS_ENV]);
 const router = createRouter(serveEmuOptions);
+
+export const emuCameraFeeds: EmulatorCameraFeeds = {
+  launchArgs: cameraLaunchArgs,
+  seedPlaceholders: seedCameraFeeds,
+};
 
 function stopAll(): void {
   try {


### PR DESCRIPTION
## Why

The Hub boots emulators itself, so nothing in serve-emu can attach the camera feeds for it. This PR pins serve-emu to the camera middleware, attaches the feeds on every Android boot, and adds the changeset. With it the Camera section from the previous PR comes alive.

The feed path is fixed at emulator launch. That is why every emulator the Hub boots gets the feeds attached, with no toggle. An opt-in would leave the panel dead until a restart, and serve-emu's test card is a fair default for an app under test.

## Scope

- `packages/serve-emu` is pinned to `625469a`, the head of expo/serve-emu#22, which stacks on #18. Re-pin once both land.
- `bootAndroidHubDevice` seeds both feeds and boots with `cameraLaunchArgs(serial)`. A seed failure boots the emulator without the flags and reports the failure in `errors`. `device-actions.ts` depends on one `EmulatorCameraFeeds` collaborator with `launchArgs` and `seedPlaceholders`, and `serve-emu.ts` supplies it from the vendored middleware.
- serve-emu reads `wiredAtLaunch` from the running emulator's `hardware-qemu.ini`, so the Hub declares nothing about wiring. A Hub restart, an emulator killed outside the Hub, or a recycled serial cannot produce a stale answer.
- Changeset for `expo-device-hub`, the one published package; the private `@expo/hub-*` packages ship inside it.

## Tradeoffs

Always-on also attaches a camera to AVDs whose `config.ini` declares no camera hardware. serve-emu documents that `-camera-front imagefile:` yields a front camera even with `hw.camera.front=none`. A check on the AVD config before adding the flags would restore that, if Wear or TV profiles matter.

## Blast Radius

Every Android emulator the Hub boots now runs with `-camera-back imagefile:… -camera-front imagefile:…`. Its camera shows serve-emu's checkerboard test card instead of the emulator's virtual scene until an image is posted. Emulators booted elsewhere, physical devices, and iOS simulators are untouched.

## Verification

- `bun test` in `expo-device-hub`: 167 pass. `boot-hub-device.test.ts` pins the boot order, the launch args for the allocated serial, and the seed-failure fallback. `bun run typecheck` and `bun run lint` at the root pass. `bun run build:server` bundles.
- On the Hub dev server: an AVD booted through `POST /api/devices/boot` carries both camera flags and `GET /vendor/serve-emu/api/camera?device=…` reports `wiredAtLaunch: true`. A posted 1280x960 PNG comes back with a matching digest, a JPEG body is refused with 400, and the emulator's camera app shows the posted image on screen.
- A Hub server restarted under the running emulator still reports `wiredAtLaunch: true`. A dead serial answers 503.

Last PR of the emulator camera stack. Depends on expo/serve-emu#18 and expo/serve-emu#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
