### PR TITLE
Fix WebRTC recovery after Android capture changes

### DIFF
--- a/.changeset/steady-android-webrtc.md
+++ b/.changeset/steady-android-webrtc.md
@@ -2,4 +2,4 @@
 'expo-device-hub': patch
 ---
 
-Reconnect WebRTC video when an Android capture source or gRPC image mode changes, and keep the source controls pending until the replacement stream renders.
+Reconnect WebRTC video when an Android capture source or gRPC image mode changes, retaining the last frame and keeping the source controls pending until the replacement stream renders.

--- a/.changeset/steady-android-webrtc.md
+++ b/.changeset/steady-android-webrtc.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Reconnect WebRTC video when an Android capture source or gRPC image mode changes, and keep the source controls pending until the replacement stream renders.

--- a/bun.lock
+++ b/bun.lock
@@ -70,8 +70,11 @@
         "@swc/core": "^1.15.43",
         "@types/bun": "latest",
         "@types/react": "~19.2.2",
+        "@types/react-dom": "~19.2.2",
+        "happy-dom": "^20.14.0",
         "oxfmt": "^0.56.0",
         "oxlint": "^1.71.0",
+        "react-dom": "catalog:",
         "typescript": "~6.0.3",
       },
       "peerDependencies": {
@@ -1146,6 +1149,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -1262,6 +1267,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
 
     "bun-plugin-tailwind": ["bun-plugin-tailwind@0.1.2", "", { "peerDependencies": { "bun": ">=1.0.0" } }, "sha512-41jNC1tZRSK3s1o7pTNrLuQG8kL/0vR/JgiTmZAJ1eHwe0w5j6HFPKeqEk0WAD13jfrUC7+ULuewFBBCoADPpg=="],
@@ -1369,6 +1376,8 @@
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
 
@@ -1509,6 +1518,8 @@
     "got": ["got@14.6.6", "", { "dependencies": { "@sindresorhus/is": "^7.0.1", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.12", "decompress-response": "^10.0.0", "form-data-encoder": "^4.0.2", "http2-wrapper": "^2.2.1", "keyv": "^5.5.3", "lowercase-keys": "^3.0.0", "p-cancelable": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^4.26.1" } }, "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2179,6 +2190,8 @@
     "werift": ["werift@0.24.4", "", { "dependencies": { "@fidm/x509": "^1.2.1", "@noble/curves": "^1.8.1", "@peculiar/x509": "^1.12.3", "@shinyoshiaki/binary-data": "^0.6.1", "buffer": "^6.0.3", "debug": "4.4.0", "mediabunny": "^1.45.2", "multicast-dns": "^7.2.5", "tweetnacl": "^1.0.3" } }, "sha512-NoROZ11L/ZqAB5ombCB4VBuVNdIZfwI493zlxlIX7BlwfWRy55eDJdtWMC2VX35yBXFaWwA8NtYbmJ8qWtVk9Q=="],
 
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/packages/@expo/hub-client/package.json
+++ b/packages/@expo/hub-client/package.json
@@ -44,8 +44,11 @@
     "@swc/core": "^1.15.43",
     "@types/bun": "latest",
     "@types/react": "~19.2.2",
+    "@types/react-dom": "~19.2.2",
+    "happy-dom": "^20.14.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "react-dom": "catalog:",
     "typescript": "~6.0.3"
   },
   "engines": {

--- a/packages/@expo/hub-client/src/DeviceScreen.tsx
+++ b/packages/@expo/hub-client/src/DeviceScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { streamGeometry } from './orientation';
 import { AgentInteractionIndicator } from './AgentInteractionIndicator';
 import { TouchIndicator } from './TouchIndicator';
+import { VideoSurface } from './VideoSurface';
 import {
   type DeviceScreenProps,
   type KeyboardInput,
@@ -48,11 +49,8 @@ export const DEVICE_SCREEN_STATUS_LAYOUT_STYLE: CSSProperties = {
 };
 
 /**
- * Whether the surface should present the media element as-is. While
- * `reconnecting`, the element still holds the last frame (a canvas keeps its
- * pixels, a video keeps the final frame of an ended track), so nothing must
- * cover or blank it — that is what keeps an Android capture-source switch or
- * a brief socket drop from flashing black.
+ * Keep live media or its retained frame visible during brief reconnections.
+ * A status overlay must not cover the saved picture while video is replaced.
  */
 export function deviceScreenPresentsMedia(status: DeviceScreenProps['client']['status']): boolean {
   return status === 'streaming' || status === 'reconnecting';
@@ -350,7 +348,7 @@ export function DeviceScreen({
       {videoKind === 'canvas' ? (
         <canvas ref={attachVideo} style={mediaStyle} />
       ) : videoKind === 'video' ? (
-        <video ref={attachVideo} autoPlay muted playsInline style={mediaStyle} />
+        <VideoSurface attachVideo={attachVideo} style={mediaStyle} />
       ) : (
         <img ref={attachVideo} alt="Device screen" draggable={false} style={mediaStyle} />
       )}

--- a/packages/@expo/hub-client/src/VideoSurface.tsx
+++ b/packages/@expo/hub-client/src/VideoSurface.tsx
@@ -1,0 +1,31 @@
+import { type CSSProperties, useLayoutEffect, useRef } from 'react';
+
+import type { DeviceClient } from './types';
+
+/** The client can cover an unready replacement video with its previous frame. */
+export function VideoSurface({
+  attachVideo,
+  style,
+}: {
+  attachVideo: DeviceClient['attachVideo'];
+  style: CSSProperties;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const retainedFrameRef = useRef<HTMLCanvasElement | null>(null);
+
+  useLayoutEffect(() => {
+    attachVideo(videoRef.current, retainedFrameRef.current);
+    return () => attachVideo(null);
+  }, [attachVideo]);
+
+  return (
+    <>
+      <video ref={videoRef} autoPlay muted playsInline style={style} />
+      <canvas
+        ref={retainedFrameRef}
+        aria-hidden="true"
+        style={{ ...style, visibility: 'hidden' }}
+      />
+    </>
+  );
+}

--- a/packages/@expo/hub-client/src/__tests__/android-webrtc-restart.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/android-webrtc-restart.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { useAndroidDeviceClient } from '../useAndroidDevice';
+import { DeviceScreen } from '../DeviceScreen';
 import type { DeviceClient, DeviceStreamSourceStatus } from '../types';
 
 class Peer extends EventTarget {
@@ -30,6 +31,7 @@ class Peer extends EventTarget {
   }
   async setRemoteDescription() {}
   close() {
+    if (video?.srcObject) frameVisibleAtClose.push(retainedFrame()?.style.visibility === 'visible');
     this.closed = true;
   }
   deliverTrack() {
@@ -73,6 +75,9 @@ let browser: Window;
 let root: Root;
 let client: DeviceClient;
 let video: HTMLVideoElement;
+let container: HTMLDivElement;
+let savedFrames: number;
+let frameVisibleAtClose: boolean[];
 let metadata: ReturnType<typeof deferred<Response>>;
 let replacement: ReturnType<typeof deferred<Response>>;
 let authoritative: ReturnType<typeof source>;
@@ -107,6 +112,8 @@ beforeEach(() => {
   authoritative = source(1);
   puts = 0;
   offers = 0;
+  savedFrames = 0;
+  frameVisibleAtClose = [];
   intervals.clear();
   timeouts.clear();
   let timerId = 0;
@@ -150,12 +157,14 @@ beforeEach(() => {
     }
     return Response.json({});
   });
-  root = createRoot(document.createElement('div'));
-  video = document.createElement('video');
-  Object.defineProperties(video, {
-    videoWidth: { value: 1080 },
-    videoHeight: { value: 1920 },
-    play: { value: async () => {} },
+  container = document.createElement('div');
+  root = createRoot(container);
+  Object.defineProperty(browser.HTMLCanvasElement.prototype, 'getContext', {
+    value: () => ({
+      drawImage: () => {
+        savedFrames++;
+      },
+    }),
   });
 });
 
@@ -165,21 +174,28 @@ afterEach(async () => {
   for (const restore of restoreGlobals.splice(0).reverse()) restore();
 });
 
-function Harness() {
+function Harness({ device = 'emulator-5554', enabled = true } = {}) {
   client = useAndroidDeviceClient({
     baseUrl: 'http://device.test',
-    device: 'emulator-5554',
+    device,
+    enabled,
     streamMode: 'webrtc',
   });
-  return null;
+  return <DeviceScreen client={client} />;
 }
 
 async function mount() {
   await act(async () => root.render(<Harness />));
   expect(offers).toBe(1);
+  video = container.querySelector('video')!;
+  Object.defineProperties(video, {
+    videoWidth: { value: 1080 },
+    videoHeight: { value: 1920 },
+    readyState: { value: 2, configurable: true },
+    play: { value: async () => {} },
+  });
   await act(async () => {
     metadata.resolve(Response.json(authoritative));
-    client.attachVideo(video);
     ControlSocket.instances[0].onopen?.();
     Peer.instances[0].deliverTrack();
   });
@@ -188,6 +204,10 @@ async function mount() {
   // Initial source metadata must not replace the already connecting peer.
   expect(offers).toBe(1);
   expect(Peer.instances).toHaveLength(1);
+}
+
+function retainedFrame() {
+  return container.querySelector('canvas');
 }
 
 async function paintFrame() {
@@ -207,6 +227,40 @@ async function reconnectControl() {
 }
 
 describe('Android WebRTC capture replacement hooks', () => {
+  test('retains the last frame from the switch request until replacement video paints', async () => {
+    await mount();
+    await act(async () => client.setStreamSource('grpc-screenshot'));
+    expect(savedFrames).toBe(1);
+    expect(retainedFrame()?.style.visibility).toBe('visible');
+    await confirmReplacement();
+    expect(frameVisibleAtClose).toEqual([true]);
+    expect(retainedFrame()?.style.visibility).toBe('visible');
+    await act(async () => Peer.instances[1].deliverTrack());
+    expect(retainedFrame()?.style.visibility).toBe('visible');
+    expect(savedFrames).toBe(1);
+    await paintFrame();
+    expect(retainedFrame()?.style.visibility).toBe('hidden');
+    expect(client.status).toBe('streaming');
+  });
+
+  test.each(['device change', 'disabled'] as const)(
+    'clears a retained frame on %s',
+    async (change) => {
+      await mount();
+      await act(async () => client.setStreamSource('grpc-screenshot'));
+      expect(retainedFrame()?.style.visibility).toBe('visible');
+      await act(async () =>
+        root.render(
+          <Harness
+            device={change === 'device change' ? 'emulator-5556' : undefined}
+            enabled={change !== 'disabled'}
+          />,
+        ),
+      );
+      expect(retainedFrame()?.style.visibility).not.toBe('visible');
+    },
+  );
+
   test('restarts once on confirmation and keeps the replacement peer when its frame commits', async () => {
     await mount();
     await act(async () => client.setStreamSource('grpc-screenshot'));
@@ -235,6 +289,7 @@ describe('Android WebRTC capture replacement hooks', () => {
     async (timing) => {
       await mount();
       await act(async () => client.setStreamSource('grpc-screenshot'));
+      expect(retainedFrame()?.style.visibility).toBe('visible');
       await act(async () => ControlSocket.instances[0].onclose?.({ code: 1012 }));
       expect(client.status).toBe('reconnecting');
       await reconnectControl();
@@ -285,6 +340,7 @@ describe('Android WebRTC capture replacement hooks', () => {
       expect(offers).toBe(1);
       expect(Peer.instances).toHaveLength(1);
       expect(Peer.instances[0].closed).toBe(false);
+      expect(retainedFrame()?.style.visibility).toBe('hidden');
       if (result === 'failed') expect(client.streamSourceError).toContain('Capture unavailable');
     },
   );
@@ -329,6 +385,13 @@ describe('Android WebRTC capture replacement hooks', () => {
       expect(client.streamSource?.sessionGeneration).toBe(generation);
       expect(offers).toBe(expectedOffers);
       expect(Peer.instances).toHaveLength(expectedOffers);
+      expect(retainedFrame()?.style.visibility).toBe('visible');
+      // Repeated replacements without a new frame must keep the original snapshot.
+      expect(savedFrames).toBe(1);
     }
+    expect(frameVisibleAtClose).toEqual([true, true]);
+    await act(async () => Peer.instances[2].deliverTrack());
+    await paintFrame();
+    expect(retainedFrame()?.style.visibility).toBe('hidden');
   });
 });

--- a/packages/@expo/hub-client/src/__tests__/android-webrtc-restart.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/android-webrtc-restart.test.tsx
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Window } from 'happy-dom';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { useAndroidDeviceClient } from '../useAndroidDevice';
+import type { DeviceClient, DeviceStreamSourceStatus } from '../types';
+
+class Peer extends EventTarget {
+  static instances: Peer[] = [];
+  closed = false;
+  iceGatheringState = 'complete';
+  connectionState = 'connected';
+  localDescription: RTCSessionDescriptionInit | null = null;
+  ontrack: ((event: { streams: object[]; track: object }) => void) | null = null;
+
+  constructor() {
+    super();
+    Peer.instances.push(this);
+  }
+
+  addTransceiver() {
+    return {};
+  }
+  async createOffer() {
+    return { type: 'offer' as const, sdp: 'offer' };
+  }
+  async setLocalDescription(description: RTCSessionDescriptionInit) {
+    this.localDescription = description;
+  }
+  async setRemoteDescription() {}
+  close() {
+    this.closed = true;
+  }
+  deliverTrack() {
+    this.ontrack?.({ streams: [new browser.MediaStream()], track: {} });
+  }
+}
+
+class ControlSocket {
+  static instances: ControlSocket[] = [];
+  static OPEN = 1;
+  readyState = 1;
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+
+  constructor() {
+    ControlSocket.instances.push(this);
+  }
+  send() {}
+  close() {}
+}
+
+const source = (sessionGeneration: number): DeviceStreamSourceStatus & { ok: true } => ({
+  ok: true,
+  mode: sessionGeneration === 1 ? 'scrcpy' : 'grpc-screenshot',
+  grpcImageMode: 'mmap',
+  inputSource: 'scrcpy',
+  availableInputSources: ['scrcpy', 'grpc'],
+  availableModes: ['scrcpy', 'grpc-screenshot'],
+  sessionGeneration,
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let browser: Window;
+let root: Root;
+let client: DeviceClient;
+let video: HTMLVideoElement;
+let metadata: ReturnType<typeof deferred<Response>>;
+let replacement: ReturnType<typeof deferred<Response>>;
+let authoritative: ReturnType<typeof source>;
+let puts: number;
+let offers: number;
+type Timer = { callback: () => void; delay: number };
+const intervals = new Map<number, Timer>();
+const timeouts = new Map<number, Timer>();
+const restoreGlobals: (() => void)[] = [];
+
+function installGlobal(name: string, value: unknown) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  restoreGlobals.push(() => {
+    if (previous) Object.defineProperty(globalThis, name, previous);
+    else Reflect.deleteProperty(globalThis, name);
+  });
+}
+
+beforeEach(() => {
+  browser = new Window();
+  installGlobal('window', browser);
+  installGlobal('document', browser.document);
+  installGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  installGlobal('RTCPeerConnection', Peer);
+  installGlobal('RTCRtpReceiver', { getCapabilities: () => null });
+  installGlobal('WebSocket', ControlSocket);
+  Peer.instances = [];
+  ControlSocket.instances = [];
+  metadata = deferred<Response>();
+  replacement = deferred<Response>();
+  authoritative = source(1);
+  puts = 0;
+  offers = 0;
+  intervals.clear();
+  timeouts.clear();
+  let timerId = 0;
+  installGlobal('setInterval', (callback: () => void, delay: number) => {
+    intervals.set(++timerId, { callback, delay });
+    return timerId;
+  });
+  installGlobal('clearInterval', (id: number) => intervals.delete(id));
+  installGlobal('setTimeout', (callback: () => void, delay: number) => {
+    timeouts.set(++timerId, { callback, delay });
+    return timerId;
+  });
+  installGlobal('clearTimeout', (id: number) => timeouts.delete(id));
+  let initialSourceRead = true;
+  installGlobal('fetch', async (input: string | URL, init?: RequestInit) => {
+    const path = new URL(String(input)).pathname;
+    if (path === '/api') {
+      return Response.json({
+        stream: {
+          transport: 'webrtc',
+          codec: 'h264',
+          iceServers: [],
+          iceTransportPolicy: 'all',
+        },
+      });
+    }
+    if (path === '/api/stream-mode') {
+      if (init?.method === 'PUT') {
+        puts++;
+        return replacement.promise;
+      }
+      if (initialSourceRead) {
+        initialSourceRead = false;
+        return metadata.promise;
+      }
+      return Response.json(authoritative);
+    }
+    if (path === '/webrtc/offer') {
+      offers++;
+      return Response.json({ type: 'answer', sdp: 'answer' });
+    }
+    return Response.json({});
+  });
+  root = createRoot(document.createElement('div'));
+  video = document.createElement('video');
+  Object.defineProperties(video, {
+    videoWidth: { value: 1080 },
+    videoHeight: { value: 1920 },
+    play: { value: async () => {} },
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  await browser.happyDOM.close();
+  for (const restore of restoreGlobals.splice(0).reverse()) restore();
+});
+
+function Harness() {
+  client = useAndroidDeviceClient({
+    baseUrl: 'http://device.test',
+    device: 'emulator-5554',
+    streamMode: 'webrtc',
+  });
+  return null;
+}
+
+async function mount() {
+  await act(async () => root.render(<Harness />));
+  expect(offers).toBe(1);
+  await act(async () => {
+    metadata.resolve(Response.json(authoritative));
+    client.attachVideo(video);
+    ControlSocket.instances[0].onopen?.();
+    Peer.instances[0].deliverTrack();
+  });
+  await paintFrame();
+  expect(client.status).toBe('streaming');
+  // Initial source metadata must not replace the already connecting peer.
+  expect(offers).toBe(1);
+  expect(Peer.instances).toHaveLength(1);
+}
+
+async function paintFrame() {
+  await act(async () => video.dispatchEvent(new window.Event('loadeddata')));
+}
+
+async function confirmReplacement(generation = 2) {
+  authoritative = source(generation);
+  await act(async () => replacement.resolve(Response.json(authoritative)));
+}
+
+async function reconnectControl() {
+  const entry = [...timeouts].find(([, timer]) => timer.delay === 100);
+  if (!entry) throw new Error('The control socket did not schedule a reconnect');
+  timeouts.delete(entry[0]);
+  await act(async () => entry[1].callback());
+}
+
+describe('Android WebRTC capture replacement hooks', () => {
+  test('restarts once on confirmation and keeps the replacement peer when its frame commits', async () => {
+    await mount();
+    await act(async () => client.setStreamSource('grpc-screenshot'));
+    expect(client.streamSourcePending).toBe(true);
+    expect(offers).toBe(1);
+
+    await confirmReplacement();
+    expect(offers).toBe(2);
+    expect(Peer.instances).toHaveLength(2);
+    expect(Peer.instances[0].closed).toBe(true);
+    expect(client.streamSource?.sessionGeneration).toBe(1);
+    expect(client.streamSourcePending).toBe(true);
+    await act(async () => Peer.instances[1].deliverTrack());
+    expect(client.streamSourcePending).toBe(true);
+    await paintFrame();
+    expect(client.streamSource?.sessionGeneration).toBe(2);
+    expect(client.streamSourcePending).toBe(false);
+    expect(client.status).toBe('streaming');
+    expect(offers).toBe(2);
+    expect(Peer.instances).toHaveLength(2);
+    expect(Peer.instances[1].closed).toBe(false);
+  });
+
+  test.each(['before', 'with'] as const)(
+    'keeps controls pending if the control socket recovers %s the PUT response',
+    async (timing) => {
+      await mount();
+      await act(async () => client.setStreamSource('grpc-screenshot'));
+      await act(async () => ControlSocket.instances[0].onclose?.({ code: 1012 }));
+      expect(client.status).toBe('reconnecting');
+      await reconnectControl();
+      if (timing === 'before') {
+        await act(async () => ControlSocket.instances[1].onopen?.());
+        expect(client.status).toBe('streaming');
+        await confirmReplacement();
+      } else {
+        await act(async () => {
+          ControlSocket.instances[1].onopen?.();
+          replacement.resolve(Response.json(source(2)));
+        });
+      }
+      expect(offers).toBe(2);
+      expect(client.status).toBe('reconnecting');
+      expect(client.streamSourcePending).toBe(true);
+      expect(client.streamSource?.sessionGeneration).toBe(1);
+      await act(async () => {
+        client.setStreamSource('grpc-screenshot');
+        client.setStreamSource('scrcpy');
+      });
+      expect(puts).toBe(1);
+
+      await act(async () => Peer.instances[1].deliverTrack());
+      expect(client.streamSourcePending).toBe(true);
+      await paintFrame();
+      expect(client.streamSourcePending).toBe(false);
+      expect(client.streamSource?.sessionGeneration).toBe(2);
+      expect(offers).toBe(2);
+    },
+  );
+
+  test.each(['failed', 'unchanged'] as const)(
+    'preserves the peer when the PUT is %s',
+    async (result) => {
+      await mount();
+      await act(async () => client.setStreamSource('grpc-screenshot'));
+      await act(async () =>
+        replacement.resolve(
+          result === 'failed'
+            ? Response.json({ error: 'Capture unavailable' }, { status: 503 })
+            : Response.json(source(1)),
+        ),
+      );
+      expect(client.streamSourcePending).toBe(false);
+      expect(client.streamSource?.sessionGeneration).toBe(1);
+      expect(client.status).toBe('streaming');
+      expect(offers).toBe(1);
+      expect(Peer.instances).toHaveLength(1);
+      expect(Peer.instances[0].closed).toBe(false);
+      if (result === 'failed') expect(client.streamSourceError).toContain('Capture unavailable');
+    },
+  );
+
+  test('waits for the replacement frame when changing the gRPC image mode', async () => {
+    authoritative = source(2);
+    await mount();
+    await act(async () => client.setGrpcImageMode('png'));
+    await act(async () =>
+      replacement.resolve(
+        Response.json({
+          ...source(3),
+          grpcImageMode: 'png',
+        }),
+      ),
+    );
+    expect(puts).toBe(1);
+    expect(offers).toBe(2);
+    expect(client.streamSource?.grpcImageMode).toBe('mmap');
+    expect(client.streamSourcePending).toBe(true);
+    await act(async () => Peer.instances[1].deliverTrack());
+    await paintFrame();
+    expect(client.streamSource?.grpcImageMode).toBe('png');
+    expect(client.streamSourcePending).toBe(false);
+    expect(offers).toBe(2);
+    expect(Peer.instances).toHaveLength(2);
+  });
+
+  test('restarts once per polled generation change, including a server reset', async () => {
+    await mount();
+    for (const [generation, expectedOffers] of [
+      [2, 2],
+      [2, 2],
+      [0, 3],
+    ]) {
+      authoritative = source(generation);
+      await act(async () => {
+        for (const timer of intervals.values()) {
+          if (timer.delay === 3000) timer.callback();
+        }
+      });
+      expect(client.streamSource?.sessionGeneration).toBe(generation);
+      expect(offers).toBe(expectedOffers);
+      expect(Peer.instances).toHaveLength(expectedOffers);
+    }
+  });
+});

--- a/packages/@expo/hub-client/src/__tests__/webrtc-restart.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-restart.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
 import { androidWebRtcRestartKey } from '../android-stream-source';
-import { IDLE_STREAM_SWITCH, reduceStreamSwitch } from '../stream-switch';
 import { observeWebRtcRestartKey } from '../webrtc-restart';
 
 describe('capture generation WebRTC restart', () => {
@@ -19,11 +18,6 @@ describe('capture generation WebRTC restart', () => {
   test('restarts on successful replacement before a new frame commits the UI selection', () => {
     const displayed = { sessionGeneration: 1 };
     const pending = { sessionGeneration: 2 };
-    const requesting = reduceStreamSwitch(IDLE_STREAM_SWITCH, {
-      type: 'request-start', live: true,
-    });
-    const switching = reduceStreamSwitch(requesting, { type: 'request-success', replaced: true });
-    expect(switching.phase).toBe('awaiting-interruption');
 
     const restarted = observeWebRtcRestartKey(
       { key: 1, generation: 0 },
@@ -32,17 +26,14 @@ describe('capture generation WebRTC restart', () => {
     expect(restarted).toEqual({ key: 2, generation: 1 });
 
     // Once video paints, committing pending state must not restart the new peer again.
-    expect(observeWebRtcRestartKey(restarted, androidWebRtcRestartKey(pending, null))).toBe(restarted);
+    expect(observeWebRtcRestartKey(restarted, androidWebRtcRestartKey(pending, null))).toBe(
+      restarted,
+    );
   });
 
-  test('keeps the live peer during a request and after failed or no-op replacements', () => {
+  test('preserves the restart generation when the source generation is unchanged', () => {
     const displayed = { sessionGeneration: 1 };
     const live = { key: 1, generation: 0 };
-    const requesting = reduceStreamSwitch(IDLE_STREAM_SWITCH, {
-      type: 'request-start', live: true,
-    });
-    expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, null))).toBe(live);
-    expect(reduceStreamSwitch(requesting, { type: 'request-failure' })).toBe(IDLE_STREAM_SWITCH);
     expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, null))).toBe(live);
     expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, displayed))).toBe(live);
   });

--- a/packages/@expo/hub-client/src/__tests__/webrtc-restart.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-restart.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+
+import { androidWebRtcRestartKey } from '../android-stream-source';
+import { IDLE_STREAM_SWITCH, reduceStreamSwitch } from '../stream-switch';
+import { observeWebRtcRestartKey } from '../webrtc-restart';
+
+describe('capture generation WebRTC restart', () => {
+  test('uses initial metadata as a baseline without restarting a connecting peer', () => {
+    const unknown = { key: null, generation: 0 };
+    expect(androidWebRtcRestartKey(null, null)).toBeNull();
+    const baseline = observeWebRtcRestartKey(
+      unknown,
+      androidWebRtcRestartKey({ sessionGeneration: 1 }, null),
+    );
+    expect(baseline).toEqual({ key: 1, generation: 0 });
+    expect(observeWebRtcRestartKey(baseline, 1)).toBe(baseline);
+  });
+
+  test('restarts on successful replacement before a new frame commits the UI selection', () => {
+    const displayed = { sessionGeneration: 1 };
+    const pending = { sessionGeneration: 2 };
+    const requesting = reduceStreamSwitch(IDLE_STREAM_SWITCH, {
+      type: 'request-start', live: true,
+    });
+    const switching = reduceStreamSwitch(requesting, { type: 'request-success', replaced: true });
+    expect(switching.phase).toBe('awaiting-interruption');
+
+    const restarted = observeWebRtcRestartKey(
+      { key: 1, generation: 0 },
+      androidWebRtcRestartKey(displayed, pending),
+    );
+    expect(restarted).toEqual({ key: 2, generation: 1 });
+
+    // Once video paints, committing pending state must not restart the new peer again.
+    expect(observeWebRtcRestartKey(restarted, androidWebRtcRestartKey(pending, null))).toBe(restarted);
+  });
+
+  test('keeps the live peer during a request and after failed or no-op replacements', () => {
+    const displayed = { sessionGeneration: 1 };
+    const live = { key: 1, generation: 0 };
+    const requesting = reduceStreamSwitch(IDLE_STREAM_SWITCH, {
+      type: 'request-start', live: true,
+    });
+    expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, null))).toBe(live);
+    expect(reduceStreamSwitch(requesting, { type: 'request-failure' })).toBe(IDLE_STREAM_SWITCH);
+    expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, null))).toBe(live);
+    expect(observeWebRtcRestartKey(live, androidWebRtcRestartKey(displayed, displayed))).toBe(live);
+  });
+
+  test('restarts on externally polled changes, including a server generation reset', () => {
+    const live = { key: 2, generation: 1 };
+    const external = observeWebRtcRestartKey(
+      live,
+      androidWebRtcRestartKey({ sessionGeneration: 3 }, null),
+    );
+    expect(external).toEqual({ key: 3, generation: 2 });
+    expect(observeWebRtcRestartKey(external, 0)).toEqual({ key: 0, generation: 3 });
+  });
+
+  test('establishes a fresh baseline when device metadata becomes unknown', () => {
+    const unknown = observeWebRtcRestartKey({ key: 2, generation: 1 }, null);
+    expect(unknown).toEqual({ key: null, generation: 1 });
+    expect(observeWebRtcRestartKey(unknown, 8)).toEqual({ key: 8, generation: 1 });
+  });
+});

--- a/packages/@expo/hub-client/src/android-stream-source.ts
+++ b/packages/@expo/hub-client/src/android-stream-source.ts
@@ -10,6 +10,14 @@ const ANDROID_STREAM_SOURCES = [
   'grpc-screenshot',
 ] as const satisfies readonly DeviceStreamSource[];
 
+/** A confirmed replacement must reconnect before its first frame commits the UI selection. */
+export function androidWebRtcRestartKey(
+  displayed: Pick<DeviceStreamSourceStatus, 'sessionGeneration'> | null,
+  pending: Pick<DeviceStreamSourceStatus, 'sessionGeneration'> | null,
+): number | null {
+  return pending?.sessionGeneration ?? displayed?.sessionGeneration ?? null;
+}
+
 function isAndroidStreamSource(value: unknown): value is DeviceStreamSource {
   return ANDROID_STREAM_SOURCES.some((source) => source === value);
 }

--- a/packages/@expo/hub-client/src/retained-video-frame.ts
+++ b/packages/@expo/hub-client/src/retained-video-frame.ts
@@ -1,0 +1,45 @@
+/** Holds a video snapshot across peer teardown and MediaStream replacement. */
+export class RetainedVideoFrame {
+  private video: HTMLVideoElement | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private retained = false;
+
+  attach(video: HTMLVideoElement | null, canvas: HTMLCanvasElement | null): void {
+    if (this.video === video && this.canvas === canvas) return;
+    this.reset();
+    this.video = video;
+    this.canvas = canvas;
+    this.release();
+  }
+
+  retain(): void {
+    const { video, canvas } = this;
+    // Never overwrite the saved picture with a closed track or an unready stream.
+    if (this.retained || !video || !canvas || video.readyState < 2) return;
+    if (video.videoWidth <= 0 || video.videoHeight <= 0) return;
+    try {
+      const context = canvas.getContext('2d');
+      if (!context) return;
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      context.drawImage(video, 0, 0);
+      canvas.style.visibility = 'visible';
+      this.retained = true;
+    } catch {
+      // A video without a drawable frame must not prevent transport recovery.
+    }
+  }
+
+  release(): void {
+    if (this.canvas) this.canvas.style.visibility = 'hidden';
+    this.retained = false;
+  }
+
+  reset(): void {
+    this.release();
+    if (this.canvas) {
+      this.canvas.width = 0;
+      this.canvas.height = 0;
+    }
+  }
+}

--- a/packages/@expo/hub-client/src/stream-switch.ts
+++ b/packages/@expo/hub-client/src/stream-switch.ts
@@ -39,8 +39,12 @@ export type StreamSwitchEvent =
    */
   | { type: 'request-start'; live: boolean }
   | { type: 'request-failure' }
-  /** `replaced` is whether the server started a new session generation. */
-  | { type: 'request-success'; replaced: boolean }
+  /**
+   * `replaced` is whether the server started a new session generation.
+   * `restartRequired` means the client must still renegotiate video, even if
+   * the control socket recovered before the response arrived.
+   */
+  | { type: 'request-success'; replaced: boolean; restartRequired?: boolean }
   /** The live stream stopped delivering frames (or lost its control channel). */
   | { type: 'stream-interrupted' }
   /** The stream is live again. */
@@ -97,7 +101,9 @@ export function reduceStreamSwitch(
         case 'request-failure':
           return IDLE_STREAM_SWITCH;
         case 'request-success':
-          if (!event.replaced || state.recovered) return IDLE_STREAM_SWITCH;
+          if (!event.replaced) return IDLE_STREAM_SWITCH;
+          if (event.restartRequired) return AWAITING_FRAME;
+          if (state.recovered) return IDLE_STREAM_SWITCH;
           return state.interrupted ? AWAITING_FRAME : AWAITING_INTERRUPTION;
         case 'timeout':
           return state;

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -508,9 +508,14 @@ export interface DeviceClient {
   /**
    * Ref callback for the paint target. The hook owns the element: `canvas`
    * receives decoded H.264 frames, `img` points at MJPEG, and `video` receives
-   * a WebRTC MediaStream.
+   * a WebRTC MediaStream. The optional canvas covers video with a retained
+   * frame while a replacement stream is connecting; the hook owns its pixels
+   * and visibility.
    */
-  attachVideo: (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => void;
+  attachVideo: (
+    el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null,
+    retainedFrame?: HTMLCanvasElement | null,
+  ) => void;
 
   /** Forward a normalized touch/drag to the device. */
   sendTouch: (sample: TouchSample) => void;

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -37,6 +37,7 @@ import {
 } from './android-stream-settings';
 import {
   androidStreamSourceErrorMessage,
+  androidWebRtcRestartKey,
   parseAndroidStreamSource,
 } from './android-stream-source';
 import {
@@ -829,6 +830,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     sendIceServersInOffer: false,
     allowCodecFallback: false,
     onKeyframeNeeded: requestWebRtcKeyframe,
+    restartKey: androidWebRtcRestartKey(streamSource, pendingStreamSourceRef.current),
   });
 
   const webRtcLive =
@@ -866,9 +868,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       setStatus('streaming');
       setError(null);
     } else if (webRtcWasLive && !webRtcGraceExpired) {
-      // When serve-emu swaps the capture source the RTP video usually keeps
-      // flowing; only the control socket is closed and reopened. Keep the frame
-      // and report a reconnect instead of an error while that settles.
+      // A capture generation change renegotiates video and reopens control.
+      // Keep the last frame and report a reconnect while they settle.
       setStatus('reconnecting');
       setError(null);
     } else if (webRtcError) {

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -233,6 +233,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     ReadonlySet<DeviceSettingKey>
   >(() => new Set());
   const [streamSource, setStreamSourceState] = useState<DeviceStreamSourceStatus | null>(null);
+  const [pendingStreamSource, setPendingStreamSourceState] =
+    useState<DeviceStreamSourceStatus | null>(null);
   // True until the first authoritative read of the capture source completes.
   const [streamSourceLoading, setStreamSourceLoading] = useState(false);
   const [streamSourceError, setStreamSourceError] = useState<string | null>(null);
@@ -287,6 +289,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const streamSwitchRef = useRef<StreamSwitchState>(IDLE_STREAM_SWITCH);
   // The server's answer to a switch, held back until the new stream is on screen.
   const pendingStreamSourceRef = useRef<DeviceStreamSourceStatus | null>(null);
+  // Events read synchronously from the ref; rendering subscribes to the state copy.
+  const setPendingStreamSource = useCallback((next: DeviceStreamSourceStatus | null) => {
+    pendingStreamSourceRef.current = next;
+    setPendingStreamSourceState(next);
+  }, []);
   const streamLiveRef = useRef(false);
   const streamSourceControllerRef = useRef<AbortController | null>(null);
   const streamSourceRefreshControllerRef = useRef<AbortController | null>(null);
@@ -299,10 +306,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const commitPendingStreamSource = useCallback(() => {
     const next = pendingStreamSourceRef.current;
     if (!next) return;
-    pendingStreamSourceRef.current = null;
+    setPendingStreamSource(null);
     streamSourceRef.current = next;
     setStreamSourceState(next);
-  }, []);
+  }, [setPendingStreamSource]);
 
   /**
    * Advance the switch tracker synchronously (callers may read the result) and
@@ -322,10 +329,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   );
 
   const resetStreamSwitch = useCallback(() => {
-    pendingStreamSourceRef.current = null;
+    setPendingStreamSource(null);
     streamSwitchRef.current = IDLE_STREAM_SWITCH;
     setStreamSwitch(IDLE_STREAM_SWITCH);
-  }, []);
+  }, [setPendingStreamSource]);
   useEffect(
     () => () => {
       streamSourceControllerRef.current?.abort();
@@ -516,6 +523,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     toPatch: androidStreamSettingsPatch,
   });
 
+  const webRtcRequested = streamMode === 'webrtc';
+  const waitingForWebRtcMetadata = webRtcRequested && serverStreamSettings === null;
+  const useWebRtc =
+    webRtcRequested && serverStreamSettings?.transport === 'webrtc';
+
   const putStreamMode = useCallback(
     (body: {
       mode: DeviceStreamSource;
@@ -533,7 +545,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       const request = ++streamSourceRequestRef.current;
       const controller = new AbortController();
       streamSourceControllerRef.current = controller;
-      pendingStreamSourceRef.current = null;
+      setPendingStreamSource(null);
       dispatchStreamSwitch({ type: 'request-start', live: streamLiveRef.current });
       setStreamSourceError(null);
       void fetch(streamSourceUrl, {
@@ -558,10 +570,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
             // and closed this viewer's sockets. Hold the new source back until
             // the replacement stream is on screen so the sidebar and the device
             // frame change together (a same-generation answer changed nothing).
-            pendingStreamSourceRef.current = next;
+            setPendingStreamSource(next);
             dispatchStreamSwitch({
               type: 'request-success',
               replaced: next.sessionGeneration !== previousGeneration,
+              restartRequired: useWebRtc,
             });
           }
         })
@@ -581,7 +594,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           }
         });
     },
-    [dispatchStreamSwitch, streamSourceUrl],
+    [dispatchStreamSwitch, setPendingStreamSource, streamSourceUrl, useWebRtc],
   );
 
   const setStreamSource = useCallback(
@@ -800,10 +813,6 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     };
   }, [active, baseUrl, targetDevice]);
 
-  const webRtcRequested = streamMode === 'webrtc';
-  const waitingForWebRtcMetadata = webRtcRequested && serverStreamSettings === null;
-  const useWebRtc =
-    webRtcRequested && serverStreamSettings?.transport === 'webrtc';
   const requestWebRtcKeyframe = useCallback(() => {
     send({ type: 'reset-video' });
   }, [send]);
@@ -830,7 +839,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     sendIceServersInOffer: false,
     allowCodecFallback: false,
     onKeyframeNeeded: requestWebRtcKeyframe,
-    restartKey: androidWebRtcRestartKey(streamSource, pendingStreamSourceRef.current),
+    restartKey: androidWebRtcRestartKey(streamSource, pendingStreamSource),
   });
 
   const webRtcLive =

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -47,6 +47,7 @@ import {
 import { buildCodecString, isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
+import { RetainedVideoFrame } from './retained-video-frame';
 import {
   RECONNECT_BASE_DELAY_MS,
   STREAM_RECONNECT_GRACE_MS,
@@ -267,6 +268,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
   const wsRef = useRef<WebSocket | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const retainedWebRtcFrameRef = useRef(new RetainedVideoFrame());
   // Monotonic log id source, persisted across logcat reconnects so ids stay
   // unique even though lines are kept (the stream effect may re-run).
   const logSeqRef = useRef(0);
@@ -342,13 +344,19 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   );
 
   const attachVideo = useCallback(
-    (el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null) => {
+    (
+      el: HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null,
+      retainedFrame: HTMLCanvasElement | null = null,
+    ) => {
       canvasRef.current = el?.tagName === 'CANVAS' ? (el as HTMLCanvasElement) : null;
       const video = el?.tagName === 'VIDEO' ? (el as HTMLVideoElement) : null;
+      retainedWebRtcFrameRef.current.attach(video, retainedFrame);
       setWebRtcVideoElement((current) => (current === video ? current : video));
     },
     [],
   );
+
+  const retainWebRtcFrame = useCallback(() => retainedWebRtcFrameRef.current.retain(), []);
 
   const attachLogs = useCallback(() => setLogsEnabled(true), []);
   const detachLogs = useCallback(() => setLogsEnabled(false), []);
@@ -542,6 +550,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         return;
       }
       const previousGeneration = streamSourceRef.current?.sessionGeneration ?? null;
+      if (useWebRtc) retainWebRtcFrame();
       const request = ++streamSourceRequestRef.current;
       const controller = new AbortController();
       streamSourceControllerRef.current = controller;
@@ -571,6 +580,9 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
             // the replacement stream is on screen so the sidebar and the device
             // frame change together (a same-generation answer changed nothing).
             setPendingStreamSource(next);
+            if (next.sessionGeneration === previousGeneration) {
+              retainedWebRtcFrameRef.current.release();
+            }
             dispatchStreamSwitch({
               type: 'request-success',
               replaced: next.sessionGeneration !== previousGeneration,
@@ -582,6 +594,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           // The server stages source changes atomically, so the previous source
           // remains authoritative when a replacement fails.
           if (!controller.signal.aborted && streamSourceRequestRef.current === request) {
+            retainedWebRtcFrameRef.current.release();
             setStreamSourceError(
               cause instanceof Error ? cause.message : 'Unable to change stream source.',
             );
@@ -594,7 +607,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           }
         });
     },
-    [dispatchStreamSwitch, setPendingStreamSource, streamSourceUrl, useWebRtc],
+    [dispatchStreamSwitch, retainWebRtcFrame, setPendingStreamSource, streamSourceUrl, useWebRtc],
   );
 
   const setStreamSource = useCallback(
@@ -839,6 +852,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     sendIceServersInOffer: false,
     allowCodecFallback: false,
     onKeyframeNeeded: requestWebRtcKeyframe,
+    onBeforeDisconnect: retainWebRtcFrame,
     restartKey: androidWebRtcRestartKey(streamSource, pendingStreamSource),
   });
 
@@ -899,9 +913,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   useEffect(() => {
     if (!useWebRtc) return;
     const video = webRtcVideoElement;
-    // While the peer renegotiates (`webRtcStream` null) the element keeps its
-    // previous MediaStream, whose ended track leaves the last frame visible —
-    // the same "hold the last frame" the canvas path gets for free.
+    // The retained-frame canvas covers peer teardown and srcObject replacement
+    // until this stream has a frame ready to display.
     if (!video || !webRtcStream) return;
 
     let stopped = false;
@@ -922,6 +935,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       }
       if (firstFrame) {
         firstFrame = false;
+        retainedWebRtcFrameRef.current.release();
         setWebRtcVideoReady(true);
       }
       markWebRtcFrameDecoded(presentedFrameDelta);
@@ -972,6 +986,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       setFps(0);
     };
   }, [useWebRtc, webRtcStream, webRtcVideoElement, markWebRtcFrameDecoded]);
+
+  useEffect(() => {
+    const retainedFrame = retainedWebRtcFrameRef.current;
+    return () => retainedFrame.reset();
+  }, [active, baseUrl, targetDevice, useWebRtc]);
 
   // Detach the media only when this surface stops showing WebRTC or moves to
   // another device; a lost stream alone keeps its last frame (see above).

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -12,6 +12,11 @@ import {
   WebRtcSignalingTimeoutError,
 } from './webrtc-negotiation';
 import { useWebRtcStreamStats, type WebRtcStatsConnection } from './stream-stats';
+import {
+  observeWebRtcRestartKey,
+  type WebRtcRestartKey,
+  type WebRtcRestartState,
+} from './webrtc-restart';
 
 export type WebRtcIceServer = {
   urls: string[];
@@ -118,6 +123,7 @@ export function useWebRtcStream({
   sendIceServersInOffer = true,
   allowCodecFallback = true,
   onKeyframeNeeded,
+  restartKey = null,
 }: {
   offerUrl: string;
   closeUrl: string;
@@ -130,6 +136,8 @@ export function useWebRtcStream({
   sendIceServersInOffer?: boolean;
   allowCodecFallback?: boolean;
   onKeyframeNeeded?: () => void;
+  /** Re-negotiate when an authoritative source generation changes; null means unknown. */
+  restartKey?: WebRtcRestartKey;
 }) {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [failure, setFailure] = useState<WebRtcStreamFailure | null>(null);
@@ -137,6 +145,12 @@ export function useWebRtcStream({
   const [statsConnection, setStatsConnection] = useState<WebRtcStatsConnection | null>(null);
   const [streamStatsEnabled, setStreamStatsEnabled] = useState(false);
   const [retryGeneration, setRetryGeneration] = useState(0);
+  const [restartState, setRestartState] = useState<WebRtcRestartState>({
+    key: restartKey,
+    generation: 0,
+  });
+  const nextRestartState = observeWebRtcRestartKey(restartState, restartKey);
+  if (nextRestartState !== restartState) setRestartState(nextRestartState);
   const firstFrameTimeoutRef = useRef<number | undefined>(undefined);
   const firstFrameDecodedRef = useRef(false);
   const presentedFramesRef = useRef(0);
@@ -172,6 +186,7 @@ export function useWebRtcStream({
     iceTransportPolicy,
     sendIceServersInOffer,
     allowCodecFallback,
+    restartState.generation,
   ]);
 
   useEffect(() => {
@@ -446,6 +461,7 @@ export function useWebRtcStream({
     allowCodecFallback,
     onKeyframeNeeded,
     retryGeneration,
+    restartState.generation,
   ]);
 
   return { stream, failure, error, markFrameDecoded, streamStats, setStreamStatsEnabled };

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -123,6 +123,7 @@ export function useWebRtcStream({
   sendIceServersInOffer = true,
   allowCodecFallback = true,
   onKeyframeNeeded,
+  onBeforeDisconnect,
   restartKey = null,
 }: {
   offerUrl: string;
@@ -136,6 +137,8 @@ export function useWebRtcStream({
   sendIceServersInOffer?: boolean;
   allowCodecFallback?: boolean;
   onKeyframeNeeded?: () => void;
+  /** Preserve the displayed frame before closing the current peer. */
+  onBeforeDisconnect?: () => void;
   /** Re-negotiate when an authoritative source generation changes; null means unknown. */
   restartKey?: WebRtcRestartKey;
 }) {
@@ -242,6 +245,7 @@ export function useWebRtcStream({
     };
 
     const closePeer = () => {
+      onBeforeDisconnect?.();
       clearFirstFrameTimeout();
       clearDisconnectedTimer();
       setStream(null);
@@ -437,6 +441,7 @@ export function useWebRtcStream({
 
     return () => {
       stopped = true;
+      onBeforeDisconnect?.();
       window.removeEventListener('pagehide', releaseOnPageHide);
       window.removeEventListener('beforeunload', releaseOnPageHide);
       lifecycleController.abort();
@@ -460,6 +465,7 @@ export function useWebRtcStream({
     sendIceServersInOffer,
     allowCodecFallback,
     onKeyframeNeeded,
+    onBeforeDisconnect,
     retryGeneration,
     restartState.generation,
   ]);

--- a/packages/@expo/hub-client/src/webrtc-restart.ts
+++ b/packages/@expo/hub-client/src/webrtc-restart.ts
@@ -1,0 +1,18 @@
+export type WebRtcRestartKey = string | number | null;
+
+export type WebRtcRestartState = {
+  key: WebRtcRestartKey;
+  generation: number;
+};
+
+/** Initial metadata establishes a baseline; later known changes replace the peer. */
+export function observeWebRtcRestartKey(
+  previous: WebRtcRestartState,
+  key: WebRtcRestartKey,
+): WebRtcRestartState {
+  if (previous.key === key) return previous;
+  return {
+    key,
+    generation: previous.generation + (previous.key !== null && key !== null ? 1 : 0),
+  };
+}

--- a/packages/@expo/hub-client/src/webrtc-restart.ts
+++ b/packages/@expo/hub-client/src/webrtc-restart.ts
@@ -1,4 +1,4 @@
-export type WebRtcRestartKey = string | number | null;
+export type WebRtcRestartKey = number | null;
 
 export type WebRtcRestartState = {
   key: WebRtcRestartKey;


### PR DESCRIPTION
Changing an Android capture source or gRPC image mode can leave the existing WebRTC peer attached to the previous publisher. The preview then freezes until watchdog recovery. Renegotiate when the server confirms a new capture generation, using the pending response before waiting for its first frame to commit the UI selection.

Initial metadata establishes a baseline without restarting an in-flight connection. Failed and no-op changes preserve the peer, and committing the replacement selection does not trigger a second restart. The same logic handles externally observed capture replacements and server generation resets. Pending capture metadata is React state, and a control socket that recovers before the PUT response does not finish the switch before the replacement video renders. A canvas snapshot retains the last displayed frame across peer teardown and MediaStream replacement, then clears when the new video has a frame ready. Failed/no-op switches resume the current video, and changing devices clears the saved picture.

This is the standalone recovery fix extracted from #70, based on current upstream `main` (`87c2037`). It uses the existing capture-generation contract and can merge independently: the diff contains client logic, regression tests and their development dependencies, and a patch changeset for the published `expo-device-hub` package. It has no RGB option or submodule changes.

### Validation

- On this standalone branch, `@expo/hub-client`: **168 tests passed**, build, typecheck, and lint passed.
- Hook-level tests mount DeviceScreen with the Android client and WebRTC hooks together, covering one restart per capture or image-mode replacement, no restart on first-frame commit, socket recovery before or alongside the PUT response, blocked concurrent switches, failed/no-op changes, and polled generation resets. They also cover retaining the last frame through repeated replacements and clearing it on device changes or disable. Pure helper tests also cover initial/unknown metadata.
- Frozen-lockfile installation and changeset validation passed.
- A Chromium pixel check using generated MediaStream tracks kept the old red frame visible while the replacement stream had no frame, then showed green after its first frame arrived. Hiding the retained canvas exposed the blank surface, confirming the check detects the original gap. This validates browser presentation without an emulator.
- Prior agent-browser testing of this same recovery logic in #70, using the built standalone Hub CLI, reduced RGB→MMAP recovery from roughly 18 seconds to **2.45 seconds** and measured **2.52 seconds** for MMAP→RGB. Timing runs from the capture-change PUT request to a connected replacement peer decoding at least five frames with presentation advancing. These measurements were made on the RGB feature branch, not repeated on this extracted branch. PNG uses the same generation-based recovery but has no separate timing measurement.
