### PR TITLE
feat(hub-components): add the Camera inspector section

### DIFF
--- a/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import { type DeviceCameraStatus, type DeviceClient } from "@expo/hub-client";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CameraSection } from "../dashboard/CameraSection";
+
+const BASE_CLIENT: DeviceClient = {
+  platform: "android",
+  status: "streaming",
+  error: null,
+  screen: { width: 1080, height: 2400 },
+  fps: 60,
+  devices: [],
+  logs: [],
+  logsEnabled: false,
+  attachLogs: () => {},
+  detachLogs: () => {},
+  clearLogs: () => {},
+  events: [],
+  eventsEnabled: false,
+  attachEvents: () => {},
+  detachEvents: () => {},
+  clearEvents: () => {},
+  activity: null,
+  deviceSettings: null,
+  deviceSettingsPending: new Set(),
+  setDeviceSetting: () => {},
+  camera: null,
+  cameraPending: new Set(),
+  cameraError: null,
+  setCameraImage: () => {},
+  clearCameraImage: () => {},
+  streamCapabilities: null,
+  streamSettings: null,
+  streamSettingsPending: false,
+  updateStreamSettings: () => {},
+  streamSource: null,
+  streamSourcePending: false,
+  streamSourceError: null,
+  setStreamSource: () => {},
+  setGrpcImageMode: () => {},
+  setGrpcInputSource: () => {},
+  streamStats: null,
+  setStreamStatsEnabled: () => {},
+  webRtcCodec: "h264",
+  setWebRtcCodec: () => {},
+  capabilities: {
+    deviceSettings: false,
+    activity: false,
+    events: false,
+    camera: true,
+    streamSettings: {},
+  },
+  foregroundApp: null,
+  videoKind: "img",
+  attachVideo: () => {},
+  sendTouch: () => {},
+  sendKey: () => false,
+  pressButton: () => {},
+  reload: () => {},
+  rotate: () => {},
+  screenshot: async () => null,
+  appearance: "light",
+  setAppearance: () => {},
+  hardwareKeyboardConnected: null,
+  setHardwareKeyboardConnected: () => {},
+  toggleSoftwareKeyboard: () => {},
+};
+
+function cameraClient(overrides: Partial<DeviceClient> = {}): DeviceClient {
+  return { ...BASE_CLIENT, ...overrides };
+}
+
+function cameraStatus(wiredAtLaunch: boolean): DeviceCameraStatus {
+  return {
+    wiredAtLaunch,
+    feeds: [
+      {
+        facing: "back",
+        placeholder: false,
+        width: 1280,
+        height: 960,
+        bytes: 204_800,
+        imageUrl: "/camera/back.png",
+      },
+      {
+        facing: "front",
+        placeholder: true,
+        width: 640,
+        height: 480,
+        bytes: 1_024,
+        imageUrl: "/camera/front.png",
+      },
+    ],
+  };
+}
+
+const FEED_LABELS = ["Back camera", "Front camera"];
+
+function feedMarkup(html: string, label: string) {
+  const start = html.indexOf(`>${label}<`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const following = FEED_LABELS.filter((other) => other !== label)
+    .map((other) => html.indexOf(`>${other}<`, start + 1))
+    .filter((index) => index > start);
+  return html.slice(start, following.length > 0 ? Math.min(...following) : html.length);
+}
+
+function buttonTag(markup: string, label: string) {
+  const labelIndex = markup.indexOf(`>${label}</span>`);
+  expect(labelIndex).toBeGreaterThanOrEqual(0);
+
+  const start = markup.lastIndexOf("<button", labelIndex);
+  return markup.slice(start, markup.indexOf(">", start) + 1);
+}
+
+function render(client: DeviceClient) {
+  return renderToStaticMarkup(<CameraSection client={client} defaultOpen />);
+}
+
+describe("CameraSection", () => {
+  test("shows both feeds and keeps Reset available only for a replaced image", () => {
+    const html = render(cameraClient({ camera: cameraStatus(true) }));
+
+    const back = feedMarkup(html, "Back camera");
+    const front = feedMarkup(html, "Front camera");
+    expect(back).toContain('src="/camera/back.png"');
+    expect(back).toContain("1280×960 · 200.0 KB");
+    expect(front).toContain("640×480 · Test card");
+    expect(buttonTag(back, "Reset")).not.toContain("disabled");
+    expect(buttonTag(front, "Reset")).toContain('disabled=""');
+  });
+
+  test("explains an emulator booted without camera feeds and disables every control", () => {
+    const html = render(cameraClient({ camera: cameraStatus(false) }));
+
+    expect(html).toContain(
+      "This emulator started without camera feeds. Shut it down and boot it from Hub to attach them.",
+    );
+    for (const label of FEED_LABELS) {
+      const feed = feedMarkup(html, label);
+      expect(buttonTag(feed, "Choose PNG…")).toContain('disabled=""');
+      expect(buttonTag(feed, "Reset")).toContain('disabled=""');
+      expect(feed).toContain('aria-disabled="true"');
+    }
+  });
+
+  test("reports a failed write as an alert", () => {
+    const html = render(
+      cameraClient({ camera: cameraStatus(true), cameraError: "The emulator rejected the image." }),
+    );
+
+    const alert = html.match(/<span role="alert"[^>]*>([^<]*)<\/span>/);
+    expect(alert?.[1]).toBe("The emulator rejected the image.");
+  });
+});

--- a/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
@@ -1,0 +1,175 @@
+import { type DragEvent, type KeyboardEvent, useRef, useState } from "react";
+
+import {
+  type DeviceCameraFacing,
+  type DeviceCameraFeed,
+  type DeviceClient,
+} from "@expo/hub-client";
+import { Button, bg, border, radius, text, textSize } from "../primitives";
+import { CollapsibleSection } from "./CollapsibleSection";
+import { SectionNote } from "./SectionNote";
+
+const CAMERA_FACING_ORDER: readonly DeviceCameraFacing[] = ["back", "front"];
+const FACING_LABELS: Record<DeviceCameraFacing, string> = {
+  back: "Back camera",
+  front: "Front camera",
+};
+
+const UNWIRED_NOTE =
+  "This emulator started without camera feeds. Shut it down and boot it from Hub to attach them.";
+const CLOSING_NOTE = "PNG only. The app sees a new image after it reopens the camera.";
+
+function formatBytes(value: number) {
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 ** 2).toFixed(1)} MB`;
+}
+
+function feedStatus(feed: DeviceCameraFeed) {
+  if (feed.imageUrl === null) return "No image";
+
+  const parts: string[] = [];
+  if (feed.width !== null && feed.height !== null) parts.push(`${feed.width}×${feed.height}`);
+  if (feed.placeholder) parts.push("Test card");
+  else if (feed.bytes !== null) parts.push(formatBytes(feed.bytes));
+  return parts.join(" · ") || "Image set";
+}
+
+/** Host-fed emulator camera images: one preview, picker, and reset per facing. */
+export function CameraSection({
+  client,
+  defaultOpen = false,
+}: {
+  client: DeviceClient;
+  /** Whether the section is initially expanded. */
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const inputs = useRef<Record<DeviceCameraFacing, HTMLInputElement | null>>({
+    back: null,
+    front: null,
+  });
+  const camera = client.camera;
+  const wired = camera?.wiredAtLaunch ?? false;
+
+  function openPicker(facing: DeviceCameraFacing) {
+    inputs.current[facing]?.click();
+  }
+
+  return (
+    <CollapsibleSection title="Camera" open={open} onOpenChange={setOpen}>
+      {camera === null ? (
+        <SectionNote>Reading camera feeds…</SectionNote>
+      ) : (
+        <>
+          {!wired && <SectionNote>{UNWIRED_NOTE}</SectionNote>}
+          {CAMERA_FACING_ORDER.map((facing) => {
+            const feed = camera.feeds.find((item) => item.facing === facing);
+            if (!feed) return null;
+
+            const label = FACING_LABELS[facing];
+            const pending = client.cameraPending.has(facing);
+            const disabled = pending || !wired;
+            const pickerHandlers = disabled
+              ? {}
+              : {
+                  onDragOver: (event: DragEvent<HTMLDivElement>) => event.preventDefault(),
+                  onDrop: (event: DragEvent<HTMLDivElement>) => {
+                    event.preventDefault();
+                    const file = event.dataTransfer.files[0];
+                    if (file) client.setCameraImage(facing, file);
+                  },
+                  onClick: () => openPicker(facing),
+                  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+                    if (event.key !== "Enter" && event.key !== " ") return;
+                    event.preventDefault();
+                    openPicker(facing);
+                  },
+                };
+            return (
+              <div key={facing} style={{ padding: "0 0 12px" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    padding: "0 0 6px",
+                  }}
+                >
+                  <span style={{ ...textSize.sm, fontWeight: 500, color: text.secondary }}>
+                    {label}
+                  </span>
+                  <span style={{ ...textSize.xs, color: text.tertiary }}>{feedStatus(feed)}</span>
+                </div>
+                <div
+                  role="button"
+                  tabIndex={disabled ? -1 : 0}
+                  aria-disabled={disabled || undefined}
+                  aria-label={`Choose a PNG for the ${facing} camera`}
+                  {...pickerHandlers}
+                  style={{
+                    aspectRatio: "4 / 3",
+                    width: "100%",
+                    boxSizing: "border-box",
+                    backgroundColor: bg.subtle,
+                    border: `1px solid ${border.default}`,
+                    borderRadius: radius.md,
+                    overflow: "hidden",
+                    cursor: disabled ? "default" : "pointer",
+                  }}
+                >
+                  {feed.imageUrl && (
+                    <img
+                      src={feed.imageUrl}
+                      alt={`${label} image`}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        display: "block",
+                      }}
+                    />
+                  )}
+                </div>
+                <div style={{ display: "flex", gap: 8, padding: "8px 0 0" }}>
+                  <Button
+                    theme="secondary"
+                    size="xs"
+                    disabled={disabled}
+                    onClick={() => openPicker(facing)}
+                  >
+                    Choose PNG…
+                  </Button>
+                  <Button
+                    theme="tertiary"
+                    size="xs"
+                    disabled={disabled || feed.placeholder}
+                    onClick={() => client.clearCameraImage(facing)}
+                  >
+                    Reset
+                  </Button>
+                </div>
+                {pending && <SectionNote role="status">{`Updating ${facing} camera…`}</SectionNote>}
+                <input
+                  ref={(node) => {
+                    inputs.current[facing] = node;
+                  }}
+                  type="file"
+                  accept="image/png"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) client.setCameraImage(facing, file);
+                    event.target.value = "";
+                  }}
+                  style={{ display: "none" }}
+                />
+              </div>
+            );
+          })}
+          {client.cameraError && <SectionNote role="alert">{client.cameraError}</SectionNote>}
+          <SectionNote>{CLOSING_NOTE}</SectionNote>
+        </>
+      )}
+    </CollapsibleSection>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -4,6 +4,7 @@ import {
   type DeviceStreamMode,
 } from '@expo/hub-client';
 import { SidebarToggle, bg } from '../primitives';
+import { CameraSection } from './CameraSection';
 import { SIDEBAR_SECTION_INSET } from './CollapsibleSection';
 import { CurrentAppSection } from './CurrentAppSection';
 import { DeviceOptionsSection } from './DeviceOptionsSection';
@@ -45,9 +46,6 @@ export type LogSidebarProps = {
 /**
  * Right column: a compact inspector for the selected device, rendered directly
  * on the dashboard canvas so it matches the existing sidebar treatment.
- *
- * Section order: Current app (with its activity charts), Device options,
- * Stream options, Events, Logs. The first two start open.
  */
 export function LogSidebar({
   onToggle,
@@ -130,6 +128,7 @@ export function LogSidebar({
             onHttpCodecChange={onHttpCodecChange}
           />
         )}
+        {client?.capabilities.camera && <CameraSection client={client} />}
         {client?.capabilities.events && <EventsSection client={client} />}
         <LogsSection client={client} />
       </div>

--- a/packages/@expo/hub-components/src/dashboard/SectionNote.tsx
+++ b/packages/@expo/hub-components/src/dashboard/SectionNote.tsx
@@ -1,0 +1,18 @@
+import { text, textSize } from "../primitives";
+
+export function SectionNote({ children, role }: { children: string; role?: "alert" | "status" }) {
+  return (
+    <span
+      role={role}
+      aria-live={role === "status" ? "polite" : undefined}
+      style={{
+        ...textSize.xs,
+        display: "block",
+        padding: "0 0 8px",
+        color: role === "alert" ? text.danger : text.tertiary,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -11,8 +11,9 @@ import {
   type DeviceStreamSource,
   type DeviceWebRtcCodec,
 } from '@expo/hub-client';
-import { Select, type SelectOption, text, textSize } from '../primitives';
+import { Select, type SelectOption } from '../primitives';
 import { CollapsibleSection } from './CollapsibleSection';
+import { SectionNote } from './SectionNote';
 import { SidebarRow } from './SidebarRow';
 import { type StreamModeAvailability } from './StreamSection';
 import { StreamStatistics } from './StreamStatistics';
@@ -115,29 +116,6 @@ function withCurrentValue(
   return options.some((option) => option.value === current)
     ? options
     : [{ value: current, label: label(value) }, ...options];
-}
-
-function SectionNote({
-  children,
-  role,
-}: {
-  children: string;
-  role?: 'alert' | 'status';
-}) {
-  return (
-    <span
-      role={role}
-      aria-live={role === 'status' ? 'polite' : undefined}
-      style={{
-        ...textSize.xs,
-        display: 'block',
-        padding: '0 0 8px',
-        color: role === 'alert' ? text.danger : text.tertiary,
-      }}
-    >
-      {children}
-    </span>
-  );
 }
 
 /** Viewer transport, backend-supported codecs, and optional runtime encoder controls. */

--- a/packages/@expo/hub-components/src/index.ts
+++ b/packages/@expo/hub-components/src/index.ts
@@ -70,6 +70,7 @@ export {
   type DeviceFrameOption,
 } from './dashboard/DeviceOptionsSection';
 export { ActivityCharts, ActivitySection } from './dashboard/ActivitySection';
+export { CameraSection } from './dashboard/CameraSection';
 export { EventsSection } from './dashboard/EventsSection';
 export { LogsSection } from './dashboard/LogsSection';
 export { CollapsibleSection } from './dashboard/CollapsibleSection';

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -379,6 +379,30 @@ test('renders Android stream options while omitting unsupported and iOS-only sec
   }
 });
 
+test('shows the Camera section only when the client reports camera feeds', () => {
+  const android = inspectorClient('android');
+  const html = renderToStaticMarkup(
+    <LogSidebar
+      client={{
+        ...android,
+        camera: { wiredAtLaunch: true, feeds: [] },
+        capabilities: { ...android.capabilities, camera: true },
+      }}
+    />,
+  );
+
+  expect(html).toContain('<section aria-label="Camera"');
+  const camera = sectionMarkup(html, 'Camera');
+  expect(camera).toContain('>Camera</span>');
+  expect(camera).toContain('aria-expanded="false"');
+  const cameraIndex = html.indexOf('<section aria-label="Camera"');
+  expect(cameraIndex).toBeGreaterThan(html.indexOf('<section aria-label="Stream options"'));
+  expect(cameraIndex).toBeLessThan(html.indexOf('<section aria-label="Events"'));
+
+  const iosHtml = renderToStaticMarkup(<LogSidebar client={inspectorClient('ios')} />);
+  expect(iosHtml).not.toContain('<section aria-label="Camera"');
+});
+
 test('shows Android resolution while omitting encoder settings serve-emu cannot change', () => {
   const html = renderToStaticMarkup(
     <StreamOptionsSection


### PR DESCRIPTION
## Why

With the camera state on `DeviceClient`, the inspector can show it. This PR adds the Camera section so a person or an agent can hand the app under test a known picture without leaving the dashboard.

## Scope

- `CameraSection` renders one 4:3 preview per facing, back then front, with a PNG picker, a drop target, and a Reset that restores serve-emu's test card. The status line shows the size and whether the feed still holds the test card.
- An emulator that was started without camera feeds shows the same blocks with the controls disabled and a note to boot it from the Hub.
- `LogSidebar` places the section between Stream options and Events when `capabilities.camera` is true. `SectionNote` moves out of `StreamOptionsSection` so both sections share it.

Out of scope: the Hub server wiring that attaches the feeds at boot. Against today's pinned serve-emu the section stays hidden.

## Tradeoffs

The section accepts PNG only and shows the backend's message for anything else. Converting other formats in the browser needs a size cap and EXIF handling and is its own change.

## Blast Radius

`@expo/hub-components` and one Hub test file. The section renders only when the client reports camera support, which today's backend never does.

## Verification

`bun test` in `hub-components`: 23 pass, with render tests for the wired state, the unwired state, the disabled Reset on a test card, and the error alert. The Hub package's inspector test asserts the section's position and that an iOS client never shows it. `bun run typecheck` and `bun run lint` at the root pass.

Live in the dashboard with the full stack: a drop of a PNG onto the front preview updates it, a drop of a JPEG shows the backend's PNG-only message as an alert, and Reset restores the test card.

Fourth PR of the emulator camera stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
