### PR TITLE
Add RGB888 gRPC image mode to Device Hub

### DIFF
--- a/.changeset/android-rgb888-grpc.md
+++ b/.changeset/android-rgb888-grpc.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add separately selectable RGB888 image delivery over gRPC to Android streaming, including CLI and programmatic configuration, runtime switching, and capture diagnostics. Keep MMAP as the Hub default.

--- a/.changeset/android-rgb888-grpc.md
+++ b/.changeset/android-rgb888-grpc.md
@@ -2,4 +2,4 @@
 'expo-device-hub': minor
 ---
 
-Add separately selectable RGB888 image delivery over gRPC to Android streaming, including CLI and programmatic configuration, runtime switching, and capture diagnostics. Keep MMAP as the Hub default.
+Add RGB888 image delivery over gRPC to Android streaming.

--- a/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream-source.test.ts
@@ -3,26 +3,29 @@ import { describe, expect, test } from 'bun:test';
 import { parseAndroidStreamSource } from '../android-stream-source';
 
 describe('parseAndroidStreamSource', () => {
-  test('parses the authoritative gRPC image mode', () => {
-    expect(
-      parseAndroidStreamSource({
-        ok: true,
+  test.each(['png', 'mmap', 'rgb888'])(
+    'parses the authoritative %s gRPC image mode',
+    (grpcImageMode) => {
+      expect(
+        parseAndroidStreamSource({
+          ok: true,
+          mode: 'grpc-screenshot',
+          grpcImageMode,
+          inputSource: 'scrcpy',
+          availableInputSources: ['scrcpy', 'grpc'],
+          availableModes: ['scrcpy', 'grpc-screenshot'],
+          sessionGeneration: 4,
+        }),
+      ).toEqual({
         mode: 'grpc-screenshot',
-        grpcImageMode: 'mmap',
+        grpcImageMode,
         inputSource: 'scrcpy',
         availableInputSources: ['scrcpy', 'grpc'],
         availableModes: ['scrcpy', 'grpc-screenshot'],
         sessionGeneration: 4,
-      }),
-    ).toEqual({
-      mode: 'grpc-screenshot',
-      grpcImageMode: 'mmap',
-      inputSource: 'scrcpy',
-      availableInputSources: ['scrcpy', 'grpc'],
-      availableModes: ['scrcpy', 'grpc-screenshot'],
-      sessionGeneration: 4,
-    });
-  });
+      });
+    },
+  );
 
   test('rejects missing or unsupported image modes', () => {
     const response = {

--- a/packages/@expo/hub-client/src/__tests__/stream-stats.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/stream-stats.test.ts
@@ -502,70 +502,73 @@ describe('readWebRtcServerStats', () => {
     });
   });
 
-  test('normalizes gRPC producer, transport, and host-copy diagnostics', () => {
-    const result = readWebRtcServerStats(
-      {
-        sampledAt: 2_000,
-        source: { codec: 'h264', fps: 58, frames: 500 },
-        sessions: [
-          {
-            sessionId: 'viewer',
-            submittedFrames: 490,
-            publisherDroppedFrames: 0,
-            payloadBytesSubmitted: 2_000_000,
-          },
-        ],
-        capture: {
-          offeredFrames: 500,
-          forwardedFrames: 490,
-          grpc: {
-            imageMode: 'mmap',
-            sourceTimestampFps: 60,
-            rawMessageReceiveFps: 59.5,
-            usableImageFps: 59,
-            freshEncoderWriteFps: 58.5,
-            rawGrpcMessagesReceived: 600,
-            rawGrpcMessagesEmitted: 590,
-            rawGrpcMessagesCoalesced: 10,
-            sequenceGaps: 2,
-            imagePayloadBytes: 552_960,
-            transportBytes: 55_296_000,
-            grpcMessageBytesReceived: 12_000,
-            mmapFileBytesRead: 56_000_000,
-            mmapReadRetries: 1,
-            mmapTornFramesDropped: 0,
-            productionToReceiveLatencyMs: { p50: 4.2, p95: 8.1 },
-            productionToUsableLatencyMs: { p50: 4.7, p95: 9.2 },
-            protobufDecodeTimeMs: { p50: 0.1, p95: 0.2 },
-            sharedReadCopyTimeMs: { p50: 0.3, p95: 0.6 },
+  test.each(['mmap', 'rgb888'])(
+    'normalizes %s producer, transport, and host-copy diagnostics',
+    (imageMode) => {
+      const result = readWebRtcServerStats(
+        {
+          sampledAt: 2_000,
+          source: { codec: 'h264', fps: 58, frames: 500 },
+          sessions: [
+            {
+              sessionId: 'viewer',
+              submittedFrames: 490,
+              publisherDroppedFrames: 0,
+              payloadBytesSubmitted: 2_000_000,
+            },
+          ],
+          capture: {
+            offeredFrames: 500,
+            forwardedFrames: 490,
+            grpc: {
+              imageMode,
+              sourceTimestampFps: 60,
+              rawMessageReceiveFps: 59.5,
+              usableImageFps: 59,
+              freshEncoderWriteFps: 58.5,
+              rawGrpcMessagesReceived: 600,
+              rawGrpcMessagesEmitted: 590,
+              rawGrpcMessagesCoalesced: 10,
+              sequenceGaps: 2,
+              imagePayloadBytes: 552_960,
+              transportBytes: 55_296_000,
+              grpcMessageBytesReceived: imageMode === 'mmap' ? 12_000 : 55_308_000,
+              mmapFileBytesRead: imageMode === 'mmap' ? 56_000_000 : 0,
+              mmapReadRetries: imageMode === 'mmap' ? 1 : 0,
+              mmapTornFramesDropped: 0,
+              productionToReceiveLatencyMs: { p50: 4.2, p95: 8.1 },
+              productionToUsableLatencyMs: { p50: 4.7, p95: 9.2 },
+              protobufDecodeTimeMs: { p50: 0.1, p95: 0.2 },
+              sharedReadCopyTimeMs: imageMode === 'mmap' ? { p50: 0.3, p95: 0.6 } : null,
+            },
           },
         },
-      },
-      'viewer',
-    );
+        'viewer',
+      );
 
-    expect(result.capture?.grpc).toEqual({
-      imageMode: 'mmap',
-      producerFps: 60,
-      receiveFps: 59.5,
-      usableImageFps: 59,
-      encoderInputFps: 58.5,
-      messagesReceived: 600,
-      messagesEmitted: 590,
-      messagesCoalesced: 10,
-      sequenceGaps: 2,
-      imagePayloadBytes: 552_960,
-      transportBytes: 55_296_000,
-      messageBytesReceived: 12_000,
-      mmapFileBytesRead: 56_000_000,
-      mmapReadRetries: 1,
-      mmapTornFramesDropped: 0,
-      productionToReceiveLatencyMs: { p50: 4.2, p95: 8.1 },
-      productionToUsableLatencyMs: { p50: 4.7, p95: 9.2 },
-      protobufDecodeTimeMs: { p50: 0.1, p95: 0.2 },
-      mmapReadCopyTimeMs: { p50: 0.3, p95: 0.6 },
-    });
-  });
+      expect(result.capture?.grpc).toEqual({
+        imageMode,
+        producerFps: 60,
+        receiveFps: 59.5,
+        usableImageFps: 59,
+        encoderInputFps: 58.5,
+        messagesReceived: 600,
+        messagesEmitted: 590,
+        messagesCoalesced: 10,
+        sequenceGaps: 2,
+        imagePayloadBytes: 552_960,
+        transportBytes: 55_296_000,
+        messageBytesReceived: imageMode === 'mmap' ? 12_000 : 55_308_000,
+        mmapFileBytesRead: imageMode === 'mmap' ? 56_000_000 : 0,
+        mmapReadRetries: imageMode === 'mmap' ? 1 : 0,
+        mmapTornFramesDropped: 0,
+        productionToReceiveLatencyMs: { p50: 4.2, p95: 8.1 },
+        productionToUsableLatencyMs: { p50: 4.7, p95: 9.2 },
+        protobufDecodeTimeMs: { p50: 0.1, p95: 0.2 },
+        mmapReadCopyTimeMs: imageMode === 'mmap' ? { p50: 0.3, p95: 0.6 } : { p50: null, p95: null },
+      });
+    },
+  );
 });
 
 describe('describeWebRtcPublisherCounters', () => {

--- a/packages/@expo/hub-client/src/android-stream-source.ts
+++ b/packages/@expo/hub-client/src/android-stream-source.ts
@@ -32,7 +32,7 @@ export function androidStreamSourceErrorMessage(status: number, value: unknown):
 }
 
 function isGrpcImageMode(value: unknown): value is DeviceGrpcImageMode {
-  return value === 'png' || value === 'mmap';
+  return value === 'png' || value === 'mmap' || value === 'rgb888';
 }
 
 function isInputSource(value: unknown): value is DeviceInputSource {

--- a/packages/@expo/hub-client/src/stream-stats.ts
+++ b/packages/@expo/hub-client/src/stream-stats.ts
@@ -288,7 +288,9 @@ function readWebRtcCaptureStats(value: unknown): DeviceStreamCaptureStats | null
         ? null
         : {
             imageMode:
-              grpc.imageMode === 'png' || grpc.imageMode === 'mmap' ? grpc.imageMode : null,
+              grpc.imageMode === 'png' || grpc.imageMode === 'mmap' || grpc.imageMode === 'rgb888'
+                ? grpc.imageMode
+                : null,
             producerFps: finiteNumber(grpc.sourceTimestampFps),
             receiveFps: finiteNumber(grpc.rawMessageReceiveFps),
             usableImageFps: finiteNumber(grpc.usableImageFps),

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -179,7 +179,7 @@ export interface DeviceStreamEncoderSettings {
 export type DeviceStreamSource = 'scrcpy' | 'grpc-screenshot';
 
 /** Pixel delivery selected for the emulator gRPC screenshot source. */
-export type DeviceGrpcImageMode = 'png' | 'mmap';
+export type DeviceGrpcImageMode = 'png' | 'mmap' | 'rgb888';
 
 /** Input transport used while gRPC provides emulator video. */
 export type DeviceInputSource = 'scrcpy' | 'grpc';

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -59,6 +59,7 @@ const STREAM_SOURCE_OPTIONS: ReadonlyArray<SelectOption<DeviceStreamSource>> = [
 const GRPC_IMAGE_MODE_OPTIONS: ReadonlyArray<SelectOption<DeviceGrpcImageMode>> = [
   { value: 'png', label: 'PNG' },
   { value: 'mmap', label: 'MMAP' },
+  { value: 'rgb888', label: 'RGB888' },
 ];
 const GRPC_INPUT_SOURCE_OPTIONS: ReadonlyArray<SelectOption<DeviceInputSource>> = [
   { value: 'scrcpy', label: 'scrcpy' },
@@ -157,10 +158,6 @@ export function StreamOptionsSection({
   const inputSourceOptions = GRPC_INPUT_SOURCE_OPTIONS.filter((option) =>
     streamSource?.availableInputSources.includes(option.value),
   );
-  // Every one of these controls restarts the capture session, so they share the
-  // pending state and the switching note.
-  const sourceControlsVisible =
-    !!streamSource && (sourceOptions.length > 1 || streamSource.mode === 'grpc-screenshot');
   const settingsReady = client.streamSettings !== null;
   const settingsDisabled = !settingsReady || client.streamSettingsPending;
   const transport: StreamTransport =
@@ -274,9 +271,6 @@ export function StreamOptionsSection({
             />
           </SidebarRow>
         </>
-      )}
-      {sourceControlsVisible && client.streamSourcePending && !client.streamSourceError && (
-        <SectionNote role="status">Switching stream source…</SectionNote>
       )}
       <SidebarRow label="Transport">
         <Select

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -67,9 +67,46 @@ npx expo-device-hub --platform android --transport webrtc
 ```
 
 Use `--stream-source scrcpy` to select scrcpy at startup, or `--grpc-image-mode png` to
-send a compressed image in each gRPC message. The same source and PNG/MMAP choices are
-available at runtime under **Stream options**. Run `npx expo-device-hub --help` for the
-full option list.
+send a compressed image in each gRPC message. Use `--grpc-image-mode rgb888` for raw
+RGB888 pixels inside each gRPC response. The same source and PNG/MMAP/RGB888 choices
+are available at runtime under **Stream options**. Run `npx expo-device-hub --help`
+for the full option list.
+
+```sh
+npx expo-device-hub --platform android --stream-source grpc-screenshot --grpc-image-mode rgb888
+```
+
+Programmatic serve-emu options accept
+`{ streamMode: "grpc-screenshot", grpcImageMode: "rgb888" }`. Hub's shared dashboard
+selector applies the choice through the embedded serve-emu `PUT /api/stream-mode`
+endpoint with `{ "mode": "grpc-screenshot", "grpcImageMode": "rgb888" }` (under
+`/vendor/serve-emu` in Hub). The applied selection updates when the replacement
+stream renders, and failed replacements preserve the previous selection.
+
+RGB888 response bytes are validated and passed to ffmpeg/libx264 as `rgb24`,
+without MMAP allocation or verification rereads and without PNG in the continuous
+capture stream. This still involves emulator GPU-to-CPU readback, not texture
+sharing or hardware encoding. It is not zero-copy or guaranteed faster. Source
+frame rate, locally paced encoder submissions, gRPC payload bytes and decode
+timing remain separate in capture statistics. MMAP remains the Hub default.
+
+To measure incoming gRPC responses, sample `grpcCapture.rawGrpcMessagesReceived`
+from `/vendor/serve-emu/health?device=<serial>` and divide the counter difference
+by the elapsed seconds within the same capture session. This counter increments
+when a complete gRPC response has been assembled, before protobuf decoding,
+MMAP reads, frame selection, and encoder writes. Count differences include idle
+time; the displayed **Host receive FPS** is an active-cadence estimate that can
+retain its last value while idle. RGB888's normal capture path also pauses the
+HTTP/2 stream for local pacing, so received response rate is not a measurement
+of every frame rendered internally by the emulator.
+
+MMAP uses gRPC metadata notifications to trigger selected shared-memory reads;
+it does not continuously poll the file. After the stream has delivered a message,
+10 seconds without another decoded stream message triggers a unary
+`getScreenshot` probe. A successful MMAP probe triggers a fresh shared-memory
+read. These probes do not increment the stream notification counter. Repeating
+the cached image for the encoder also does not imply a new gRPC response or a
+new MMAP read.
 
 MMAP support is experimental and depends on the Android Emulator build. Google
 tracks an Apple Silicon `streamScreenshot` MMAP fix as issue

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -444,7 +444,7 @@ test('shows the Android emulator capture source select', () => {
   expect(selectMarkup(html, 'Stream source')).not.toContain('disabled=""');
 });
 
-test('shows PNG and MMAP only while the gRPC source is active', () => {
+test('shows PNG, MMAP and RGB888 only while the gRPC source is active', () => {
   const scrcpyHtml = renderToStaticMarkup(
     <StreamOptionsSection client={inspectorClient('android')} defaultOpen />,
   );
@@ -469,7 +469,7 @@ test('shows PNG and MMAP only while the gRPC source is active', () => {
   expect(selectOptionLabels(grpcHtml, 'Input source')).toEqual(['scrcpy', 'gRPC']);
   expect(selectValue(grpcHtml, 'Input source')).toBe('scrcpy');
   expect(grpcHtml).toContain('>gRPC frames</span>');
-  expect(selectOptionLabels(grpcHtml, 'gRPC image mode')).toEqual(['PNG', 'MMAP']);
+  expect(selectOptionLabels(grpcHtml, 'gRPC image mode')).toEqual(['PNG', 'MMAP', 'RGB888']);
   expect(selectValue(grpcHtml, 'gRPC image mode')).toBe('MMAP');
 });
 
@@ -484,8 +484,7 @@ test('disables the Android capture source select while replacement is pending', 
   expect(source).toContain('disabled=""');
   // The previous source stays selected until the replacement stream renders.
   expect(selectValue(html, 'Stream source')).toBe('scrcpy');
-  expect(html).toContain('role="status"');
-  expect(html).toContain('Switching stream source…');
+  expect(html).not.toContain('Switching stream source…');
 });
 
 test('disables every gRPC capture control while replacement is pending', () => {
@@ -506,7 +505,7 @@ test('disables every gRPC capture control while replacement is pending', () => {
   // Input source and image mode restart the same capture session as Source.
   expect(selectMarkup(html, 'Input source')).toContain('disabled=""');
   expect(selectMarkup(html, 'gRPC image mode')).toContain('disabled=""');
-  expect(html).toContain('Switching stream source…');
+  expect(html).not.toContain('Switching stream source…');
 });
 
 test('shows no switching hint once the capture source is settled', () => {
@@ -785,7 +784,7 @@ test('shows only the server statistics that serve-emu can provide', () => {
   expect(`${encoder}${capture}`).not.toContain('>—</span>');
 });
 
-test('shows the gRPC producer-to-client pipeline diagnostics', () => {
+test.each(['mmap', 'rgb888'] as const)('shows the %s producer-to-client pipeline diagnostics', (imageMode) => {
   const client = {
     ...inspectorClient('android'),
     streamStats: streamStats(
@@ -798,7 +797,7 @@ test('shows the gRPC producer-to-client pipeline diagnostics', () => {
           forwardedFrames: 575,
           pumpRestarts: null,
           grpc: {
-            imageMode: 'mmap',
+            imageMode,
             producerFps: 60,
             receiveFps: 59.5,
             usableImageFps: 59,
@@ -833,7 +832,7 @@ test('shows the gRPC producer-to-client pipeline diagnostics', () => {
   );
   const capture = streamStatisticGroupMarkup(html, 'Capture statistics');
 
-  expect(streamStatisticValue(capture, 'gRPC image mode')).toBe('MMAP');
+  expect(streamStatisticValue(capture, 'gRPC image mode')).toBe(imageMode.toUpperCase());
   expect(streamStatisticValue(capture, 'Emulator producer FPS')).toBe('60 FPS');
   expect(streamStatisticValue(capture, 'Host receive FPS')).toBe('60 FPS');
   expect(streamStatisticValue(capture, 'Usable image FPS')).toBe('59 FPS');
@@ -843,8 +842,13 @@ test('shows the gRPC producer-to-client pipeline diagnostics', () => {
   expect(streamStatisticValue(capture, 'Coalesced notifications')).toBe('10');
   expect(streamStatisticValue(capture, 'Latest image payload')).toBe('540.0 KiB');
   expect(streamStatisticValue(capture, 'Produce→usable p50 / p95')).toBe('4.7 / 9.2 ms');
-  expect(streamStatisticValue(capture, 'MMAP read p50 / p95')).toBe('0.3 / 0.6 ms');
-  expect(streamStatisticValue(capture, 'Torn frames dropped')).toBe('0');
+  if (imageMode === 'mmap') {
+    expect(streamStatisticValue(capture, 'MMAP read p50 / p95')).toBe('0.3 / 0.6 ms');
+    expect(streamStatisticValue(capture, 'Torn frames dropped')).toBe('0');
+  } else {
+    expect(capture).not.toContain('MMAP');
+    expect(capture).not.toContain('Torn frames dropped');
+  }
 });
 
 test('shows the WebRTC measuring state without inventing zero readings', () => {
@@ -1317,4 +1321,31 @@ test('shows only the viewer-local frame option while iOS device settings are una
   expect(html).not.toContain('>Appearance</span>');
   expect(html).not.toContain('>Liquid glass</span>');
   expect(html).not.toContain('>Keyboard</span>');
+});
+
+test('shows RGB888 applied, pending, and failed without changing the selection', () => {
+  for (const state of ['applied', 'pending', 'failed']) {
+    const client = {
+      ...inspectorClient('android'),
+      streamSource: {
+        mode: 'grpc-screenshot',
+        grpcImageMode: 'rgb888',
+        inputSource: 'scrcpy',
+        availableInputSources: ['scrcpy', 'grpc'],
+        availableModes: ['scrcpy', 'grpc-screenshot'],
+        sessionGeneration: 2,
+      },
+      streamSourcePending: state === 'pending',
+      streamSourceError: state === 'failed' ? 'RGB888 capture failed' : null,
+    } satisfies DeviceClient;
+    const html = renderToStaticMarkup(<StreamOptionsSection client={client} defaultOpen />);
+    expect(selectValue(html, 'gRPC image mode')).toBe('RGB888');
+    expect(html).not.toContain('Raw pixels over gRPC');
+    expect(selectMarkup(html, 'gRPC image mode').includes('disabled=""')).toBe(state === 'pending');
+    expect(html).not.toContain('Switching stream source…');
+    if (state === 'failed') {
+      expect(html).toContain('role="alert"');
+      expect(html).toContain('RGB888 capture failed');
+    }
+  }
 });

--- a/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/serve-emu-options.test.ts
@@ -15,6 +15,22 @@ const DEFAULT_ANDROID_STREAM = {
 } as const;
 
 describe('standaloneServeEmuOptions', () => {
+  test('passes RGB888 CLI and programmatic options through the embedded server payload', () => {
+    const cli = parseCliOptions(['--grpc-image-mode', 'RGB888', '--max-dimension', '0']);
+    expect(cli.grpcImageMode).toBe('rgb888');
+    const expected = {
+      streamMode: 'grpc-screenshot',
+      grpcImageMode: 'rgb888',
+      maxSize: 0,
+      streamSettings: { transport: 'websocket' },
+    };
+    expect(standaloneServeEmuOptions(cli)).toEqual(expected);
+    expect(readStandaloneServeEmuOptions(encodeStandaloneServeEmuOptions(cli))).toEqual(expected);
+    expect(
+      standaloneServeEmuOptions({ ...parseCliOptions([]), grpcImageMode: 'rgb888', maxDimension: 0 }),
+    ).toEqual(expected);
+  });
+
   test('defaults Android streaming to gRPC with MMAP', () => {
     expect(standaloneServeEmuOptions(parseCliOptions([]))).toEqual({
       ...DEFAULT_ANDROID_STREAM,

--- a/packages/expo-device-hub/src/server/cli/options.ts
+++ b/packages/expo-device-hub/src/server/cli/options.ts
@@ -19,7 +19,7 @@ export type WebRtcIcePolicy = (typeof WEBRTC_ICE_POLICIES)[number];
 export const ANDROID_STREAM_SOURCES = ['scrcpy', 'grpc-screenshot'] as const;
 export type AndroidStreamSource = (typeof ANDROID_STREAM_SOURCES)[number];
 export const DEFAULT_ANDROID_STREAM_SOURCE: AndroidStreamSource = 'grpc-screenshot';
-export const GRPC_IMAGE_MODES = ['png', 'mmap'] as const;
+export const GRPC_IMAGE_MODES = ['png', 'mmap', 'rgb888'] as const;
 export type GrpcImageMode = (typeof GRPC_IMAGE_MODES)[number];
 export const DEFAULT_GRPC_IMAGE_MODE: GrpcImageMode = 'mmap';
 

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -33,7 +33,7 @@ Working:
 - Live H.264 video over WebSocket/WebCodecs or WebRTC, with an MSE fallback
 - Per-tab switching between WebSocket and WebRTC, with lazy WebRTC startup
 - Runtime switching between scrcpy and host-side gRPC screenshot capture on Android Emulators, with scrcpy or gRPC input while gRPC video is active
-- Runtime PNG/MMAP selection and redacted JSON stream-stat downloads in the UI
+- Runtime PNG/MMAP/RGB888 selection and redacted JSON stream-stat downloads in the UI
 - Tap, swipe, text, keyevent, Back, Home, Recents, and Power input
 - Keyboard passthrough in the browser UI: editing/navigation keys, Ctrl/Cmd shortcuts (select all, copy, paste, cut, undo, redo), and IME composition for CJK text
 - Multi-client streaming, so multiple browser tabs can share one device
@@ -98,7 +98,7 @@ bun run --filter serve-emu start
 ## CLI
 
 ```text
-serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
+serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
 serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
 serve-emu --avd <name> [--gpu <mode>] [--restart-avd] [--camera] [--camera-image <path.png>]
 serve-emu --avd-list
@@ -113,7 +113,7 @@ serve-emu --running-avds
 | `--unsafe-no-auth` | false | Allow a non-loopback bind with **no** authentication (dangerous) |
 | `-s, --serial` | auto | adb device serial; required when multiple devices are online |
 | `--stream-mode` | `scrcpy` | Screen capture source: `scrcpy`, or emulator-only host capture through `grpc-screenshot` |
-| `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, or raw pixels through shared-memory `mmap`. The selected mode is strict; capture errors do not fall back to the other mode |
+| `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
 | `--max-fps` | `60` | Cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
@@ -199,7 +199,7 @@ Open `http://localhost:3300` after starting the CLI. The UI streams the device i
 
 - Pointer input, keyboard passthrough (typing, navigation keys, shortcuts, IME composition), hardware buttons, and screenshots
 - Device selection plus AVD start/stop
-- Stream-source switching between scrcpy and gRPC screenshot capture on emulators, with an explicit PNG/MMAP image-mode selector for gRPC
+- Stream-source switching between scrcpy and gRPC screenshot capture on emulators, with an explicit PNG/MMAP/RGB888 image-mode selector for gRPC
 - Per-tab WebSocket/WebRTC selection and redacted stream-stat downloads
 - Orientation, night mode, font scale, network, GPS location, and route playback
 - Logcat filtering, pause/copy controls, app management, file import, and session replay
@@ -239,7 +239,7 @@ curl -X POST "$BASE/api/devices/select" \
 
 `GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, the
 available stream and input sources, and the active session generation. `PUT
-/api/stream-mode` accepts an optional `grpcImageMode` of `png` or `mmap` and an
+/api/stream-mode` accepts an optional `grpcImageMode` of `png`, `mmap`, or `rgb888` and an
 optional `inputSource` of `scrcpy` or `grpc` when `mode` is `grpc-screenshot`.
 gRPC streaming defaults to the control-only scrcpy input transport.
 Changing either value stages one replacement capture atomically; an MMAP error
@@ -629,12 +629,42 @@ to emulator gRPC. Set the initial choice with `--input-source scrcpy|grpc`.
 `--grpc-image-mode png`
 requests compressed images in the gRPC stream, while `--grpc-image-mode mmap`
 requests raw RGB pixels through the emulator's shared-memory side channel.
+`--grpc-image-mode rgb888` requests `IMG_FORMAT_RGB888` with the width and height
+set to `--max-size`, omitting `transport` from `streamScreenshot`. Each response's
+`image` bytes are validated against its actual dimensions (`width * height * 3`)
+and passed to ffmpeg as `rgb24`. It uses no MMAP region or verification rereads,
+and no PNG encoding or decoding in the continuous stream. Startup/geometry and
+inactivity probes also request in-band RGB888. The emulator preserves aspect
+ratio within the requested bounds; zero requests native size, including after
+rotation or display resizing.
+
+This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
+texture sharing, zero-copy, or hardware encoding; speed depends on the workload
+and must be measured. A bounded gRPC message pacer and a single latest image
+preserve encoder backpressure. `--max-fps` paces local consumption and encoder
+submission; it does not impose a server-side screenshot FPS limit. Health
+reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
+protobuf decode timing, and separate received/source/encoder frame rates.
+MMAP counters remain zero and shared-memory timing remains null for RGB888.
+
+```sh
+serve-emu -s emulator-5554 --stream-mode grpc-screenshot --grpc-image-mode rgb888
+curl -X PUT http://localhost:3300/api/stream-mode \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot","grpcImageMode":"rgb888"}'
+```
+
+The standalone server and embedded `createApp`/`createRouter` accept
+`{ streamMode: "grpc-screenshot", grpcImageMode: "rgb888" }`. Both use the same
+GET/PUT contract for runtime switching; failed replacements retain the applied
+mode. Serve-emu still defaults to PNG; Expo Device Hub defaults to MMAP.
+
 `serve-emu` uses the bearer token advertised by the emulator's discovery file
 when one is present. If an explicitly selected emulator exposes an endpoint
 without a token, `serve-emu` prints a warning before using that local endpoint;
 only select this mode for an emulator you trust.
 
-`serve-emu` encodes either mode with ffmpeg/libx264 into the same Annex-B H.264
+`serve-emu` encodes all three modes with ffmpeg/libx264 into the same Annex-B H.264
 packet shape, so browser streaming, backpressure recovery, recording, and the
 REST and WebSocket control APIs remain unchanged. The selected gRPC image mode
 never falls back automatically. The UI can replace either source or gRPC image

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -35,7 +35,7 @@ Working:
 - Live H.264 video over WebSocket/WebCodecs or WebRTC, with an MSE fallback
 - Per-tab switching between WebSocket and WebRTC, with lazy WebRTC startup
 - Runtime switching between scrcpy and host-side gRPC screenshot capture on Android Emulators, with scrcpy or gRPC input while gRPC video is active
-- Runtime PNG/MMAP selection and redacted JSON stream-stat downloads in the UI
+- Runtime PNG/MMAP/RGB888 selection and redacted JSON stream-stat downloads in the UI
 - Tap, swipe, text, keyevent, Back, Home, Recents, and Power input
 - Keyboard passthrough in the browser UI: editing/navigation keys, Ctrl/Cmd shortcuts (select all, copy, paste, cut, undo, redo), and IME composition for CJK text
 - Multi-client streaming, so multiple browser tabs can share one device
@@ -100,7 +100,7 @@ bun run --filter serve-emu start
 ## CLI
 
 ```text
-serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
+serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
 serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
 serve-emu --avd <name> [--gpu <mode>] [--restart-avd] [--camera] [--camera-image <path.png>]
 serve-emu --avd-list
@@ -115,7 +115,7 @@ serve-emu --running-avds
 | `--unsafe-no-auth` | false | Allow a non-loopback bind with **no** authentication (dangerous) |
 | `-s, --serial` | auto | adb device serial; required when multiple devices are online |
 | `--stream-mode` | `scrcpy` | Screen capture source: `scrcpy`, or emulator-only host capture through `grpc-screenshot` |
-| `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, or raw pixels through shared-memory `mmap`. The selected mode is strict; capture errors do not fall back to the other mode |
+| `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
 | `--max-fps` | `60` | Cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
@@ -201,7 +201,7 @@ Open `http://localhost:3300` after starting the CLI. The UI streams the device i
 
 - Pointer input, keyboard passthrough (typing, navigation keys, shortcuts, IME composition), hardware buttons, and screenshots
 - Device selection plus AVD start/stop
-- Stream-source switching between scrcpy and gRPC screenshot capture on emulators, with an explicit PNG/MMAP image-mode selector for gRPC
+- Stream-source switching between scrcpy and gRPC screenshot capture on emulators, with an explicit PNG/MMAP/RGB888 image-mode selector for gRPC
 - Per-tab WebSocket/WebRTC selection and redacted stream-stat downloads
 - Orientation, night mode, font scale, network, GPS location, and route playback
 - Logcat filtering, pause/copy controls, app management, file import, and session replay
@@ -241,7 +241,7 @@ curl -X POST "$BASE/api/devices/select" \
 
 `GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, the
 available stream and input sources, and the active session generation. `PUT
-/api/stream-mode` accepts an optional `grpcImageMode` of `png` or `mmap` and an
+/api/stream-mode` accepts an optional `grpcImageMode` of `png`, `mmap`, or `rgb888` and an
 optional `inputSource` of `scrcpy` or `grpc` when `mode` is `grpc-screenshot`.
 gRPC streaming defaults to the control-only scrcpy input transport.
 Changing either value stages one replacement capture atomically; an MMAP error
@@ -631,12 +631,42 @@ to emulator gRPC. Set the initial choice with `--input-source scrcpy|grpc`.
 `--grpc-image-mode png`
 requests compressed images in the gRPC stream, while `--grpc-image-mode mmap`
 requests raw RGB pixels through the emulator's shared-memory side channel.
+`--grpc-image-mode rgb888` requests `IMG_FORMAT_RGB888` with the width and height
+set to `--max-size`, omitting `transport` from `streamScreenshot`. Each response's
+`image` bytes are validated against its actual dimensions (`width * height * 3`)
+and passed to ffmpeg as `rgb24`. It uses no MMAP region or verification rereads,
+and no PNG encoding or decoding in the continuous stream. Startup/geometry and
+inactivity probes also request in-band RGB888. The emulator preserves aspect
+ratio within the requested bounds; zero requests native size, including after
+rotation or display resizing.
+
+This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
+texture sharing, zero-copy, or hardware encoding; speed depends on the workload
+and must be measured. A bounded gRPC message pacer and a single latest image
+preserve encoder backpressure. `--max-fps` paces local consumption and encoder
+submission; it does not impose a server-side screenshot FPS limit. Health
+reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
+protobuf decode timing, and separate received/source/encoder frame rates.
+MMAP counters remain zero and shared-memory timing remains null for RGB888.
+
+```sh
+serve-emu -s emulator-5554 --stream-mode grpc-screenshot --grpc-image-mode rgb888
+curl -X PUT http://localhost:3300/api/stream-mode \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot","grpcImageMode":"rgb888"}'
+```
+
+The standalone server and embedded `createApp`/`createRouter` accept
+`{ streamMode: "grpc-screenshot", grpcImageMode: "rgb888" }`. Both use the same
+GET/PUT contract for runtime switching; failed replacements retain the applied
+mode. Serve-emu still defaults to PNG; Expo Device Hub defaults to MMAP.
+
 `serve-emu` uses the bearer token advertised by the emulator's discovery file
 when one is present. If an explicitly selected emulator exposes an endpoint
 without a token, `serve-emu` prints a warning before using that local endpoint;
 only select this mode for an emulator you trust.
 
-`serve-emu` encodes either mode with ffmpeg/libx264 into the same Annex-B H.264
+`serve-emu` encodes all three modes with ffmpeg/libx264 into the same Annex-B H.264
 packet shape, so browser streaming, backpressure recovery, recording, and the
 REST and WebSocket control APIs remain unchanged. The selected gRPC image mode
 never falls back automatically. The UI can replace either source or gRPC image

--- a/packages/serve-emu/packages/serve-emu/src/cli.ts
+++ b/packages/serve-emu/packages/serve-emu/src/cli.ts
@@ -192,7 +192,7 @@ if (values.help) {
   console.log(`serve-emu — host an Android device over WebSocket/WebRTC
 
 Usage:
-  serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--grpc-image-mode <png|mmap>] [--input-source <scrcpy|grpc>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms]
+  serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--grpc-image-mode <png|mmap|rgb888>] [--input-source <scrcpy|grpc>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms]
   serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
   serve-emu --avd <name> [--restart-avd]
   serve-emu --avd-list
@@ -232,11 +232,12 @@ Options:
                          Screen capture source (default: scrcpy). The gRPC
                          screenshot source captures and encodes on the emulator
                          host and is available only for Android Emulators.
-      --grpc-image-mode <png|mmap>
-                         Emulator gRPC image delivery (default: png). PNG sends
-                         compressed images in-band; MMAP uses shared memory for
-                         raw pixels. The selected mode is strict: capture errors
-                         do not fall back to the other mode.
+      --grpc-image-mode <png|mmap|rgb888>
+                         Emulator gRPC image delivery (default: png).
+                         PNG sends compressed images in-band.
+                         RGB888 sends raw pixels over gRPC.
+                         MMAP uses shared memory for raw pixels. Capture errors
+                         do not fall back to another mode.
       --input-source <scrcpy|grpc>
                          Input transport for gRPC streaming (default: scrcpy).
                          scrcpy runs a control-only server; grpc sends input

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -612,6 +612,8 @@ export function isUsableRgbFrame(image: EmuImage): boolean {
     image.height > 0 &&
     Number.isSafeInteger(image.width) &&
     Number.isSafeInteger(image.height) &&
+    image.width <= 16_384 &&
+    image.height <= 16_384 &&
     image.image.length === image.width * image.height * 3
   );
 }
@@ -691,7 +693,9 @@ export function grpcImageModeBehavior(
   }
   return {
     encoderInputFormat: "rgb24",
-    predecodeMaxFps: undefined,
+    // In-band RGB messages own their pixels and can use the same bounded
+    // predecode pacer as PNG. MMAP metadata must be decoded immediately.
+    predecodeMaxFps: imageMode === "rgb888" ? maxFps : undefined,
     needsEncoderFollowUp: (repeat) => !repeat,
   };
 }
@@ -850,19 +854,36 @@ function createGrpcImageCaptureTransport(options: {
   onError(error: unknown): void;
 }): GrpcImageCaptureTransport {
   const behavior = grpcImageModeBehavior(options.imageMode, options.maxFps);
-  if (options.imageMode === "png") {
+  if (options.imageMode !== "mmap") {
+    const isRgb = options.imageMode === "rgb888";
     let closed = false;
     return {
       ...behavior,
       streamFormat: {
-        format: IMG_FORMAT_PNG,
+        format: isRgb ? IMG_FORMAT_RGB888 : IMG_FORMAT_PNG,
         width: options.maxSize,
         height: options.maxSize,
       },
       push(notification, source, receivedAtMs) {
-        if (!closed && isUsablePngFrame(notification)) {
-          options.consume(notification, source, receivedAtMs);
+        if (closed || options.signal.aborted) return;
+        if (isRgb) {
+          // A metadata-only 0x0 response signals an inactive display.
+          if (
+            notification.width === 0 &&
+            notification.height === 0 &&
+            notification.image.length === 0
+          ) return;
+          if (!isUsableRgbFrame(notification)) {
+            throw new Error(
+              `emulator RGB888 screenshot must contain ${notification.width}x${notification.height} RGB888 pixels (received ${notification.image.length} bytes)`,
+            );
+          }
+        } else if (!isUsablePngFrame(notification)) {
+          return;
         }
+        // The protobuf decoder supplies a view of the owned message buffer.
+        // Keep it intact through the existing latest-frame/encoder pipeline.
+        options.consume(notification, source, receivedAtMs);
       },
       recordRawPacingEvent(event, detail) {
         options.diagnostics.recordGrpcMessage(event, detail);
@@ -2272,8 +2293,13 @@ export async function startGrpcSession(
       await runtime.wakeDevice(serial, lifetime.signal);
       await runtime.sleep(100, lifetime.signal);
     }
+    // Native geometry probes never enter the encoder. Keep RGB888 probes
+    // in-band too; inactivity probes reuse transport.streamFormat below.
+    const probeFormat = {
+      format: imageMode === "rgb888" ? IMG_FORMAT_RGB888 : IMG_FORMAT_PNG,
+    };
     let probe = await client.getScreenshot(
-      { format: IMG_FORMAT_PNG },
+      probeFormat,
       lifetime.signal,
     );
     if (probe.width <= 0 || probe.height <= 0) {
@@ -2285,7 +2311,7 @@ export async function startGrpcSession(
       ) {
         await runtime.sleep(100, lifetime.signal);
         probe = await client.getScreenshot(
-          { format: IMG_FORMAT_PNG },
+          probeFormat,
           lifetime.signal,
         );
       }
@@ -2303,7 +2329,7 @@ export async function startGrpcSession(
       initialDisplaySizeSignal,
       readDisplaySizeSignal: (signal) => readDisplaySizeSignal(serial, signal),
       readNativeImage: (signal) =>
-        client.getScreenshot({ format: IMG_FORMAT_PNG }, signal),
+        client.getScreenshot(probeFormat, signal),
       onNativeSize: (size) => {
         nativeTouchSize = size;
       },
@@ -2354,7 +2380,7 @@ export async function startGrpcSession(
       consume: onImage,
       onError: (error) =>
         emitFatal({
-          message: `emulator MMAP screenshot failed: ${error instanceof Error ? error.message : String(error)}`,
+          message: `emulator ${imageMode} screenshot failed: ${error instanceof Error ? error.message : String(error)}`,
           code: "grpc-stream-error",
         }),
     });

--- a/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
+++ b/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
@@ -99,7 +99,7 @@ export function isInputSource(value: unknown): value is InputSource {
 }
 
 /** Exact image delivery mode used by the emulator gRPC screenshot source. */
-export const GRPC_IMAGE_MODES = ["png", "mmap"] as const;
+export const GRPC_IMAGE_MODES = ["png", "mmap", "rgb888"] as const;
 export type GrpcImageMode = (typeof GRPC_IMAGE_MODES)[number];
 export const DEFAULT_GRPC_IMAGE_MODE: GrpcImageMode = "png";
 export function isGrpcImageMode(value: unknown): value is GrpcImageMode {
@@ -124,9 +124,9 @@ export type GrpcCaptureDiagnostics = {
   imageMode: GrpcImageMode;
   /** Raw framed protobuf messages received before either pacing stage. */
   rawGrpcMessagesReceived: number;
-  /** PNG messages decoded by the raw pacer, or MMAP notifications selected for a snapshot. */
+  /** In-band messages decoded by the raw pacer, or MMAP notifications selected for a snapshot. */
   rawGrpcMessagesEmitted: number;
-  /** PNG messages replaced by a newer one, or MMAP notifications dropped/replaced by pacing. */
+  /** In-band messages replaced by a newer one, or MMAP notifications dropped/replaced by pacing. */
   rawGrpcMessagesCoalesced: number;
   /** Complete PNG or RGB images made available to the encoder. */
   usableImages: number;

--- a/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
+++ b/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
@@ -41,6 +41,10 @@ const GRPC_IMAGE_MODE_COPY = {
     label: "PNG",
     description: "Compressed in-band images",
   },
+  rgb888: {
+    label: "RGB888",
+    description: "Raw pixels over gRPC",
+  },
   mmap: {
     label: "MMAP",
     description: "Shared-memory raw pixels",
@@ -375,8 +379,10 @@ export function StreamModePanel() {
         ? "gRPC screenshot is available only for Android Emulator devices."
         : loaded.mode === "grpc-screenshot"
           ? loaded.grpcImageMode === "mmap"
-            ? "Frames use the emulator's shared-memory MMAP path; input uses gRPC."
-            : "Frames use in-band PNG images; input uses gRPC."
+            ? `Frames use the emulator's shared-memory MMAP path; input uses ${loaded.inputSource}.`
+            : loaded.grpcImageMode === "rgb888"
+              ? `Frames use raw RGB888 pixels over gRPC; input uses ${loaded.inputSource}.`
+              : `Frames use in-band PNG images; input uses ${loaded.inputSource}.`
           : "Frames and input use the scrcpy server on the device.";
 
   return (

--- a/packages/serve-emu/packages/serve-emu/tests/api-contracts.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/api-contracts.test.ts
@@ -78,6 +78,10 @@ describe("API contracts", () => {
   test("recognizes only explicit gRPC image modes", () => {
     expect(isGrpcImageMode("png")).toBe(true);
     expect(isGrpcImageMode("mmap")).toBe(true);
+    expect(isGrpcImageMode("rgb888")).toBe(true);
+    expect(parseStreamModeRequest({ mode: "grpc-screenshot", grpcImageMode: "rgb888" })).toEqual({
+      mode: "grpc-screenshot", grpcImageMode: "rgb888",
+    });
     expect(isGrpcImageMode("auto")).toBe(false);
     expect(isGrpcImageMode(null)).toBe(false);
   });

--- a/packages/serve-emu/packages/serve-emu/tests/cli-image-mode.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/cli-image-mode.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+async function runCli(...args: string[]) {
+  const proc = Bun.spawn(
+    [
+      process.execPath,
+      new URL("../src/cli.ts", import.meta.url).pathname,
+      ...args,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, code };
+}
+
+describe("CLI gRPC image modes", () => {
+  test("documents RGB888 while retaining the PNG default", async () => {
+    const result = await runCli("--help");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("--grpc-image-mode <png|mmap|rgb888>");
+    expect(result.stdout).toContain("default: png");
+    expect(result.stdout).toContain("RGB888 sends raw pixels over gRPC");
+  });
+
+  test.each(["png", "mmap", "rgb888"])(
+    "accepts %s before validating encoder options",
+    async (mode) => {
+      // An explicit serial bypasses discovery; invalid max-size stops before
+      // opening a capture session, so this runs without adb or an emulator.
+      const result = await runCli(
+        "--serial",
+        "emulator-test",
+        "--stream-mode",
+        "grpc-screenshot",
+        "--grpc-image-mode",
+        mode,
+        "--max-size",
+        "invalid",
+      );
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("--max-size");
+      expect(result.stderr).not.toContain("--grpc-image-mode must be");
+    },
+  );
+
+  test("rejects unsupported image modes before opening capture", async () => {
+    const result = await runCli("--grpc-image-mode", "rgb");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      "--grpc-image-mode must be one of: png, mmap, rgb888",
+    );
+  });
+});

--- a/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
@@ -366,8 +366,14 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
       0x0a, 0x06, 0x08, 0x02, 0x18, 0x02, 0x20, 0x01, 0x22, 0x06, 1, 2, 3, 4, 5,
       6,
     ]);
+    const requests: Buffer[] = [];
+    const payloadBytes: number[] = [];
+    const decodeBytes: number[] = [];
     const server = http2.createServer();
     server.on("stream", (stream: ServerHttp2Stream, headers) => {
+      const chunks: Buffer[] = [];
+      stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream.on("end", () => requests.push(Buffer.concat(chunks)));
       stream.respond({
         ":status": 200,
         "content-type": "application/grpc",
@@ -381,9 +387,7 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
         stream.write(grpcFrame(imageBody));
       }
     });
-    await new Promise<void>((resolve) =>
-      server.listen(0, "127.0.0.1", resolve),
-    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
     const address = server.address();
     if (!address || typeof address === "string")
       throw new Error("missing test port");
@@ -397,17 +401,29 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
 
     try {
       await client.streamScreenshot(
-        { format: 2 },
+        { format: IMG_FORMAT_RGB888, width: 720, height: 720 },
         (image, source) => {
           images.push(image);
           sources.push(source);
           if (images.length === 2) controller.abort();
         },
         controller.signal,
-        { maxFps: 60 },
+        {
+          maxFps: 60,
+          onPacingEvent: (event, detail) => {
+            if (event === "received") payloadBytes.push(detail.messageBytes);
+          },
+          onDecode: (event) => decodeBytes.push(event.messageBytes),
+        },
       );
       expect(images).toHaveLength(2);
       expect(sources).toEqual(["stream", "probe"]);
+      const expectedRequest = grpcFrame(
+        Buffer.from([0x08, 0x02, 0x18, 0xd0, 0x05, 0x20, 0xd0, 0x05]),
+      );
+      expect(requests).toEqual([expectedRequest, expectedRequest]);
+      expect(payloadBytes).toEqual([imageBody.length]);
+      expect(decodeBytes).toEqual([imageBody.length]);
     } finally {
       client.close();
       await new Promise<void>((resolve, reject) =>
@@ -415,9 +431,20 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
       );
     }
   });
+
+
 });
 
 describe("emulator image protobuf", () => {
+  test("encodes RGB888 dimensions without a transport and preserves native-size zeros", () => {
+    expect(
+      encodeImageFormat({ format: IMG_FORMAT_RGB888, width: 720, height: 720 }),
+    ).toEqual(Buffer.from([0x08, 0x02, 0x18, 0xd0, 0x05, 0x20, 0xd0, 0x05]));
+    expect(
+      encodeImageFormat({ format: IMG_FORMAT_RGB888, width: 0, height: 0 }),
+    ).toEqual(Buffer.from([0x08, 0x02]));
+  });
+
   test("encodes ImageFormat.transport field 6 with an MMAP file handle", () => {
     expect(
       encodeImageFormat({

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -30,6 +30,7 @@ import {
   IMG_FORMAT_PNG,
   IMG_FORMAT_RGB888,
   type EmuImage,
+  type ImageFormatRequest,
   type GrpcScreenshotImageSource,
   type KeyboardEventRequest,
 } from "../src/emulator-grpc.ts";
@@ -245,6 +246,12 @@ describe("gRPC screenshot session helpers", () => {
     expect(pngBehavior.needsEncoderFollowUp(false, true)).toBe(true);
     expect(pngBehavior.needsEncoderFollowUp(true, false)).toBe(true);
     expect(pngBehavior.needsEncoderFollowUp(true, true)).toBe(false);
+
+    const rgbBehavior = grpcImageModeBehavior("rgb888", 24);
+    expect(rgbBehavior.encoderInputFormat).toBe("rgb24");
+    expect(rgbBehavior.predecodeMaxFps).toBe(24);
+    expect(rgbBehavior.needsEncoderFollowUp(false, true)).toBe(true);
+    expect(rgbBehavior.needsEncoderFollowUp(true, false)).toBe(false);
 
     const mmapBehavior = grpcImageModeBehavior("mmap", 60);
     expect(mmapBehavior.encoderInputFormat).toBe("rgb24");
@@ -1032,12 +1039,17 @@ class FakeGrpcClient implements GrpcSessionClient {
     readonly emitInitialStreamImage = true,
   ) {}
 
-  async getScreenshot(): Promise<EmuImage> {
+  readonly probeFormats: ImageFormatRequest[] = [];
+  streamFormat: ImageFormatRequest | null = null;
+  streamMaxFps: number | undefined;
+
+  async getScreenshot(format: ImageFormatRequest): Promise<EmuImage> {
+    this.probeFormats.push(format);
     return this.probe;
   }
 
   streamScreenshot(
-    _format: unknown,
+    format: ImageFormatRequest,
     onImage: (
       image: EmuImage,
       source: GrpcScreenshotImageSource,
@@ -1049,6 +1061,8 @@ class FakeGrpcClient implements GrpcSessionClient {
       onPacingEvent?: (event: "received" | "emitted" | "coalesced") => void;
     },
   ): Promise<void> {
+    this.streamFormat = format;
+    this.streamMaxFps = _options?.maxFps;
     this.streamImage = onImage;
     if (this.emitInitialStreamImage) onImage(this.probe, "stream", Date.now());
     return new Promise((resolve) => {
@@ -1082,6 +1096,7 @@ class FakeGrpcEncoder implements GrpcSessionEncoder {
   readonly quarterTurn: QuarterTurn;
   closed = false;
   writes = 0;
+  lastBuffer: Buffer | null = null;
   acceptedWrites = 0;
   #published = false;
 
@@ -1099,6 +1114,7 @@ class FakeGrpcEncoder implements GrpcSessionEncoder {
 
   write(_rgb: Buffer, _ptsUs: bigint): boolean {
     this.writes++;
+    this.lastBuffer = _rgb;
     const accepted = this.behavior.writeResults?.shift() ?? true;
     if (!accepted) return false;
     this.acceptedWrites++;
@@ -1166,6 +1182,196 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("startGrpcSession integration", () => {
+  test.each([0, 8, 1280])(
+    "streams in-band RGB888 at maxSize=%s with rgb24 input and no MMAP",
+    async (maxSize) => {
+      const rgb = {
+        ...integrationImage(),
+        format: IMG_FORMAT_RGB888,
+        image: Buffer.alloc(4 * 6 * 3, 123),
+      };
+      const client = new FakeGrpcClient(rgb);
+      const encoders: FakeGrpcEncoder[] = [];
+      const parent = new AbortController();
+      const session = await startGrpcSession(
+        {
+          serial: "emulator-5554",
+          mode: "grpc-screenshot",
+          grpcImageMode: "rgb888",
+          inputSource: "grpc",
+          maxSize,
+          maxFps: 24,
+          signal: parent.signal,
+        },
+        {
+          readDisplaySizeSignal: async () => "physical:4x6",
+          runtime: integrationRuntime(client, encoders),
+        },
+      );
+      try {
+        expect(client.probeFormats).toEqual([{ format: IMG_FORMAT_RGB888 }]);
+        expect(client.streamFormat).toEqual({
+          format: IMG_FORMAT_RGB888,
+          width: maxSize,
+          height: maxSize,
+        });
+        expect(client.streamMaxFps).toBe(24);
+        expect(encoders[0]!.options).toMatchObject({
+          width: 4,
+          height: 6,
+          inputFormat: "rgb24",
+          quarterTurn: 0,
+        });
+        expect(encoders[0]!.lastBuffer).toBe(rgb.image);
+        expect(session.diagnostics!().grpcCapture).toMatchObject({
+          imageMode: "rgb888",
+          usableImages: 1,
+          transportBytes: 72,
+          imagePayloadBytes: 72,
+          mmapFileBytesRead: 0,
+          mmapReadRetries: 0,
+          mmapTornFramesDropped: 0,
+          sharedReadCopyTimeMs: null,
+        });
+        // Already oriented images must not be rotated again, including 180 degrees.
+        client.streamImage!({ ...rgb, rotation: 2 }, "stream", Date.now());
+        expect(encoders).toHaveLength(1);
+        const landscape = {
+          ...rgb,
+          rotation: 1,
+          width: 6,
+          height: 4,
+          image: Buffer.alloc(72, 42),
+        };
+        client.streamImage!(landscape, "stream", Date.now());
+        await waitFor(() => encoders.length === 2);
+        expect(encoders[0]!.closed).toBe(true);
+        expect(encoders[1]!.options).toMatchObject({
+          width: 6,
+          height: 4,
+          quarterTurn: 0,
+          inputFormat: "rgb24",
+        });
+        await waitFor(() => encoders[1]!.lastBuffer === landscape.image);
+        expect(session.meta).toMatchObject({ width: 6, height: 4 });
+        // A native-size display can grow; no startup-sized shared region constrains it.
+        if (maxSize === 0) {
+          const larger = {
+            ...rgb,
+            width: 8,
+            height: 10,
+            image: Buffer.alloc(240),
+          };
+          client.streamImage!(larger, "probe", Date.now());
+          await waitFor(() => encoders.length === 3);
+          await waitFor(() => encoders[2]!.lastBuffer === larger.image);
+          expect(session.meta).toMatchObject({ width: 8, height: 10 });
+        }
+        parent.abort();
+        await session.close();
+        const writes = encoders.map((encoder) => encoder.writes);
+        client.streamImage!(rgb, "stream", Date.now());
+        expect(encoders.map((encoder) => encoder.writes)).toEqual(writes);
+        expect(encoders.every((encoder) => encoder.closed)).toBe(true);
+        expect(client.closed).toBe(true);
+      } finally {
+        await session.close();
+      }
+    },
+  );
+
+  test("ignores RGB888 inactivity markers and rejects malformed stream and fallback images", async () => {
+    const rgb = {
+      ...integrationImage(),
+      format: IMG_FORMAT_RGB888,
+      image: Buffer.alloc(72),
+    };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554",
+        mode: "grpc-screenshot",
+        grpcImageMode: "rgb888",
+        inputSource: "grpc",
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: integrationRuntime(client, encoders),
+      },
+    );
+    try {
+      client.streamImage!(
+        { ...rgb, width: 0, height: 0, image: Buffer.alloc(0) },
+        "stream",
+        Date.now(),
+      );
+      expect(session.diagnostics!().grpcCapture!.usableImages).toBe(1);
+      for (const invalid of [
+        { ...rgb, image: Buffer.alloc(71) },
+        { ...rgb, image: Buffer.alloc(73) },
+        { ...rgb, image: Buffer.alloc(0) },
+        { ...rgb, format: IMG_FORMAT_PNG },
+        { ...rgb, width: 0 },
+        { ...rgb, width: -1 },
+        { ...rgb, width: 1.5 },
+        { ...rgb, width: 16_385 },
+        { ...rgb, height: Number.NaN },
+      ]) {
+        for (const source of ["stream", "probe"] as const) {
+          expect(() => client.streamImage!(invalid, source, Date.now())).toThrow(
+            "RGB888 screenshot must contain",
+          );
+        }
+      }
+      expect(session.diagnostics!().grpcCapture!.usableImages).toBe(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("keeps only the latest RGB888 frame during encoder backpressure", async () => {
+    const rgb = {
+      ...integrationImage(),
+      format: IMG_FORMAT_RGB888,
+      image: Buffer.alloc(72),
+    };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const behavior = { writeResults: [true] };
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554",
+        mode: "grpc-screenshot",
+        grpcImageMode: "rgb888",
+        inputSource: "grpc",
+        maxFps: 60,
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: integrationRuntime(client, encoders, behavior),
+      },
+    );
+    try {
+      behavior.writeResults.push(false, false, true);
+      let newest = rgb;
+      for (let seq = 2; seq < 102; seq++) {
+        newest = { ...rgb, seq, image: Buffer.alloc(72, seq) };
+        client.streamImage!(newest, "stream", Date.now());
+      }
+      await waitFor(() => encoders[0]!.acceptedWrites === 2);
+      expect(encoders[0]!.lastBuffer).toBe(newest.image);
+      expect(encoders[0]!.writes).toBe(4);
+      expect(session.diagnostics!().grpcCapture).toMatchObject({
+        usableImages: 101,
+        acceptedEncoderWrites: 2,
+        encoderBackpressureRejections: 2,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   test("routes controls through a control-only scrcpy session", async () => {
     const client = new FakeGrpcClient(integrationImage());
     const encoders: FakeGrpcEncoder[] = [];

--- a/packages/serve-emu/packages/serve-emu/tests/middleware-create-app.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/middleware-create-app.test.ts
@@ -488,19 +488,20 @@ test("reports configured source settings and rolling encoded-frame timing", asyn
   }
 });
 
-test("includes optional gRPC session capture diagnostics in WebRTC stats", async () => {
+test.each(["mmap", "rgb888"] as const)("includes %s session capture diagnostics in WebRTC stats", async (imageMode) => {
+  const diagnostics = { ...GRPC_CAPTURE_DIAGNOSTICS, imageMode };
   const { session, drained } = fakeScrcpySession(1);
   const adapted = adaptScrcpySession(session);
   const grpcSession: EmuSession = {
     ...adapted,
     mode: "grpc-screenshot",
-    diagnostics: () => ({ grpcCapture: GRPC_CAPTURE_DIAGNOSTICS }),
+    diagnostics: () => ({ grpcCapture: diagnostics }),
   };
   const app = await createApp(
     {
       serial: session.serial,
       streamMode: "grpc-screenshot",
-      grpcImageMode: "mmap",
+      grpcImageMode: imageMode,
       streamSettings: {
         transport: "webrtc",
         codec: "h264",
@@ -519,11 +520,11 @@ test("includes optional gRPC session capture diagnostics in WebRTC stats", async
     await drained;
     expect(app.health()).toMatchObject({
       streamMode: "grpc-screenshot",
-      grpcImageMode: "mmap",
-      grpcCapture: GRPC_CAPTURE_DIAGNOSTICS,
+      grpcImageMode: imageMode,
+      grpcCapture: diagnostics,
     });
     expect(app.webRtcStats(SESSION_ID)).toMatchObject({
-      capture: { grpc: GRPC_CAPTURE_DIAGNOSTICS },
+      capture: { grpc: diagnostics },
     });
   } finally {
     await app.stop();

--- a/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
@@ -821,16 +821,17 @@ describe("createRouter stream mode", () => {
   });
 
   test("atomically replaces gRPC capture when its explicit image mode changes", async () => {
+    let failRgb888 = true;
     const opened: Array<{ mode: StreamMode; grpcImageMode: string }> = [];
     const router = createRouter(
       { serial: "emulator-5554" },
       {
-        listDevices: async () => [
-          { serial: "emulator-5554", state: "device" },
-        ],
+        listDevices: async () => [{ serial: "emulator-5554", state: "device" }],
         createApp: (options) =>
           createApp(options, {
             startSession: async ({ mode, grpcImageMode }) => {
+              if (failRgb888 && grpcImageMode === "rgb888")
+                throw new Error("RGB888 startup failed");
               opened.push({ mode, grpcImageMode });
               return liveStreamSession(mode);
             },
@@ -838,9 +839,7 @@ describe("createRouter stream mode", () => {
       },
     );
 
-    await router.handleRequest(
-      new Request("http://router.test/api/stream-mode"),
-    );
+    await router.handleRequest(new Request("http://router.test/api/stream-mode"));
     const mmap = await router.handleRequest(
       put("/api/stream-mode", {
         mode: "grpc-screenshot",
@@ -853,6 +852,63 @@ describe("createRouter stream mode", () => {
       sessionGeneration: 1,
     });
 
+    const failedRgb888 = await router.handleRequest(
+      put("/api/stream-mode", {
+        mode: "grpc-screenshot",
+        grpcImageMode: "rgb888",
+      }),
+    );
+    expect(failedRgb888.status).toBe(503);
+    expect(await failedRgb888.json()).toMatchObject({
+      error: { message: "RGB888 startup failed" },
+    });
+    expect(
+      await (
+        await router.handleRequest(
+          new Request("http://router.test/api/stream-mode"),
+        )
+      ).json(),
+    ).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "mmap",
+      sessionGeneration: 1,
+    });
+    failRgb888 = false;
+
+    const rgb888 = await router.handleRequest(
+      put("/api/stream-mode", {
+        mode: "grpc-screenshot",
+        grpcImageMode: "rgb888",
+      }),
+    );
+    expect(rgb888.status).toBe(200);
+    expect(await rgb888.json()).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+    expect(
+      await (
+        await router.handleRequest(
+          new Request("http://router.test/api/stream-mode"),
+        )
+      ).json(),
+    ).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+    const unchanged = await router.handleRequest(
+      put("/api/stream-mode", {
+        mode: "grpc-screenshot",
+        grpcImageMode: "rgb888",
+      }),
+    );
+    expect(await unchanged.json()).toMatchObject({
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+
     const png = await router.handleRequest(
       put("/api/stream-mode", {
         mode: "grpc-screenshot",
@@ -862,11 +918,12 @@ describe("createRouter stream mode", () => {
     expect(await responseJson(png)).toMatchObject({
       mode: "grpc-screenshot",
       grpcImageMode: "png",
-      sessionGeneration: 2,
+      sessionGeneration: 3,
     });
     expect(opened).toEqual([
       { mode: "scrcpy", grpcImageMode: "png" },
       { mode: "grpc-screenshot", grpcImageMode: "mmap" },
+      { mode: "grpc-screenshot", grpcImageMode: "rgb888" },
       { mode: "grpc-screenshot", grpcImageMode: "png" },
     ]);
 
@@ -884,7 +941,7 @@ describe("createRouter stream mode", () => {
         message: "stream mode request.grpcImageMode is invalid",
       },
     });
-    expect(opened).toHaveLength(3);
+    expect(opened).toHaveLength(4);
 
     await router.stopAll();
   });

--- a/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
@@ -352,49 +352,49 @@ describe("server stream source switching", () => {
     expect(openCalls).toBe(0);
   });
 
-  test("passes the configured initial gRPC image mode to capture", async () => {
-    const opened: Array<{
-      mode: StreamMode;
-      grpcImageMode: GrpcImageMode;
-    }> = [];
-    const capture = fakeSession(
-      "emulator-5554",
-      "grpc-screenshot",
-      "mmap",
-    );
-    const captured: CapturedServer = { options: null };
-    const started = await startServer(
-      {
-        serial: "emulator-5554",
-        port: 3300,
-        streamMode: "grpc-screenshot",
-        grpcImageMode: "mmap",
-      },
-      {
-        openSession: async ({ mode, grpcImageMode }) => {
-          opened.push({ mode, grpcImageMode });
-          return capture.session;
+  test.each(["mmap", "rgb888"] as const)(
+    "passes the configured initial gRPC image mode to capture",
+    async (imageMode) => {
+      const opened: Array<{
+        mode: StreamMode;
+        grpcImageMode: GrpcImageMode;
+      }> = [];
+      const capture = fakeSession("emulator-5554", "grpc-screenshot", imageMode);
+      const captured: CapturedServer = { options: null };
+      const started = await startServer(
+        {
+          serial: "emulator-5554",
+          port: 3300,
+          streamMode: "grpc-screenshot",
+          grpcImageMode: imageMode,
         },
-        serve: capturingServe(captured),
-      },
-    );
+        {
+          openSession: async ({ mode, grpcImageMode }) => {
+            opened.push({ mode, grpcImageMode });
+            return capture.session;
+          },
+          serve: capturingServe(captured),
+        },
+      );
 
-    expect(opened).toEqual([
-      { mode: "grpc-screenshot", grpcImageMode: "mmap" },
-    ]);
-    expect(
-      await (await request(captured, "/api/stream-mode")).json(),
-    ).toMatchObject({
-      mode: "grpc-screenshot",
-      grpcImageMode: "mmap",
-    });
-    expect(await (await request(captured, "/health")).json()).toMatchObject({
-      streamMode: "grpc-screenshot",
-      grpcImageMode: "mmap",
-      grpcCapture: { imageMode: "mmap", usableImages: 0 },
-    });
-    await started.stop();
-  });
+      expect(opened).toEqual([
+        { mode: "grpc-screenshot", grpcImageMode: imageMode },
+      ]);
+      expect(
+        await (await request(captured, "/api/stream-mode")).json(),
+      ).toMatchObject({
+        mode: "grpc-screenshot",
+        grpcImageMode: imageMode,
+      });
+      expect(await (await request(captured, "/health")).json()).toMatchObject({
+        streamMode: "grpc-screenshot",
+        grpcImageMode: imageMode,
+        grpcCapture: { imageMode: imageMode, usableImages: 0 },
+      });
+      await started.stop();
+    },
+  );
+
 
   test("switches gRPC input atomically and preserves it through an encoder restart", async () => {
     const opened: Array<{
@@ -571,12 +571,14 @@ describe("server stream source switching", () => {
   });
 
   test("atomically applies an explicit gRPC image mode without fallback", async () => {
+    let failRgb888 = true;
     const opened: Array<{
       mode: StreamMode;
       grpcImageMode: GrpcImageMode;
     }> = [];
     const captures = [
       fakeSession("emulator-5554", "scrcpy"),
+      fakeSession("emulator-5554", "grpc-screenshot", "rgb888"),
       fakeSession("emulator-5554", "grpc-screenshot"),
       fakeSession("emulator-5554", "grpc-screenshot"),
     ];
@@ -585,6 +587,8 @@ describe("server stream source switching", () => {
       { serial: "emulator-5554", port: 3300 },
       {
         openSession: async ({ mode, grpcImageMode }) => {
+          if (failRgb888 && grpcImageMode === "rgb888")
+            throw new Error("RGB888 startup failed");
           opened.push({ mode, grpcImageMode });
           const capture = captures[opened.length - 1];
           if (!capture) throw new Error("unexpected capture start");
@@ -594,11 +598,7 @@ describe("server stream source switching", () => {
       },
     );
 
-    const mmap = await putMode(
-      captured,
-      "grpc-screenshot",
-      "mmap",
-    );
+    const mmap = await putMode(captured, "grpc-screenshot", "mmap");
     expect(mmap.status).toBe(200);
     expect(await mmap.json()).toMatchObject({
       mode: "grpc-screenshot",
@@ -606,20 +606,56 @@ describe("server stream source switching", () => {
       sessionGeneration: 1,
     });
 
+    const failedRgb888 = await putMode(captured, "grpc-screenshot", "rgb888");
+    expect(failedRgb888.status).toBe(503);
+    expect(await failedRgb888.json()).toMatchObject({
+      error: { message: "RGB888 startup failed" },
+    });
+    expect(
+      await (await request(captured, "/api/stream-mode")).json(),
+    ).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "mmap",
+      sessionGeneration: 1,
+    });
+    failRgb888 = false;
+
+    const rgb888 = await putMode(captured, "grpc-screenshot", "rgb888");
+    expect(rgb888.status).toBe(200);
+    expect(await rgb888.json()).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+    expect(
+      await (await request(captured, "/api/stream-mode")).json(),
+    ).toMatchObject({
+      mode: "grpc-screenshot",
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+    const unchanged = await putMode(captured, "grpc-screenshot", "rgb888");
+    expect(await unchanged.json()).toMatchObject({
+      grpcImageMode: "rgb888",
+      sessionGeneration: 2,
+    });
+
     const png = await putMode(captured, "grpc-screenshot", "png");
     expect(png.status).toBe(200);
     expect(await png.json()).toMatchObject({
       mode: "grpc-screenshot",
       grpcImageMode: "png",
-      sessionGeneration: 2,
+      sessionGeneration: 3,
     });
     expect(opened).toEqual([
       { mode: "scrcpy", grpcImageMode: "png" },
       { mode: "grpc-screenshot", grpcImageMode: "mmap" },
+      { mode: "grpc-screenshot", grpcImageMode: "rgb888" },
       { mode: "grpc-screenshot", grpcImageMode: "png" },
     ]);
     expect(captures[0]?.closeCalls()).toBe(1);
     expect(captures[1]?.closeCalls()).toBe(1);
+    expect(captures[2]?.closeCalls()).toBe(1);
 
     const invalid = await request(captured, "/api/stream-mode", {
       method: "PUT",
@@ -637,10 +673,10 @@ describe("server stream source switching", () => {
         message: "stream mode request.grpcImageMode is invalid",
       },
     });
-    expect(opened).toHaveLength(3);
+    expect(opened).toHaveLength(4);
 
     await started.stop();
-    expect(captures[2]?.closeCalls()).toBe(1);
+    expect(captures[3]?.closeCalls()).toBe(1);
   });
 
   test("reports the image mode paired with a newly published context while the old context drains", async () => {

--- a/packages/serve-emu/packages/serve-emu/tests/stream-mode-panel.test.tsx
+++ b/packages/serve-emu/packages/serve-emu/tests/stream-mode-panel.test.tsx
@@ -122,7 +122,7 @@ describe("StreamModePanel", () => {
     expect(errorMarkup).toContain("WebRTC unavailable");
   });
 
-  test("renders an accessible explicit PNG/MMAP selector for the gRPC source", () => {
+  test("renders an accessible explicit PNG/MMAP/RGB888 selector for the gRPC source", () => {
     const markup = renderToStaticMarkup(
       <GrpcImageModeSelector
         value="mmap"
@@ -133,7 +133,7 @@ describe("StreamModePanel", () => {
 
     expect(markup).toContain("<legend>gRPC image mode</legend>");
     expect(markup).toContain('aria-describedby="stream-mode-help"');
-    expect(markup.match(/name="grpc-image-mode"/g)?.length).toBe(2);
+    expect(markup.match(/name="grpc-image-mode"/g)?.length).toBe(3);
     expect(markup).toContain('value="png"');
     expect(markup).toContain('checked="" value="mmap"');
     expect(markup).toContain("Compressed in-band images");
@@ -150,4 +150,32 @@ describe("StreamModePanel", () => {
     expect(disabledMarkup).toContain("<fieldset");
     expect(disabledMarkup).toContain("disabled=\"\"");
   });
+});
+
+test("renders RGB888 applied and disabled during a pending change", () => {
+  for (const disabled of [false, true]) {
+    const markup = renderToStaticMarkup(
+      <GrpcImageModeSelector
+        value="rgb888"
+        disabled={disabled}
+        onChange={() => {}}
+      />,
+    );
+    expect(markup).toContain('checked="" value="rgb888"');
+    expect(markup).toContain("Raw pixels over gRPC");
+    expect(markup.includes('disabled=""')).toBe(disabled);
+  }
+  let selected: string | undefined;
+  const selector = GrpcImageModeSelector({
+    value: "png",
+    disabled: false,
+    onChange: (mode) => {
+      selected = mode;
+    },
+  });
+  const options = selector.props.children[1].props.children;
+  options
+    .find((option: { key: string }) => option.key === "rgb888")
+    .props.children[0].props.onChange();
+  expect(selected).toBe("rgb888");
 });

--- a/packages/serve-emu/packages/serve-emu/tests/stream-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/stream-session.test.ts
@@ -39,11 +39,11 @@ function fakeScrcpy(
 }
 
 describe("stream session", () => {
-  test("rejects strict gRPC selection for physical devices", async () => {
+  test.each(["png", "mmap", "rgb888"] as const)("rejects strict %s gRPC selection for physical devices", async (grpcImageMode) => {
     await expect(
       startEmuSession({
         mode: "grpc-screenshot",
-        grpcImageMode: "png",
+        grpcImageMode,
         inputSource: "grpc",
         serial: "physical-device",
       }),


### PR DESCRIPTION
Adds RGB888 as a separate Android gRPC image option in Device Hub's standalone CLI, programmatic options, shared dashboard selector, API-state parsing, and capture diagnostics. It uses the existing `grpc-screenshot` source and keeps MMAP as the Hub default.

Includes the capture implementation, tests, UI, and documentation from https://github.com/expo/serve-emu/pull/27 directly in the monorepo under `packages/serve-emu`. Based on the serve-emu migration in #78; no serve-emu submodule or separate capture PR is required to merge this change. RGB888 pixels arrive inside each gRPC response and feed the encoder as `rgb24`, with no MMAP reads or PNG conversion in the continuous stream. Emulator GPU-to-CPU readback still occurs, with no zero-copy or performance-improvement claim.

```sh
npx expo-device-hub --transport webrtc --stream-source grpc-screenshot --grpc-image-mode rgb888
```

Runtime selection uses the existing device-scoped `PUT /vendor/serve-emu/api/stream-mode` endpoint with:

```json
{ "mode": "grpc-screenshot", "grpcImageMode": "rgb888" }
```

The shared selector retains its applied value while capture restarts, disables pending controls, and preserves error rendering. It adds the RGB888 choice without an extra descriptive note and removes the switching submessage. Documentation explains the incoming gRPC counter, local frame selection, encoder repeats, and MMAP inactivity probes.

Validation:

- Monorepo `bun run test` passed: 1,477 tests, including 931 serve-emu tests and 546 Device Hub/UI tests.
- `bun run typecheck`, `bun run lint`, and `bun run build` passed.
- `bun run --filter serve-emu check` passed on the monorepo layout (931 tests plus typechecks, builds, docs and package checks), including standalone/embedded API switching, RGB888 validation and encoder input, rotation, cleanup, and PNG/MMAP regressions.
- Live emulator: switched image modes through the Hub UI and verified WebRTC reconnection. Receive-only measurements counted complete gRPC messages before decoding/selection; those measurements used lavapipe software rendering. A subsequent `-gpu host` restart was verified separately and is not presented as a performance comparison.

Authored with Codex (GPT-6).

