### PR TITLE
Fix rotation and touch alignment for gRPC screens

### DIFF
--- a/.changeset/fix-grpc-screen-rotation.md
+++ b/.changeset/fix-grpc-screen-rotation.md
@@ -2,4 +2,4 @@
 "expo-device-hub": patch
 ---
 
-Fix gRPC screen rotation and keep touch input aligned with rotated emulator frames.
+Fix gRPC screen rotation and keep touch input aligned with rotated emulator frames, including apps that keep their display portrait while the emulator rotates.

--- a/.changeset/fix-grpc-screen-rotation.md
+++ b/.changeset/fix-grpc-screen-rotation.md
@@ -1,0 +1,5 @@
+---
+"expo-device-hub": patch
+---
+
+Fix gRPC screen rotation and keep touch input aligned with rotated emulator frames.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -395,6 +395,10 @@ not keep receiving and discarding device output.
 On emulators, selecting portrait or landscape updates both Android's rotation
 lock and the simulated accelerometer, keeping gRPC screenshots upright. Selecting
 auto releases the Android lock and preserves the current simulated orientation.
+When an app keeps its display portrait (such as the launcher), gRPC video can
+still turn sideways. Scrcpy touch input uses Android's active display rotation
+to stay aligned with that content. The mapping refreshes at each gesture's start
+and remains fixed throughout a drag, including additional pointers.
 
 ```sh
 curl "$BASE/api/orientation"

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -392,6 +392,10 @@ not keep receiving and discarding device output.
 
 ### Device Settings
 
+On emulators, selecting portrait or landscape updates both Android's rotation
+lock and the simulated accelerometer, keeping gRPC screenshots upright. Selecting
+auto releases the Android lock and preserves the current simulated orientation.
+
 ```sh
 curl "$BASE/api/orientation"
 curl -X POST "$BASE/api/orientation" \

--- a/packages/serve-emu/packages/serve-emu/CHANGELOG.md
+++ b/packages/serve-emu/packages/serve-emu/CHANGELOG.md
@@ -12,6 +12,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
 
 - Add strict host hardware H.264 encoding for Android gRPC streaming with `--encoder hardware` and an Encoder control in the standalone UI. Software remains the default; stream-mode and health APIs report the active backend and hardware probe failures.
 
+### Fixed
+
+- Synchronize emulator rotation controls with the simulated orientation used by
+  gRPC PNG and MMAP screenshots, and align gRPC touch input with rotated frames.
+
 ### Added
 
 - Add emulator-only gRPC screenshot streaming with host-side H.264 encoding,

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -397,6 +397,10 @@ not keep receiving and discarding device output.
 On emulators, selecting portrait or landscape updates both Android's rotation
 lock and the simulated accelerometer, keeping gRPC screenshots upright. Selecting
 auto releases the Android lock and preserves the current simulated orientation.
+When an app keeps its display portrait (such as the launcher), gRPC video can
+still turn sideways. Scrcpy touch input uses Android's active display rotation
+to stay aligned with that content. The mapping refreshes at each gesture's start
+and remains fixed throughout a drag, including additional pointers.
 
 ```sh
 curl "$BASE/api/orientation"

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -394,6 +394,10 @@ not keep receiving and discarding device output.
 
 ### Device Settings
 
+On emulators, selecting portrait or landscape updates both Android's rotation
+lock and the simulated accelerometer, keeping gRPC screenshots upright. Selecting
+auto releases the Android lock and preserves the current simulated orientation.
+
 ```sh
 curl "$BASE/api/orientation"
 curl -X POST "$BASE/api/orientation" \

--- a/packages/serve-emu/packages/serve-emu/src/adb.ts
+++ b/packages/serve-emu/packages/serve-emu/src/adb.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { isEmulatorSerial } from "./device-capabilities.ts";
 import { execBuffer, execText, type ExecResult } from "./exec.ts";
 
 const ADB_QUERY_TIMEOUT_MS = 2_000;
