### PR TITLE
ci: validate pull requests and main on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # PR updates replace previous runs; each main push gets its own group.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      # --only prevents dependencies from reintroducing the macOS-only serve-sim build.
+      - name: Build packages (excluding serve-sim)
+        run: bun run build --filter='!@expo/serve-sim' --only
+
+      - name: Typecheck (excluding serve-sim)
+        run: bunx turbo run typecheck --filter='!@expo/serve-sim' --only
+
+      - name: Test
+        run: bun run test


### PR DESCRIPTION
Adds one Ubuntu CI job for pull requests and pushes to `main`. The job installs dependencies with Bun 1.3.6 and a frozen lockfile, then runs lint, builds, existing typecheck scripts, and tests.

Authored by Codex (GPT-6).
