### PR TITLE
Publish canary releases on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       canary:
@@ -17,6 +20,8 @@ jobs:
   release:
     runs-on: macos-latest
     environment: npm-publish
+    env:
+      IS_CANARY: ${{ github.event_name == 'push' || inputs.canary }}
     permissions:
       contents: write # push the release commit + tags
       id-token: write # npm OIDC Trusted Publishing
@@ -53,21 +58,21 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Verify pending changesets
-        if: ${{ !inputs.canary }}
+        if: ${{ env.IS_CANARY != 'true' }}
         run: ./scripts/verify-pending-changesets.ts
 
       - name: Apply version bump & generate changelog
         run: bun run changeset:version
 
       - name: Apply canary version
-        if: ${{ inputs.canary }}
+        if: ${{ env.IS_CANARY == 'true' }}
         run: ./scripts/apply-canary-version.ts
 
       - name: Summarize versions
         run: ./scripts/summarize-versions.ts
 
       - name: Commit & push version bump
-        if: ${{ !inputs.canary }}
+        if: ${{ env.IS_CANARY != 'true' }}
         run: |
           git add -A
           git commit -m "chore(release): version packages"
@@ -77,23 +82,23 @@ jobs:
         run: ./scripts/ignore-packages.ts
 
       - name: Publish to npm
-        if: ${{ !inputs.canary }}
+        if: ${{ env.IS_CANARY != 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: "true"
         run: bun run changeset:publish
 
       - name: Publish canary to npm
-        if: ${{ inputs.canary }}
+        if: ${{ env.IS_CANARY == 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: "true"
         run: bun run changeset:publish -- --tag canary
 
       - name: Push git tags
-        if: ${{ !inputs.canary }}
+        if: ${{ env.IS_CANARY != 'true' }}
         run: git push origin --tags
 
       - name: Create GitHub releases
-        if: ${{ !inputs.canary }}
+        if: ${{ env.IS_CANARY != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/create-github-releases.ts


### PR DESCRIPTION
## Summary

- trigger the release workflow on every push to main
- treat push-triggered runs as canary releases
- preserve manual stable and canary release behavior

## Validation

- git diff --check
- parsed .github/workflows/release.yml as YAML

— Codex (GPT-5)