### PR TITLE
Fix Android WebRTC playback after returning to the tab

### DIFF
--- a/.changeset/quiet-android-streams.md
+++ b/.changeset/quiet-android-streams.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Resume Android WebRTC video when returning to a backgrounded tab, and recover streams that stop presenting frames.

--- a/bun.lock
+++ b/bun.lock
@@ -70,8 +70,10 @@
         "@swc/core": "^1.15.43",
         "@types/bun": "latest",
         "@types/react": "~19.2.2",
+        "@types/react-test-renderer": "19.1.0",
         "oxfmt": "^0.56.0",
         "oxlint": "^1.71.0",
+        "react-test-renderer": "19.2.3",
         "typescript": "~6.0.3",
       },
       "peerDependencies": {
@@ -105,7 +107,7 @@
     },
     "packages/expo-device-hub": {
       "name": "expo-device-hub",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "bin": {
         "expo-device-hub": "dist/server/cli.mjs",
       },
@@ -1146,6 +1148,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -1898,7 +1902,7 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
-    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+    "react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
     "react-native": ["react-native@0.86.0", "", { "dependencies": { "@react-native/assets-registry": "0.86.0", "@react-native/codegen": "0.86.0", "@react-native/community-cli-plugin": "0.86.0", "@react-native/gradle-plugin": "0.86.0", "@react-native/js-polyfills": "0.86.0", "@react-native/normalize-colors": "0.86.0", "@react-native/virtualized-lists": "0.86.0", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-plugin-syntax-hermes-parser": "0.36.0", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.14", "invariant": "^2.2.4", "memoize-one": "^5.0.0", "metro-runtime": "^0.84.3", "metro-source-map": "^0.84.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@react-native/jest-preset": "0.86.0", "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@react-native/jest-preset", "@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w=="],
 
@@ -1911,6 +1915,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.3", "", { "dependencies": { "react-is": "^19.2.3", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
@@ -2439,6 +2445,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
+
+    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 

--- a/packages/@expo/hub-client/package.json
+++ b/packages/@expo/hub-client/package.json
@@ -44,8 +44,10 @@
     "@swc/core": "^1.15.43",
     "@types/bun": "latest",
     "@types/react": "~19.2.2",
+    "@types/react-test-renderer": "19.1.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "react-test-renderer": "19.2.3",
     "typescript": "~6.0.3"
   },
   "engines": {

--- a/packages/@expo/hub-client/src/__tests__/android-video-resume.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/android-video-resume.test.tsx
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import { type DeviceClient } from "../types";
+import { useAndroidDeviceClient } from "../useAndroidDevice";
+
+// Run the real hooks and ref lifecycle, with only browser/network APIs replaced.
+// Window timers are manual so a hidden tab and a stalled peer are deterministic.
+class TestWindow extends EventTarget {
+  now = 0;
+  nextId = 1;
+  timers = new Map<number, { at: number; callback: () => void }>();
+  setTimeout = (callback: () => void, delay: number) => {
+    const id = this.nextId++;
+    this.timers.set(id, { at: this.now + delay, callback });
+    return id;
+  };
+  clearTimeout = (id: number) => {
+    this.timers.delete(id);
+  };
+  advance(ms: number) {
+    const end = this.now + ms;
+    while (true) {
+      const next = [...this.timers]
+        .filter(([, timer]) => timer.at <= end)
+        .sort((a, b) => a[1].at - b[1].at)[0];
+      if (!next) break;
+      this.now = next[1].at;
+      this.timers.delete(next[0]);
+      next[1].callback();
+    }
+    this.now = end;
+  }
+}
+
+class TestSocket {
+  static OPEN = 1;
+  static instances: TestSocket[] = [];
+  readyState = 1;
+  messages: string[] = [];
+  onopen: (() => void) | null = null;
+  constructor() {
+    TestSocket.instances.push(this);
+    queueMicrotask(() => this.onopen?.());
+  }
+  send(message: string) {
+    this.messages.push(message);
+  }
+  close() {
+    this.readyState = 3;
+  }
+}
+
+class TestPeer extends EventTarget {
+  static instances: TestPeer[] = [];
+  connectionState = "new";
+  iceGatheringState = "complete";
+  localDescription: RTCSessionDescriptionInit | null = null;
+  ontrack: ((event: unknown) => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  constructor() {
+    super();
+    TestPeer.instances.push(this);
+  }
+  addTransceiver() {
+    return {};
+  }
+  async createOffer() {
+    return { type: "offer", sdp: "test" };
+  }
+  async setLocalDescription(description: RTCSessionDescriptionInit) {
+    this.localDescription = description;
+  }
+  async setRemoteDescription() {
+    this.connectionState = "connected";
+    this.onconnectionstatechange?.();
+    this.ontrack?.({ track: {}, streams: [{ id: String(TestPeer.instances.length) }] });
+  }
+  close() {
+    this.connectionState = "closed";
+  }
+}
+
+class TestVideo extends EventTarget {
+  tagName = "VIDEO";
+  videoWidth = 570;
+  videoHeight = 1280;
+  currentTime = 0;
+  paused = true;
+  rejectPlay = false;
+  srcObject: unknown = null;
+  playCalls = 0;
+  presentedFrames = 0;
+  callbacks = new Map<number, VideoFrameRequestCallback>();
+  nextId = 1;
+  async play() {
+    this.playCalls++;
+    if (this.rejectPlay) throw new Error("Playback suspended");
+    this.paused = false;
+  }
+  requestVideoFrameCallback: ((callback: VideoFrameRequestCallback) => number) | undefined = (
+    callback,
+  ) => {
+    const id = this.nextId++;
+    this.callbacks.set(id, callback);
+    return id;
+  };
+  cancelVideoFrameCallback(id: number) {
+    this.callbacks.delete(id);
+  }
+  frame(advance = true) {
+    if (this.paused || !this.srcObject || doc.hidden) return false;
+    if (advance) {
+      this.currentTime += 1 / 60;
+      this.presentedFrames++;
+    }
+    const callbacks = [...this.callbacks.values()];
+    this.callbacks.clear();
+    for (const callback of callbacks) {
+      callback(performance.now(), {
+        presentedFrames: this.presentedFrames,
+        mediaTime: this.currentTime,
+        presentationTime: performance.now(),
+        expectedDisplayTime: performance.now(),
+        width: this.videoWidth,
+        height: this.videoHeight,
+      });
+    }
+    this.dispatchEvent(new Event("timeupdate"));
+    return true;
+  }
+}
+
+const globals = [
+  "window",
+  "document",
+  "fetch",
+  "WebSocket",
+  "RTCPeerConnection",
+  "RTCRtpReceiver",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const;
+const originalGlobals = new Map(
+  globals.map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]),
+);
+let testWindow: TestWindow;
+let doc: EventTarget & { hidden: boolean };
+let root: ReactTestRenderer | null;
+let video: TestVideo;
+let client: DeviceClient;
+
+beforeEach(() => {
+  TestSocket.instances = [];
+  TestPeer.instances = [];
+  root = null;
+  testWindow = new TestWindow();
+  doc = Object.assign(new EventTarget(), { hidden: false });
+  const replacements = {
+    window: testWindow,
+    document: doc,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    WebSocket: TestSocket,
+    RTCPeerConnection: TestPeer,
+    RTCRtpReceiver: { getCapabilities: () => ({ codecs: [] }) },
+    fetch: async (input: string) => {
+      const path = new URL(input).pathname;
+      return Response.json(
+        path === "/api"
+          ? {
+              stream: {
+                transport: "webrtc",
+                codec: "h264",
+                iceServers: [],
+                iceTransportPolicy: "all",
+              },
+            }
+          : path === "/webrtc/offer"
+            ? { type: "answer", sdp: "test" }
+            : {},
+      );
+    },
+  };
+  for (const [key, value] of Object.entries(replacements)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  for (const [key, descriptor] of originalGlobals) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+function Surface({ device = "emulator-5554" }: { device?: string }) {
+  client = useAndroidDeviceClient({ baseUrl: "http://hub.test", device, streamMode: "webrtc" });
+  return client.status === "idle"
+    ? null
+    : createElement(client.videoKind, { ref: client.attachVideo });
+}
+
+async function mount(frameCallbacks = true) {
+  await act(async () => {
+    root = create(createElement(Surface), {
+      createNodeMock: (element) => {
+        if (element.type !== "video") return { tagName: "CANVAS", getContext: () => null };
+        video = new TestVideo();
+        if (!frameCallbacks) video.requestVideoFrameCallback = undefined;
+        return video;
+      },
+    });
+  });
+  await act(async () => {
+    expect(video.frame()).toBe(true);
+  });
+  expect(client.status).toBe("streaming");
+}
+
+async function visibility(hidden: boolean) {
+  await act(async () => {
+    doc.hidden = hidden;
+    doc.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    testWindow.advance(ms);
+  });
+}
+
+const keyframeRequests = () =>
+  TestSocket.instances
+    .flatMap((socket) => socket.messages)
+    .filter((message) => JSON.parse(message).type === "reset-video").length;
+
+describe("Android WebRTC playback after returning to the tab", () => {
+  test("resumes suspended playback and waits for a new frame without replacing the peer", async () => {
+    await mount();
+    const stream = video.srcObject;
+    const requests = keyframeRequests();
+    await visibility(true);
+    video.paused = true;
+    await visibility(false);
+
+    expect(video.paused).toBe(false);
+    expect(client.status).toBe("reconnecting");
+    expect(video.srcObject).toBe(stream);
+    await act(async () => {
+      expect(video.frame()).toBe(true);
+    });
+    expect(client.status).toBe("streaming");
+    await advance(5_000);
+    expect(keyframeRequests()).toBe(requests);
+    expect(TestPeer.instances).toHaveLength(1);
+  });
+
+  test("requests a keyframe for a stalled decoder, then reconnects if no frame arrives", async () => {
+    await mount();
+    const requests = keyframeRequests();
+    await visibility(true);
+    await visibility(false);
+    await advance(1_000);
+    expect(keyframeRequests()).toBe(requests + 1);
+    expect(TestPeer.instances).toHaveLength(1);
+    await advance(3_000);
+    expect(TestPeer.instances).toHaveLength(2);
+    expect(TestPeer.instances[0].connectionState).toBe("closed");
+    await act(async () => {
+      expect(video.frame()).toBe(true);
+    });
+    expect(client.status).toBe("streaming");
+  });
+
+  test("a frame after the keyframe request cancels the reconnect", async () => {
+    await mount();
+    await visibility(true);
+    await visibility(false);
+    await advance(1_000);
+    await act(async () => {
+      video.frame();
+    });
+    await advance(5_000);
+    expect(TestPeer.instances).toHaveLength(1);
+    expect(client.status).toBe("streaming");
+  });
+
+  test("cancels recovery while hidden and gives the next return a fresh deadline", async () => {
+    await mount();
+    const requests = keyframeRequests();
+    await visibility(true);
+    await visibility(false);
+    await advance(500);
+    await visibility(true);
+    await advance(60_000);
+    expect(keyframeRequests()).toBe(requests);
+    expect(TestPeer.instances).toHaveLength(1);
+    await visibility(false);
+    await advance(999);
+    expect(keyframeRequests()).toBe(requests);
+    await act(async () => {
+      video.frame();
+    });
+    await advance(5_000);
+    expect(TestPeer.instances).toHaveLength(1);
+  });
+
+  test("a rejected play attempt still recovers through a replacement stream", async () => {
+    await mount();
+    await visibility(true);
+    video.paused = true;
+    video.rejectPlay = true;
+    await visibility(false);
+    expect(client.status).toBe("reconnecting");
+    video.rejectPlay = false;
+    await advance(4_000);
+    expect(TestPeer.instances).toHaveLength(2);
+    await act(async () => {
+      expect(video.frame()).toBe(true);
+    });
+    expect(client.status).toBe("streaming");
+  });
+
+  test("a callback for the last presented frame does not satisfy recovery", async () => {
+    await mount();
+    await visibility(true);
+    await visibility(false);
+    await act(async () => {
+      video.frame(false);
+      video.dispatchEvent(new Event("loadeddata"));
+    });
+    expect(client.status).toBe("reconnecting");
+    await advance(4_000);
+    expect(TestPeer.instances).toHaveLength(2);
+  });
+
+  test("without frame callbacks, only advancing playback satisfies recovery", async () => {
+    await mount(false);
+    await visibility(true);
+    await visibility(false);
+    await act(async () => {
+      video.dispatchEvent(new Event("timeupdate"));
+      video.dispatchEvent(new Event("loadeddata"));
+    });
+    expect(client.status).toBe("reconnecting");
+    await act(async () => {
+      video.frame();
+    });
+    expect(client.status).toBe("streaming");
+    await advance(5_000);
+    expect(TestPeer.instances).toHaveLength(1);
+  });
+
+  test("device replacement cancels the previous stream recovery", async () => {
+    await mount();
+    await visibility(true);
+    await visibility(false);
+    await act(async () => {
+      root!.update(createElement(Surface, { device: "emulator-5556" }));
+    });
+    await act(async () => {
+      video.frame();
+    });
+    const peersAfterSwitch = TestPeer.instances.length;
+    await advance(5_000);
+    expect(TestPeer.instances).toHaveLength(peersAfterSwitch);
+    expect(TestPeer.instances[0].connectionState).toBe("closed");
+    expect(client.status).toBe("streaming");
+  });
+
+  test("unmount removes pending recovery and visibility listeners", async () => {
+    await mount();
+    await visibility(true);
+    await visibility(false);
+    await act(async () => {
+      root!.unmount();
+      root = null;
+    });
+    const calls = video.playCalls;
+    const requests = keyframeRequests();
+    await visibility(true);
+    await visibility(false);
+    await advance(60_000);
+    expect(video.playCalls).toBe(calls);
+    expect(keyframeRequests()).toBe(requests);
+    expect(TestPeer.instances).toHaveLength(1);
+    expect(testWindow.timers.size).toBe(0);
+    expect(video.callbacks.size).toBe(0);
+  });
+});

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -91,6 +91,8 @@ const EVENTS_POLL_MS = 1000;
 const STREAM_METADATA_POLL_MS = 1500;
 const STREAM_OPTIONS_POLL_MS = 3000;
 const DEVICE_SETTINGS_POLL_MS = 3000;
+const WEBRTC_RESUME_KEYFRAME_DELAY_MS = 1_000;
+const WEBRTC_RESUME_TIMEOUT_MS = 4_000;
 
 const ANDROID_DEVICE_SETTING_KEYS: readonly AndroidDeviceSettingKey[] = [
   'appearance',
@@ -810,6 +812,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     stream: webRtcStream,
     error: webRtcError,
     markFrameDecoded: markWebRtcFrameDecoded,
+    reconnect: reconnectWebRtcStream,
     streamStats,
     setStreamStatsEnabled,
   } = useWebRtcStream({
@@ -900,9 +903,54 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     let fpsCount = 0;
     let fpsStartedAt = performance.now();
     let previousPresentedFrames: number | null = null;
+    let previousCurrentTime = video.currentTime;
+    let resuming = false;
+    let wasHidden = document.hidden;
+    let keyframeTimer: number | undefined;
+    let resumeTimer: number | undefined;
+
+    const clearResumeTimers = () => {
+      if (keyframeTimer !== undefined) window.clearTimeout(keyframeTimer);
+      if (resumeTimer !== undefined) window.clearTimeout(resumeTimer);
+      keyframeTimer = undefined;
+      resumeTimer = undefined;
+    };
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        wasHidden = true;
+        clearResumeTimers();
+        return;
+      }
+      if (stopped || !wasHidden) return;
+      wasHidden = false;
+      resuming = true;
+      firstFrame = true;
+      previousCurrentTime = video.currentTime;
+      fpsCount = 0;
+      fpsStartedAt = performance.now();
+      setWebRtcVideoReady(false);
+      setFps(0);
+      void video.play().catch(() => {});
+      // A healthy player resumes without disturbing its peer or encoder. Give
+      // it a moment, then request a keyframe; replace the session only if fresh
+      // frames still do not arrive. Hidden time never consumes this deadline.
+      keyframeTimer = window.setTimeout(requestWebRtcKeyframe, WEBRTC_RESUME_KEYFRAME_DELAY_MS);
+      resumeTimer = window.setTimeout(() => {
+        clearResumeTimers();
+        reconnectWebRtcStream();
+      }, WEBRTC_RESUME_TIMEOUT_MS);
+    };
 
     const markFrame = (presentedFrameDelta = 1) => {
       if (stopped) return;
+      // loadeddata can describe a buffered old frame. Foreground recovery
+      // requires actual presentation progress, not just media readiness.
+      if (resuming && (document.hidden || presentedFrameDelta === 0)) return;
+      if (resuming) {
+        resuming = false;
+        clearResumeTimers();
+      }
       if (video.videoWidth > 0 && video.videoHeight > 0) {
         const width = video.videoWidth;
         const height = video.videoHeight;
@@ -925,10 +973,10 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       }
     };
     const onVideoFrame: VideoFrameRequestCallback = (_now, metadata) => {
-      const presentedFrameDelta = presentedVideoFrameDelta(
-        previousPresentedFrames,
-        metadata.presentedFrames,
-      );
+      const presentedFrameDelta =
+        resuming && metadata.presentedFrames === previousPresentedFrames
+          ? 0
+          : presentedVideoFrameDelta(previousPresentedFrames, metadata.presentedFrames);
       if (
         Number.isSafeInteger(metadata.presentedFrames) &&
         metadata.presentedFrames >= 0
@@ -938,7 +986,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       markFrame(presentedFrameDelta);
       frameCallback = video.requestVideoFrameCallback(onVideoFrame);
     };
-    const onTimeUpdate = () => markFrame();
+    const onTimeUpdate = () => {
+      if (video.paused || video.currentTime === previousCurrentTime) return;
+      previousCurrentTime = video.currentTime;
+      markFrame();
+    };
     const onLoadedData = () => markFrame(0);
 
     video.srcObject = webRtcStream;
@@ -949,10 +1001,13 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       video.addEventListener('timeupdate', onTimeUpdate);
     }
     video.addEventListener('loadeddata', onLoadedData, { once: true });
+    document.addEventListener('visibilitychange', onVisibilityChange);
     void video.play().catch(() => {});
 
     return () => {
       stopped = true;
+      clearResumeTimers();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       video.removeEventListener('loadeddata', onLoadedData);
       video.removeEventListener('timeupdate', onTimeUpdate);
       if (frameCallback && typeof video.cancelVideoFrameCallback === 'function') {
@@ -961,7 +1016,14 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       setWebRtcVideoReady(false);
       setFps(0);
     };
-  }, [useWebRtc, webRtcStream, webRtcVideoElement, markWebRtcFrameDecoded]);
+  }, [
+    useWebRtc,
+    webRtcStream,
+    webRtcVideoElement,
+    markWebRtcFrameDecoded,
+    reconnectWebRtcStream,
+    requestWebRtcKeyframe,
+  ]);
 
   // Detach the media only when this surface stops showing WebRTC or moves to
   // another device; a lost stream alone keeps its last frame (see above).

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -137,6 +137,9 @@ export function useWebRtcStream({
   const [statsConnection, setStatsConnection] = useState<WebRtcStatsConnection | null>(null);
   const [streamStatsEnabled, setStreamStatsEnabled] = useState(false);
   const [retryGeneration, setRetryGeneration] = useState(0);
+  // Playback can stall while ICE still reports a connected peer. Let the
+  // renderer request a fresh session after its foreground recovery times out.
+  const reconnect = useCallback(() => setRetryGeneration((generation) => generation + 1), []);
   const firstFrameTimeoutRef = useRef<number | undefined>(undefined);
   const firstFrameDecodedRef = useRef(false);
   const presentedFramesRef = useRef(0);
@@ -448,5 +451,5 @@ export function useWebRtcStream({
     retryGeneration,
   ]);
 
-  return { stream, failure, error, markFrameDecoded, streamStats, setStreamStatsEnabled };
+  return { stream, failure, error, markFrameDecoded, reconnect, streamStats, setStreamStatsEnabled };
 }


### PR DESCRIPTION
Android WebRTC video could remain paused after returning to a backgrounded tab while Hub still reported `streaming`. Playback was started only when attaching the stream, and readiness stayed true after the first frame.

Retry playback when the tab becomes visible and require a fresh frame before restoring readiness. If frames do not resume, request a keyframe after one second and reconnect after four seconds. Cancel recovery timers while hidden and when the device, stream, or video element changes. Healthy streams retain their peer and do not request a keyframe.

Validation:

- Added nine regression tests exercising the real Android hook with simulated browser/media APIs, covering paused and stalled playback, rejected play requests, stale frame callbacks, the timeupdate fallback, repeated visibility changes, device replacement, and unmount cleanup.
- All 162 `@expo/hub-client` tests pass; type checking, lint, and package build pass.
- The original suspension reproduction now resumes with the same peer. Visibility-only and connection-replacement controls also pass.
- Added an `expo-device-hub` patch changeset and verified it.

Browser-level confirmation is still pending: the original user's browser tab was unavailable, so media suspension and frame delivery were simulated. This change targets the Android WebRTC path.