@@ -264,6 +265,24 @@ export async function setUserRotation(
     throw new Error(
       `adb shell ${args.join(" ")} failed: ${execFailure(r)}`,
     );
+  }
+  if (isEmulatorSerial(serial) && orientation !== "auto") {
+    // gRPC screenshots follow the emulator's accelerometer, independently of
+    // Android's user-rotation lock. Keep both in the same orientation so the
+    // streamed image is upright and its dimensions follow the Rotate control.
+    const acceleration = orientation === "portrait" ? "0:9.8:0" : "9.8:0:0";
+    const sensor = await runExec(
+      "adb",
+      ["-s", serial, "emu", "sensor", "set", "acceleration", acceleration],
+      { timeout: ADB_MUTATION_TIMEOUT_MS },
+    );
+    // The emulator console can report KO while adb exits successfully.
+    const output = `${sensor.stdout}\n${sensor.stderr}`.trim();
+    if (execFailed(sensor) || /^KO\b/m.test(output)) {
+      throw new Error(
+        `adb emu sensor set acceleration failed: ${execFailure(sensor)}`,
+      );
+    }
   }
   return getUserRotation(serial, runExec);
 }

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises";
+import { getDisplayRotation, type DisplayRotation } from "./adb.ts";
 import {
   ControlInputQueue,
   ControlInputRejectedError,
@@ -41,6 +42,7 @@ import {
   compileGesture,
   normalizeTextForControl,
   type Gesture,
+  type Screen,
 } from "./input.ts";
 import {
   SCRCPY_DEFAULTS,
@@ -976,6 +978,28 @@ function createGrpcImageCaptureTransport(options: {
   };
 }
 
+function rotateUnitTouch(x: number, y: number, rotation: number) {
+  if (rotation === 1) return { x: 1 - y, y: x };
+  if (rotation === 2) return { x: 1 - x, y: 1 - y };
+  if (rotation === 3) return { x: y, y: 1 - x };
+  return { x, y };
+}
+
+function rotateScrcpyGesture(gesture: Gesture, rotation: number): Gesture {
+  switch (gesture.type) {
+    case "tap":
+    case "touch":
+      return { ...gesture, ...rotateUnitTouch(gesture.x, gesture.y, rotation) };
+    case "swipe": {
+      const start = rotateUnitTouch(gesture.x1, gesture.y1, rotation);
+      const end = rotateUnitTouch(gesture.x2, gesture.y2, rotation);
+      return { ...gesture, x1: start.x, y1: start.y, x2: end.x, y2: end.y };
+    }
+    default:
+      return gesture;
+  }
+}
+
 export type GrpcDisplayGeometry = {
   encodedSize: { width: number; height: number };
   touchSize: { width: number; height: number };
@@ -1008,12 +1032,10 @@ export function resolveGrpcDisplayGeometry(options: {
     mapTouch(unitX, unitY) {
       // Screenshots are oriented, but sendTouch injects coordinates into the
       // unrotated framebuffer. Undo the image rotation before scaling.
-      if (rotation === 1) [unitX, unitY] = [1 - unitY, unitX];
-      else if (rotation === 2) [unitX, unitY] = [1 - unitX, 1 - unitY];
-      else if (rotation === 3) [unitX, unitY] = [unitY, 1 - unitX];
+      const point = rotateUnitTouch(unitX, unitY, rotation);
       return {
-        x: toPixel(unitX, touchSize.width),
-        y: toPixel(unitY, touchSize.height),
+        x: toPixel(point.x, touchSize.width),
+        y: toPixel(point.y, touchSize.height),
       };
     },
   };
@@ -1319,6 +1341,10 @@ export type GrpcSessionDependencies = {
     serial: string,
     signal: AbortSignal,
   ) => Promise<string>;
+  readDisplayRotation?: (
+    serial: string,
+    signal: AbortSignal,
+  ) => Promise<DisplayRotation>;
   startScrcpyControl?: typeof startScrcpyControl;
   runtime?: Partial<GrpcSessionRuntime>;
 };
@@ -2245,12 +2271,50 @@ export async function startGrpcSession(
 
   const createScrcpyControls = (session: ScrcpyControlSession) => {
     const writer = new SocketControlWriter(session.controlSocket);
+    const readRotation = dependencies.readDisplayRotation ??
+      ((serial: string, signal: AbortSignal) => getDisplayRotation(serial, undefined, signal));
+    const pointers = new Set<number>();
+    let touchGeometry: { rotation: number; screen: Screen } | null = null;
+    const readGeometry = async (signal: AbortSignal) => {
+      const displayRotation = await readRotation(serial, signal).catch((cause: unknown) => {
+        throw new ControlInputRejectedError("Could not determine Android display rotation", { cause });
+      });
+      throwIfAborted(signal, "touch geometry refresh aborted");
+      // The launcher can stay portrait while gRPC rotates its screenshot.
+      // scrcpy expects coordinates and dimensions in Android's display space.
+      const rotation = ((latest?.rotation ?? 0) - displayRotation + 4) % 4;
+      const sideways = rotation === 1 || rotation === 3;
+      return {
+        rotation,
+        screen: sideways
+          ? { width: nativeTouchSize.height, height: nativeTouchSize.width }
+          : { ...nativeTouchSize },
+      };
+    };
     return new ControlInputQueue({
       dispatcher: {
         async dispatchGesture(gesture, _screen, signal) {
-          // With scrcpy video disabled, touch coordinates must target the native
-          // display directly rather than the downscaled gRPC encoder output.
-          for (const step of compileGesture(gesture, nativeTouchSize).steps) {
+          let screen = nativeTouchSize;
+          let mapped = gesture;
+          if (gesture.type === "tap" || gesture.type === "swipe") {
+            const geometry = await readGeometry(signal);
+            screen = geometry.screen;
+            mapped = rotateScrcpyGesture(gesture, geometry.rotation);
+          } else if (gesture.type === "touch") {
+            const pointerId = gesture.pointerId ?? 0;
+            // A failed down must not leave subsequent moves using stale geometry.
+            if (gesture.action !== "down" && !pointers.has(pointerId)) return;
+            // Refresh for each new gesture, even when video geometry is unchanged.
+            // Keep all pointers in a drag on one mapping without querying ADB on moves.
+            if (!touchGeometry || (gesture.action === "down" && pointers.size === 0)) {
+              touchGeometry = await readGeometry(signal);
+            }
+            screen = touchGeometry.screen;
+            mapped = rotateScrcpyGesture(gesture, touchGeometry.rotation);
+            if (gesture.action === "down") pointers.add(pointerId);
+            else if (gesture.action === "up") pointers.delete(pointerId);
+          }
+          for (const step of compileGesture(mapped, screen).steps) {
             if (step.delayMs > 0) {
               await runtime.sleep(step.delayMs, signal);
             }
@@ -2259,6 +2323,8 @@ export async function startGrpcSession(
         },
         resetVideo: resetGrpcVideo,
         close(reason) {
+          pointers.clear();
+          touchGeometry = null;
           writer.close(reason);
         },
       },

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -987,13 +987,16 @@ export function resolveGrpcDisplayGeometry(options: {
   inputHeight: number;
   nativeWidth: number;
   nativeHeight: number;
+  rotation?: number;
 }): GrpcDisplayGeometry {
   const croppedWidth = options.inputWidth - (options.inputWidth % 2);
   const croppedHeight = options.inputHeight - (options.inputHeight % 2);
   const encodedSize = { width: croppedWidth, height: croppedHeight };
+  const rotation = options.rotation ?? 0;
+  const swappedAxes = rotation === 1 || rotation === 3;
   const touchSize = {
-    width: options.nativeWidth,
-    height: options.nativeHeight,
+    width: swappedAxes ? options.nativeHeight : options.nativeWidth,
+    height: swappedAxes ? options.nativeWidth : options.nativeHeight,
   };
 
   const toPixel = (unit: number, size: number) =>
@@ -1003,8 +1006,11 @@ export function resolveGrpcDisplayGeometry(options: {
     encodedSize,
     touchSize,
     mapTouch(unitX, unitY) {
-      // Emulator screenshots are already oriented and touch coordinates use
-      // that same physical top-left coordinate space.
+      // Screenshots are oriented, but sendTouch injects coordinates into the
+      // unrotated framebuffer. Undo the image rotation before scaling.
+      if (rotation === 1) [unitX, unitY] = [1 - unitY, unitX];
+      else if (rotation === 2) [unitX, unitY] = [1 - unitX, 1 - unitY];
+      else if (rotation === 3) [unitX, unitY] = [unitY, 1 - unitX];
       return {
         x: toPixel(unitX, touchSize.width),
         y: toPixel(unitY, touchSize.height),
@@ -1915,6 +1921,7 @@ export async function startGrpcSession(
       inputHeight: image.height,
       nativeWidth: nativeTouchSize.width,
       nativeHeight: nativeTouchSize.height,
+      rotation: image.rotation,
     });
   };
   encoderLifecycle = new GrpcEncoderLifecycle<GrpcSessionEncoder>((restart) => {

--- a/packages/serve-emu/packages/serve-emu/tests/adb-device-controls.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/adb-device-controls.test.ts
@@ -300,6 +300,122 @@ describe("ADB display controls", () => {
     }
   });
 
+  for (const entry of [
+    { requested: "portrait", rotation: "0", acceleration: "0:9.8:0" },
+    { requested: "landscape", rotation: "1", acceleration: "9.8:0:0" },
+  ] as const) {
+    test(`synchronizes the emulator sensor after locking ${entry.requested} rotation`, async () => {
+      const calls: Array<{ command: string; args: string[]; timeout?: number }> = [];
+      const runExec = (async (command, args, options) => {
+        calls.push({ command, args, timeout: options?.timeout });
+        if (args[2] === "emu") return result("OK\n");
+        return result(args.at(-1) === "user-rotation" ? `lock ${entry.rotation}\n` : "");
+      }) as typeof execText;
+
+      await expect(
+        setUserRotation("emulator-5554", entry.requested, runExec),
+      ).resolves.toEqual({
+        mode: "lock",
+        rotation: Number(entry.rotation),
+        orientation: entry.requested,
+        raw: `lock ${entry.rotation}`,
+      });
+      expect(calls).toEqual([
+        {
+          command: "adb",
+          args: ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation", "lock", entry.rotation],
+          timeout: 5_000,
+        },
+        {
+          command: "adb",
+          args: ["-s", "emulator-5554", "emu", "sensor", "set", "acceleration", entry.acceleration],
+          timeout: 5_000,
+        },
+        {
+          command: "adb",
+          args: ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation"],
+          timeout: 2_000,
+        },
+      ]);
+    });
+  }
+
+  test("leaves the emulator sensor pose unchanged when enabling auto rotation", async () => {
+    const calls: string[][] = [];
+    const runExec = (async (_command, args) => {
+      calls.push(args);
+      return result(args.at(-1) === "user-rotation" ? "free 1\n" : "");
+    }) as typeof execText;
+
+    await expect(
+      setUserRotation("emulator-5554", "auto", runExec),
+    ).resolves.toEqual({ mode: "free", rotation: 1, orientation: "auto", raw: "free 1" });
+    expect(calls).toEqual([
+      ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation", "free"],
+      ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation"],
+    ]);
+  });
+
+  for (const entry of [
+    {
+      name: "console KO output with a successful process exit",
+      value: result("KO: unknown sensor: acceleration\n"),
+      detail: "KO: unknown sensor: acceleration",
+    },
+    {
+      name: "console KO diagnostic on stderr",
+      value: result("", { stderr: "KO: sensor is disabled\n" }),
+      detail: "KO: sensor is disabled",
+    },
+    {
+      name: "nonzero process exit",
+      value: result("", { status: 1, stderr: "console connection refused" }),
+      detail: "console connection refused",
+    },
+    {
+      name: "process execution error",
+      value: result("", { status: null, error: new Error("spawn ENOENT") }),
+      detail: "spawn ENOENT",
+    },
+    {
+      name: "process error despite a successful exit status",
+      value: result("", { error: new Error("emulator console interrupted") }),
+      detail: "emulator console interrupted",
+    },
+  ]) {
+    test(`rejects emulator rotation on ${entry.name}`, async () => {
+      const calls: string[][] = [];
+      const runExec = (async (_command, args) => {
+        calls.push(args);
+        if (args[2] === "emu") return entry.value;
+        return result(args.at(-1) === "user-rotation" ? "lock 1\n" : "");
+      }) as typeof execText;
+
+      await expect(
+        setUserRotation("emulator-5554", "landscape", runExec),
+      ).rejects.toThrow(entry.detail);
+      expect(calls).toEqual([
+        ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation", "lock", "1"],
+        ["-s", "emulator-5554", "emu", "sensor", "set", "acceleration", "9.8:0:0"],
+      ]);
+    });
+  }
+
+  test("does not change emulator sensors when the guest rotation lock fails", async () => {
+    const calls: string[][] = [];
+    const runExec = (async (_command, args) => {
+      calls.push(args);
+      return result("", { status: 1, stderr: "rotation denied" });
+    }) as typeof execText;
+
+    await expect(
+      setUserRotation("emulator-5554", "landscape", runExec),
+    ).rejects.toThrow("rotation denied");
+    expect(calls).toEqual([
+      ["-s", "emulator-5554", "shell", "cmd", "window", "user-rotation", "lock", "1"],
+    ]);
+  });
+
   test("reports rotation command failures", async () => {
     const failed = (async () =>
       result("", { status: 1, stderr: "rotation denied" })) as typeof execText;

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -36,7 +36,7 @@ import {
   type KeyboardEventRequest,
 } from "../src/emulator-grpc.ts";
 import type { H264EncoderOpts, QuarterTurn } from "../src/h264-encoder.ts";
-import { compileGesture, parseGesture } from "../src/input.ts";
+import { compileGesture, parseGesture, type Gesture, type Screen } from "../src/input.ts";
 import type {
   ScrcpyControlSession,
   VideoFrame,
@@ -1183,6 +1183,33 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   throw new Error("condition was not reached");
 }
 
+function scrcpyControlFixture() {
+  const packets: Buffer[] = [];
+  let controlCloseCalls = 0;
+  const controlSocket = Object.assign(new EventEmitter(), {
+    destroyed: false,
+    writable: true,
+    write(packet: Buffer, callback: (error?: Error | null) => void) {
+      packets.push(Buffer.from(packet));
+      callback();
+      return true;
+    },
+  });
+  const controlProcess = new EventEmitter();
+  const controlSession = {
+    transport: "scrcpy-control",
+    serial: "emulator-5554",
+    scid: "00000001",
+    localPort: 27_183,
+    controlSocket,
+    proc: controlProcess,
+    async close() {
+      controlCloseCalls++;
+    },
+  } as unknown as ScrcpyControlSession;
+  return { controlSession, packets, get closeCalls() { return controlCloseCalls; } };
+}
+
 describe("startGrpcSession integration", () => {
   test("consumes buffered RGB frames during encoder backpressure and submits the newest", async () => {
     const width = 540, height = 1170, count = 8;
@@ -1873,43 +1900,26 @@ describe("startGrpcSession integration", () => {
   );
 
   test.each([
-    { rotation: 0, width: 4, height: 6 },
-    { rotation: 1, width: 6, height: 4 },
-    { rotation: 2, width: 4, height: 6 },
-    { rotation: 3, width: 6, height: 4 },
+    { rotation: 0, displayRotation: 0, width: 4, height: 6, x: 0.25, y: 0.5, touchWidth: 4, touchHeight: 6 },
+    { rotation: 1, displayRotation: 1, width: 6, height: 4, x: 0.25, y: 0.5, touchWidth: 6, touchHeight: 4 },
+    { rotation: 2, displayRotation: 2, width: 4, height: 6, x: 0.25, y: 0.5, touchWidth: 4, touchHeight: 6 },
+    { rotation: 3, displayRotation: 3, width: 6, height: 4, x: 0.25, y: 0.5, touchWidth: 6, touchHeight: 4 },
+    { rotation: 1, displayRotation: 0, width: 6, height: 4, x: 0.5, y: 0.25, touchWidth: 4, touchHeight: 6 },
+    { rotation: 3, displayRotation: 0, width: 6, height: 4, x: 0.5, y: 0.75, touchWidth: 4, touchHeight: 6 },
+    { rotation: 2, displayRotation: 0, width: 4, height: 6, x: 0.75, y: 0.5, touchWidth: 4, touchHeight: 6 },
+    { rotation: 0, displayRotation: 1, width: 4, height: 6, x: 0.5, y: 0.75, touchWidth: 6, touchHeight: 4 },
   ])(
-    "keeps scrcpy touch coordinates oriented at rotation $rotation",
-    async ({ rotation, width, height }) => {
+    "maps scrcpy touches from image rotation $rotation to display rotation $displayRotation",
+    async ({ rotation, displayRotation, width, height, x, y, touchWidth, touchHeight }) => {
       const client = new FakeGrpcClient(integrationImage(rotation, width, height));
       const encoders: FakeGrpcEncoder[] = [];
-      const packets: Buffer[] = [];
-      let controlCloseCalls = 0;
       let probeStarted = false;
       client.getScreenshot = async () => {
         probeStarted = true;
         return client.probe;
       };
-      const controlSocket = Object.assign(new EventEmitter(), {
-        destroyed: false,
-        writable: true,
-        write(packet: Buffer, callback: (error?: Error | null) => void) {
-          packets.push(Buffer.from(packet));
-          callback();
-          return true;
-        },
-      });
-      const controlProcess = new EventEmitter();
-      const controlSession = {
-        transport: "scrcpy-control",
-        serial: "emulator-5554",
-        scid: "00000001",
-        localPort: 27_183,
-        controlSocket,
-        proc: controlProcess,
-        async close() {
-          controlCloseCalls++;
-        },
-      } as unknown as ScrcpyControlSession;
+      const fixture = scrcpyControlFixture();
+      const { controlSession, packets } = fixture;
       let resolveControl!: (session: ScrcpyControlSession) => void;
       const controlReady = new Promise<ScrcpyControlSession>((resolve) => {
         resolveControl = resolve;
@@ -1925,10 +1935,11 @@ describe("startGrpcSession integration", () => {
           readDisplaySizeSignal: async () => "physical:4x6",
           runtime: integrationRuntime(client, encoders),
           startScrcpyControl: () => controlReady,
+          readDisplayRotation: async () => displayRotation as QuarterTurn,
         },
       );
       await waitFor(() => probeStarted);
-      expect(controlCloseCalls).toBe(0);
+      expect(fixture.closeCalls).toBe(0);
       resolveControl(controlSession);
       const session = await starting;
 
@@ -1937,16 +1948,88 @@ describe("startGrpcSession integration", () => {
 
       expect(session.inputSource).toBe("scrcpy");
       expect(packets).toEqual(
-        compileGesture(gesture, { width, height }).steps.map(
+        compileGesture({ ...gesture, x, y }, { width: touchWidth, height: touchHeight }).steps.map(
           (step) => step.packet,
         ),
       );
       expect(client.keys).toEqual([]);
       expect(client.touches).toEqual([]);
       await session.close();
-      expect(controlCloseCalls).toBe(1);
+      expect(fixture.closeCalls).toBe(1);
     },
   );
+
+  test("refreshes scrcpy mapping between apps without a video resize and holds it through multi-touch", async () => {
+    const client = new FakeGrpcClient(integrationImage(1, 600, 400));
+    const fixture = scrcpyControlFixture();
+    let displayRotation: QuarterTurn = 1;
+    let reads = 0;
+    let failRead = false;
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "png", inputSource: "scrcpy" },
+      {
+        readDisplaySizeSignal: async () => "physical:400x600",
+        runtime: integrationRuntime(client, []),
+        startScrcpyControl: async () => fixture.controlSession,
+        readDisplayRotation: async () => {
+          reads++;
+          if (failRead) throw new Error("ADB unavailable");
+          return displayRotation;
+        },
+      },
+    );
+    const videoScreen = { width: 600, height: 400 };
+    const portraitScreen = { width: 400, height: 600 };
+    const send = async (gesture: Gesture, expected: Gesture = gesture, screen: Screen = videoScreen) => {
+      fixture.packets.length = 0;
+      await session.controls.enqueue(gesture, videoScreen).completion;
+      expect(fixture.packets).toEqual(compileGesture(expected, screen).steps.map((step) => step.packet));
+    };
+    try {
+      await send({ type: "home" });
+      expect(reads).toBe(0);
+      const tap = { type: "tap", x: 0.25, y: 0.5 } as const;
+      await send(tap);
+      displayRotation = 0;
+      await send(tap, { ...tap, x: 0.5, y: 0.25 }, portraitScreen);
+      expect(reads).toBe(2);
+
+      const down = { type: "touch", action: "down", x: 0.25, y: 0.5 } as const;
+      await send(down, { ...down, x: 0.5, y: 0.25 }, portraitScreen);
+      displayRotation = 1;
+      const second = { ...down, pointerId: 1 };
+      await send(second, { ...second, x: 0.5, y: 0.25 }, portraitScreen);
+      const move = { ...down, action: "move", x: 0.75 } as const;
+      await send(move, { ...move, x: 0.5, y: 0.75 }, portraitScreen);
+      for (const pointerId of [0, 1]) {
+        const up = { ...down, action: "up", pointerId } as const;
+        await send(up, { ...up, x: 0.5, y: 0.25 }, portraitScreen);
+      }
+      expect(reads).toBe(3);
+      await send(down);
+      await send({ ...down, action: "up" });
+      expect(reads).toBe(4);
+
+      displayRotation = 0;
+      const swipe = { type: "swipe", x1: 0.1, y1: 0.5, x2: 0.8, y2: 0.25, durationMs: 100 } as const;
+      await send(swipe, { ...swipe, x1: 0.5, y1: 0.1, x2: 0.75, y2: 0.8 }, portraitScreen);
+      expect(reads).toBe(5);
+
+      failRead = true;
+      fixture.packets.length = 0;
+      await expect(session.controls.enqueue(down, videoScreen).completion).rejects.toThrow("Could not determine Android display rotation");
+      await session.controls.enqueue(move, videoScreen).completion;
+      await session.controls.enqueue({ ...down, action: "up" }, videoScreen).completion;
+      expect(fixture.packets).toEqual([]);
+      await send({ type: "back" });
+      failRead = false;
+      displayRotation = 1;
+      await send(tap);
+      expect(reads).toBe(7);
+    } finally {
+      await session.close();
+    }
+  });
 
   test("starts, routes hardware controls through gRPC keys, and closes resources", async () => {
     const client = new FakeGrpcClient(integrationImage());

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -286,7 +286,7 @@ describe("gRPC screenshot session helpers", () => {
     expect(readCalls).toBe(0);
   });
 
-  test("uses the oriented screenshot dimensions and touch coordinate space", () => {
+  test("crops the encoded image and scales portrait touches to native pixels", () => {
     const geometry = resolveGrpcDisplayGeometry({
       inputWidth: 289,
       inputHeight: 641,
@@ -1836,72 +1836,117 @@ describe("startGrpcSession integration", () => {
     }
   });
 
-  test("routes controls through a control-only scrcpy session", async () => {
-    const client = new FakeGrpcClient(integrationImage());
-    const encoders: FakeGrpcEncoder[] = [];
-    const packets: Buffer[] = [];
-    let controlCloseCalls = 0;
-    let probeStarted = false;
-    client.getScreenshot = async () => {
-      probeStarted = true;
-      return client.probe;
-    };
-    const controlSocket = Object.assign(new EventEmitter(), {
-      destroyed: false,
-      writable: true,
-      write(packet: Buffer, callback: (error?: Error | null) => void) {
-        packets.push(Buffer.from(packet));
-        callback();
-        return true;
-      },
-    });
-    const controlProcess = new EventEmitter();
-    const controlSession = {
-      transport: "scrcpy-control",
-      serial: "emulator-5554",
-      scid: "00000001",
-      localPort: 27_183,
-      controlSocket,
-      proc: controlProcess,
-      async close() {
-        controlCloseCalls++;
-      },
-    } as unknown as ScrcpyControlSession;
-    let resolveControl!: (session: ScrcpyControlSession) => void;
-    const controlReady = new Promise<ScrcpyControlSession>((resolve) => {
-      resolveControl = resolve;
-    });
-    const starting = startGrpcSession(
-      {
+  test.each([
+    { rotation: 0, width: 100, height: 200, x: 20, y: 120 },
+    { rotation: 1, width: 200, height: 100, x: 40, y: 40 },
+    { rotation: 2, width: 100, height: 200, x: 80, y: 80 },
+    { rotation: 3, width: 200, height: 100, x: 60, y: 160 },
+  ])(
+    "maps a gRPC touch at rotation $rotation back to the unrotated framebuffer",
+    async ({ rotation, width, height, x, y }) => {
+      const client = new FakeGrpcClient(integrationImage(rotation, width, height));
+      const session = await startGrpcSession(
+        {
+          serial: "emulator-5554",
+          mode: "grpc-screenshot",
+          grpcImageMode: "png",
+          inputSource: "grpc",
+        },
+        {
+          readDisplaySizeSignal: async () => "physical:100x200",
+          runtime: integrationRuntime(client, []),
+        },
+      );
+      try {
+        await session.controls.enqueue(
+          { type: "tap", x: 0.2, y: 0.6 },
+          { width, height },
+        ).completion;
+        expect(client.touches).toEqual([
+          [{ x, y, identifier: 0, pressure: 1 }],
+          [{ x, y, identifier: 0, pressure: 0 }],
+        ]);
+      } finally {
+        await session.close();
+      }
+    },
+  );
+
+  test.each([
+    { rotation: 0, width: 4, height: 6 },
+    { rotation: 1, width: 6, height: 4 },
+    { rotation: 2, width: 4, height: 6 },
+    { rotation: 3, width: 6, height: 4 },
+  ])(
+    "keeps scrcpy touch coordinates oriented at rotation $rotation",
+    async ({ rotation, width, height }) => {
+      const client = new FakeGrpcClient(integrationImage(rotation, width, height));
+      const encoders: FakeGrpcEncoder[] = [];
+      const packets: Buffer[] = [];
+      let controlCloseCalls = 0;
+      let probeStarted = false;
+      client.getScreenshot = async () => {
+        probeStarted = true;
+        return client.probe;
+      };
+      const controlSocket = Object.assign(new EventEmitter(), {
+        destroyed: false,
+        writable: true,
+        write(packet: Buffer, callback: (error?: Error | null) => void) {
+          packets.push(Buffer.from(packet));
+          callback();
+          return true;
+        },
+      });
+      const controlProcess = new EventEmitter();
+      const controlSession = {
+        transport: "scrcpy-control",
         serial: "emulator-5554",
-        mode: "grpc-screenshot",
-        grpcImageMode: "png",
-        inputSource: "scrcpy",
-      },
-      {
-        readDisplaySizeSignal: async () => "physical:4x6",
-        runtime: integrationRuntime(client, encoders),
-        startScrcpyControl: () => controlReady,
-      },
-    );
-    await waitFor(() => probeStarted);
-    expect(controlCloseCalls).toBe(0);
-    resolveControl(controlSession);
-    const session = await starting;
+        scid: "00000001",
+        localPort: 27_183,
+        controlSocket,
+        proc: controlProcess,
+        async close() {
+          controlCloseCalls++;
+        },
+      } as unknown as ScrcpyControlSession;
+      let resolveControl!: (session: ScrcpyControlSession) => void;
+      const controlReady = new Promise<ScrcpyControlSession>((resolve) => {
+        resolveControl = resolve;
+      });
+      const starting = startGrpcSession(
+        {
+          serial: "emulator-5554",
+          mode: "grpc-screenshot",
+          grpcImageMode: "png",
+          inputSource: "scrcpy",
+        },
+        {
+          readDisplaySizeSignal: async () => "physical:4x6",
+          runtime: integrationRuntime(client, encoders),
+          startScrcpyControl: () => controlReady,
+        },
+      );
+      await waitFor(() => probeStarted);
+      expect(controlCloseCalls).toBe(0);
+      resolveControl(controlSession);
+      const session = await starting;
 
-    const gesture = { type: "tap", x: 0.25, y: 0.5 } as const;
-    await session.controls.enqueue(gesture, { width: 2, height: 3 }).completion;
+      const gesture = { type: "tap", x: 0.25, y: 0.5 } as const;
+      await session.controls.enqueue(gesture, { width: 2, height: 3 }).completion;
 
-    expect(session.inputSource).toBe("scrcpy");
-    expect(packets).toEqual(
-      compileGesture(gesture, { width: 4, height: 6 }).steps.map(
-        (step) => step.packet,
-      ),
-    );
-    expect(client.keys).toEqual([]);
-    await session.close();
-    expect(controlCloseCalls).toBe(1);
-  });
+      expect(session.inputSource).toBe("scrcpy");
+      expect(packets).toEqual(
+        compileGesture(gesture, { width, height }).steps.map(
+          (step) => step.packet,
+        ),
+      );
+      expect(client.keys).toEqual([]);
+      expect(client.touches).toEqual([]);
+      await session.close();
+      expect(controlCloseCalls).toBe(1);
+    },
+  );
 
   test("starts, routes hardware controls through gRPC keys, and closes resources", async () => {
     const client = new FakeGrpcClient(integrationImage());
@@ -2035,9 +2080,17 @@ describe("startGrpcSession integration", () => {
 
     client.streamImage!(integrationImage(2), "stream", Date.now());
     await Promise.resolve();
+    await session.controls.enqueue(
+      { type: "tap", x: 0.25, y: 0.75 },
+      { width: 4, height: 6 },
+    ).completion;
 
     expect(encoders.map((encoder) => encoder.quarterTurn)).toEqual([0]);
     expect(encoders[0]!.closed).toBe(false);
+    expect(client.touches).toEqual([
+      [{ x: 3, y: 2, identifier: 0, pressure: 1 }],
+      [{ x: 3, y: 2, identifier: 0, pressure: 0 }],
+    ]);
     await session.close();
   });
 


### PR DESCRIPTION
Fix rotation and touch alignment for gRPC screens. Selecting portrait or landscape synchronizes the emulator accelerometer with Android's rotation lock, and direct gRPC touches map back to the native framebuffer.

Apps such as the launcher can keep Android's display portrait while gRPC produces a landscape screenshot. Scrcpy input now uses the difference between screenshot rotation and Android's active display rotation to transform touch coordinates and dimensions. It reads display rotation at each gesture's start, catching app switches even when video dimensions stay unchanged, and keeps one mapping throughout a multi-pointer drag. Rotation-read failures reject the affected touch while leaving subsequent controls usable.

Includes the implementation from [serve-emu #25](https://github.com/expo/serve-emu/pull/25) directly in the monorepo's `packages/serve-emu` source, rebased onto upstream `main` at `3d13723`. Includes documentation and a patch changeset.

### Validation

- On the rebased branch, all 1,072 backend tests passed. The backend aggregate check also passed coverage, documentation synchronization, typechecks, builds, and package smoke tests.
- The launcher regression failed in four mismatched-orientation cases before the fix; all eight orientation cases now pass. Additional integration coverage checks app switches without video resizing, multi-pointer drags, swipe endpoints, read-failure recovery, and hardware controls without rotation queries.
- On the rebuilt CLI with the default RGB888 gRPC stream and scrcpy input, verified the launcher reports display rotation 0 while screenshots report rotation 1. A swipe along the sideways content's top edge opens the notification shade correctly.
- Verified a launcher-icon tap opens Chrome, the mapping changes from relative rotation 1 to 0 with unchanged screenshot dimensions, and a tap on Chrome's address bar focuses it after the app transition finishes.

