### PR TITLE
fix: server connection overlay flash on startup

### DIFF
--- a/.changeset/quiet-initial-connection.md
+++ b/.changeset/quiet-initial-connection.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Prevent the connecting overlay from flashing during a quick initial server connection.

--- a/packages/@expo/hub-components/src/__tests__/server-connection-overlay.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/server-connection-overlay.test.tsx
@@ -8,6 +8,14 @@ import {
 import { font } from '../theme/tokens';
 
 describe('ServerConnectionOverlay', () => {
+  test('does not flash a connection dialog on the initial render', () => {
+    const markup = renderToStaticMarkup(
+      <ServerConnectionOverlay status="connecting" onReload={() => {}} />,
+    );
+
+    expect(markup).toBe('');
+  });
+
   test('renders above shared portals with the typed font token', () => {
     const markup = renderToStaticMarkup(
       <ServerConnectionOverlay status="disconnected" onReload={() => {}} />,

--- a/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
+++ b/packages/@expo/hub-components/src/dashboard/ServerConnectionOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   Button,
@@ -23,6 +23,8 @@ export type ServerConnectionOverlayProps = {
 
 type InertableElement = Pick<HTMLElement, 'inert'>;
 
+const CONNECTING_DELAY_MS = 1_000;
+
 /** Temporarily removes a body-level portal from pointer, keyboard, and assistive-tech access. */
 export function temporarilyInertElement(element: InertableElement): (() => void) | null {
   if (element.inert) return null;
@@ -32,12 +34,24 @@ export function temporarilyInertElement(element: InertableElement): (() => void)
   };
 }
 
-/** Full-page blocker shown until the dashboard can verify its dev server connection. */
+/** Full-page blocker for a slow initial connection or a disconnected dev server. */
 export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOverlayProps) {
   const connecting = status === 'connecting';
+  const [connectionDelayElapsed, setConnectionDelayElapsed] = useState(false);
+  const visible = !connecting || connectionDelayElapsed;
   const overlayRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
+    if (!connecting) return;
+
+    // Most initial handshakes finish quickly. Only show connection feedback
+    // if the dashboard is still waiting, and cancel it when it connects.
+    const timer = setTimeout(() => setConnectionDelayElapsed(true), CONNECTING_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [connecting]);
+
+  useEffect(() => {
+    if (!visible) return;
     const overlay = overlayRef.current;
     if (!overlay) return;
 
@@ -67,7 +81,9 @@ export function ServerConnectionOverlay({ status, onReload }: ServerConnectionOv
       observer.disconnect();
       for (const restore of restorers.values()) restore();
     };
-  }, []);
+  }, [visible]);
+
+  if (!visible) return null;
 
   return (
     <main


### PR DESCRIPTION
Adds a one-second grace period before showing the initial connecting overlay, preventing it from flashing during a quick server handshake. Actual disconnections still show immediately.

Includes a regression test for the initial render. Validation: all 33 component and device-list tests pass; DOM lifecycle checks cover quick connections, slow connections, disconnections, and timer cleanup.
