### PR TITLE
Fix delayed RGB888 playback at lower video FPS

### DIFF
--- a/.changeset/rgb888-encoder-fps.md
+++ b/.changeset/rgb888-encoder-fps.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Keep RGB888 video current when its source produces frames faster than the configured video FPS. Drain gRPC responses continuously and submit the newest image at the encoder's configured rate instead of pacing reception.

--- a/.changeset/rgb888-encoder-fps.md
+++ b/.changeset/rgb888-encoder-fps.md
@@ -1,5 +1,0 @@
----
-'expo-device-hub': patch
----
-
-Keep RGB888 video current when its source produces frames faster than the configured video FPS. Drain gRPC responses continuously and submit the newest image at the encoder's configured rate instead of pacing reception.

--- a/packages/@expo/hub-components/src/dashboard/StreamStatistics.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamStatistics.tsx
@@ -319,11 +319,15 @@ export function StreamStatistics({
                     value: formatCount(grpc.messagesReceived),
                   },
                   {
-                    label: 'Selected notifications',
+                    label: grpc.imageMode === 'rgb888'
+                      ? 'Decoded responses'
+                      : 'Selected notifications',
                     value: formatCount(grpc.messagesEmitted),
                   },
                   {
-                    label: 'Coalesced notifications',
+                    label: grpc.imageMode === 'rgb888'
+                      ? 'Predecode coalescing'
+                      : 'Coalesced notifications',
                     value: formatCount(grpc.messagesCoalesced),
                   },
                   {

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -96,9 +96,11 @@ by the elapsed seconds within the same capture session. This counter increments
 when a complete gRPC response has been assembled, before protobuf decoding,
 MMAP reads, frame selection, and encoder writes. Count differences include idle
 time; the displayed **Host receive FPS** is an active-cadence estimate that can
-retain its last value while idle. RGB888's normal capture path also pauses the
-HTTP/2 stream for local pacing, so received response rate is not a measurement
-of every frame rendered internally by the emulator.
+retain its last value while idle. RGB888 continuously drains incoming gRPC
+responses and keeps only the newest image awaiting encoding. `--video-fps`
+limits fresh encoder submissions without slowing reception or queuing old
+images for playback. Received response rate measures delivered messages,
+which may differ from the emulator's internal rendering rate.
 
 MMAP uses gRPC metadata notifications to trigger selected shared-memory reads;
 it does not continuously poll the file. After the stream has delivered a message,

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -102,6 +102,15 @@ limits fresh encoder submissions without slowing reception or queuing old
 images for playback. Received response rate measures delivered messages,
 which may differ from the emulator's internal rendering rate.
 
+For RGB888, **Decoded responses** (`rawGrpcMessagesEmitted`) tracks every
+received stream response, and **Predecode coalescing**
+(`rawGrpcMessagesCoalesced`) stays zero. These counters describe delivery to
+protobuf decoding, not selection for the encoder. Images replaced in the
+latest-image slot before encoding are not counted as coalesced messages. Compare
+**Usable image FPS** with **Encoder input FPS** to see the reduction in fresh
+images submitted to the encoder; the latter excludes repeats. Their difference
+is a rolling cadence comparison, not an exact cumulative count of dropped images.
+
 MMAP uses gRPC metadata notifications to trigger selected shared-memory reads;
 it does not continuously poll the file. After the stream has delivered a message,
 10 seconds without another decoded stream message triggers a unary

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -801,10 +801,10 @@ test.each(['mmap', 'rgb888'] as const)('shows the %s producer-to-client pipeline
             producerFps: 60,
             receiveFps: 59.5,
             usableImageFps: 59,
-            encoderInputFps: 58.5,
+            encoderInputFps: 30,
             messagesReceived: 600,
-            messagesEmitted: 590,
-            messagesCoalesced: 10,
+            messagesEmitted: imageMode === 'rgb888' ? 600 : 590,
+            messagesCoalesced: imageMode === 'rgb888' ? 0 : 10,
             sequenceGaps: 2,
             imagePayloadBytes: 552_960,
             transportBytes: 55_296_000,
@@ -836,10 +836,17 @@ test.each(['mmap', 'rgb888'] as const)('shows the %s producer-to-client pipeline
   expect(streamStatisticValue(capture, 'Emulator producer FPS')).toBe('60 FPS');
   expect(streamStatisticValue(capture, 'Host receive FPS')).toBe('60 FPS');
   expect(streamStatisticValue(capture, 'Usable image FPS')).toBe('59 FPS');
-  expect(streamStatisticValue(capture, 'Encoder input FPS')).toBe('59 FPS');
+  expect(streamStatisticValue(capture, 'Encoder input FPS')).toBe('30 FPS');
   expect(streamStatisticValue(capture, 'gRPC notifications')).toBe('600');
-  expect(streamStatisticValue(capture, 'Selected notifications')).toBe('590');
-  expect(streamStatisticValue(capture, 'Coalesced notifications')).toBe('10');
+  if (imageMode === 'rgb888') {
+    expect(streamStatisticValue(capture, 'Decoded responses')).toBe('600');
+    expect(streamStatisticValue(capture, 'Predecode coalescing')).toBe('0');
+    expect(capture).not.toContain('Selected notifications');
+    expect(capture).not.toContain('Coalesced notifications');
+  } else {
+    expect(streamStatisticValue(capture, 'Selected notifications')).toBe('590');
+    expect(streamStatisticValue(capture, 'Coalesced notifications')).toBe('10');
+  }
   expect(streamStatisticValue(capture, 'Latest image payload')).toBe('540.0 KiB');
   expect(streamStatisticValue(capture, 'Produce→usable p50 / p95')).toBe('4.7 / 9.2 ms');
   if (imageMode === 'mmap') {

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -640,9 +640,13 @@ rotation or display resizing.
 
 This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
 texture sharing, zero-copy, or hardware encoding; speed depends on the workload
-and must be measured. A bounded gRPC message pacer and a single latest image
-preserve encoder backpressure. `--max-fps` paces local consumption and encoder
-submission; it does not impose a server-side screenshot FPS limit. Health
+and must be measured. RGB888 drains incoming gRPC responses continuously and
+retains only the latest image for the encoder. `--max-fps` limits fresh encoder
+submissions independently of incoming frame rate: excess images are replaced,
+so lowering encoded FPS does not queue old source frames for delayed playback.
+Encoder backpressure also retries the latest image. PNG retains its predecode
+message pacer; MMAP selects notifications before reading shared memory. None of
+these local limits impose a server-side screenshot FPS limit. Health
 reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -651,6 +651,13 @@ reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.
 
+For RGB888, `rawGrpcMessagesEmitted` counts responses passed to protobuf decoding
+and matches `rawGrpcMessagesReceived`; `rawGrpcMessagesCoalesced` stays zero.
+Those message counters exclude images replaced in the latest-image slot before
+encoding. Compare `usableImageFps` with `freshEncoderWriteFps` (which excludes
+repeats) to observe the local reduction before encoder submission. Their
+rolling-rate difference is not an exact cumulative dropped-image count.
+
 ```sh
 serve-emu -s emulator-5554 --stream-mode grpc-screenshot --grpc-image-mode rgb888
 curl -X PUT http://localhost:3300/api/stream-mode \

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -642,9 +642,13 @@ rotation or display resizing.
 
 This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
 texture sharing, zero-copy, or hardware encoding; speed depends on the workload
-and must be measured. A bounded gRPC message pacer and a single latest image
-preserve encoder backpressure. `--max-fps` paces local consumption and encoder
-submission; it does not impose a server-side screenshot FPS limit. Health
+and must be measured. RGB888 drains incoming gRPC responses continuously and
+retains only the latest image for the encoder. `--max-fps` limits fresh encoder
+submissions independently of incoming frame rate: excess images are replaced,
+so lowering encoded FPS does not queue old source frames for delayed playback.
+Encoder backpressure also retries the latest image. PNG retains its predecode
+message pacer; MMAP selects notifications before reading shared memory. None of
+these local limits impose a server-side screenshot FPS limit. Health
 reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -653,6 +653,13 @@ reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.
 
+For RGB888, `rawGrpcMessagesEmitted` counts responses passed to protobuf decoding
+and matches `rawGrpcMessagesReceived`; `rawGrpcMessagesCoalesced` stays zero.
+Those message counters exclude images replaced in the latest-image slot before
+encoding. Compare `usableImageFps` with `freshEncoderWriteFps` (which excludes
+repeats) to observe the local reduction before encoder submission. Their
+rolling-rate difference is not an exact cumulative dropped-image count.
+
 ```sh
 serve-emu -s emulator-5554 --stream-mode grpc-screenshot --grpc-image-mode rgb888
 curl -X PUT http://localhost:3300/api/stream-mode \

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -693,9 +693,11 @@ export function grpcImageModeBehavior(
   }
   return {
     encoderInputFormat: "rgb24",
-    // In-band RGB messages own their pixels and can use the same bounded
-    // predecode pacer as PNG. MMAP metadata must be decoded immediately.
-    predecodeMaxFps: imageMode === "rgb888" ? maxFps : undefined,
+    // Drain raw RGB responses independently of encoder FPS. Pausing HTTP/2
+    // queues old pixels upstream; onImage keeps only the newest frame and the
+    // encoder write pacer decides when to submit it. MMAP also drains metadata
+    // immediately, then selects which notifications trigger memory reads.
+    predecodeMaxFps: undefined,
     needsEncoderFollowUp: (repeat) => !repeat,
   };
 }

--- a/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
+++ b/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
@@ -124,9 +124,15 @@ export type GrpcCaptureDiagnostics = {
   imageMode: GrpcImageMode;
   /** Raw framed protobuf messages received before either pacing stage. */
   rawGrpcMessagesReceived: number;
-  /** In-band messages decoded by the raw pacer, or MMAP notifications selected for a snapshot. */
+  /**
+   * In-band messages passed to decoding, or MMAP notifications selected for a
+   * snapshot; not encoder submissions.
+   */
   rawGrpcMessagesEmitted: number;
-  /** In-band messages replaced by a newer one, or MMAP notifications dropped/replaced by pacing. */
+  /**
+   * Messages coalesced before decoding, or MMAP notifications skipped by pacing.
+   * Excludes usable images replaced before encoding. RGB888 leaves this at zero.
+   */
   rawGrpcMessagesCoalesced: number;
   /** Complete PNG or RGB images made available to the encoder. */
   usableImages: number;

--- a/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
@@ -16,14 +16,7 @@ import {
   parseEmulatorGrpcPort,
 } from "../src/emulator-grpc.ts";
 import type { ExecResult } from "../src/exec.ts";
-
-function grpcFrame(message: Buffer): Buffer {
-  const frame = Buffer.allocUnsafe(5 + message.length);
-  frame[0] = 0;
-  frame.writeUInt32BE(message.length, 1);
-  message.copy(frame, 5);
-  return frame;
-}
+import { encodeEmulatorImage, grpcFrame } from "./fixtures/grpc.ts";
 
 describe("gRPC message framing", () => {
   test("assembles byte-fragmented messages without cumulative concatenation", () => {
@@ -276,10 +269,14 @@ describe("emulator gRPC discovery", () => {
 
 describe("EmulatorGrpcClient HTTP/2 integration", () => {
   test("sends the discovered bearer token and decodes a screenshot", async () => {
-    const imageBody = Buffer.from([
-      0x0a, 0x06, 0x08, 0x02, 0x18, 0x02, 0x20, 0x01, 0x22, 0x06, 1, 2, 3, 4, 5,
-      6, 0x28, 0x01, 0x30, 0x01,
-    ]);
+    const imageBody = encodeEmulatorImage({
+      format: IMG_FORMAT_RGB888,
+      width: 2,
+      height: 1,
+      image: Buffer.from([1, 2, 3, 4, 5, 6]),
+      seq: 1,
+      timestampUs: 1n,
+    });
     let authorization: string | undefined;
     const server = http2.createServer();
     server.on("stream", (stream: ServerHttp2Stream, headers) => {
@@ -317,10 +314,12 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
   });
 
   test("fails a screenshot stream that stalls after a decoded image", async () => {
-    const imageBody = Buffer.from([
-      0x0a, 0x06, 0x08, 0x02, 0x18, 0x02, 0x20, 0x01, 0x22, 0x06, 1, 2, 3, 4, 5,
-      6,
-    ]);
+    const imageBody = encodeEmulatorImage({
+      format: IMG_FORMAT_RGB888,
+      width: 2,
+      height: 1,
+      image: Buffer.from([1, 2, 3, 4, 5, 6]),
+    });
     const server = http2.createServer();
     server.on("stream", (stream: ServerHttp2Stream) => {
       stream.respond({
@@ -362,10 +361,12 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
   });
 
   test("keeps a quiet static screenshot stream healthy with unary probes", async () => {
-    const imageBody = Buffer.from([
-      0x0a, 0x06, 0x08, 0x02, 0x18, 0x02, 0x20, 0x01, 0x22, 0x06, 1, 2, 3, 4, 5,
-      6,
-    ]);
+    const imageBody = encodeEmulatorImage({
+      format: IMG_FORMAT_RGB888,
+      width: 2,
+      height: 1,
+      image: Buffer.from([1, 2, 3, 4, 5, 6]),
+    });
     const requests: Buffer[] = [];
     const payloadBytes: number[] = [];
     const decodeBytes: number[] = [];

--- a/packages/serve-emu/packages/serve-emu/tests/fixtures/grpc.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/fixtures/grpc.ts
@@ -1,0 +1,38 @@
+import {
+  encodeImageFormat,
+  type ImageFormatRequest,
+} from "../../src/emulator-grpc.ts";
+
+/** Wrap a protobuf message in the uncompressed five-byte gRPC envelope. */
+export function grpcFrame(message: Buffer): Buffer {
+  const frame = Buffer.allocUnsafe(5 + message.length);
+  frame[0] = 0;
+  frame.writeUInt32BE(message.length, 1);
+  message.copy(frame, 5);
+  return frame;
+}
+
+function varint(value: number | bigint): Buffer {
+  let remaining = BigInt(value);
+  if (remaining < 0n) throw new RangeError("fixture varint must be unsigned");
+  const bytes: number[] = [];
+  do {
+    const byte = Number(remaining & 0x7fn);
+    remaining >>= 7n;
+    bytes.push(remaining ? byte | 0x80 : byte);
+  } while (remaining);
+  return Buffer.from(bytes);
+}
+
+/** Encode the Image response fields used by the real HTTP/2 capture fixtures. */
+export function encodeEmulatorImage(
+  image: ImageFormatRequest & { image: Buffer; seq?: number; timestampUs?: bigint },
+): Buffer {
+  const format = encodeImageFormat(image);
+  return Buffer.concat([
+    Buffer.from([0x0a]), varint(format.length), format,
+    Buffer.from([0x22]), varint(image.image.length), image.image,
+    Buffer.from([0x28]), varint(image.seq ?? 0),
+    Buffer.from([0x30]), varint(image.timestampUs ?? 0n),
+  ]);
+}

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -29,7 +29,6 @@ import {
 } from "../src/grpc-session.ts";
 import {
   EmulatorGrpcClient,
-  encodeImageFormat,
   IMG_FORMAT_PNG,
   IMG_FORMAT_RGB888,
   type EmuImage,
@@ -43,6 +42,7 @@ import type {
   ScrcpyControlSession,
   VideoFrame,
 } from "../src/scrcpy.ts";
+import { encodeEmulatorImage, grpcFrame } from "./fixtures/grpc.ts";
 
 const CONFIG_FRAME: VideoFrame = {
   type: "frame",
@@ -1189,27 +1189,18 @@ describe("startGrpcSession integration", () => {
     const width = 192;
     const height = 192;
     const frameCount = 120;
-    const varint = (value: number): Buffer => {
-      const bytes: number[] = [];
-      do {
-        const byte = value & 0x7f;
-        value >>>= 7;
-        bytes.push(value ? byte | 0x80 : byte);
-      } while (value);
-      return Buffer.from(bytes);
-    };
-    const format = encodeImageFormat({ format: IMG_FORMAT_RGB888, width, height });
     const frame = (sequence: number): Buffer => {
       const pixels = Buffer.alloc(width * height * 3);
       pixels.writeUInt32LE(sequence);
-      const body = Buffer.concat([
-        Buffer.from([0x0a]), varint(format.length), format,
-        Buffer.from([0x22]), varint(pixels.length), pixels,
-        Buffer.from([0x28]), varint(sequence),
-      ]);
-      const header = Buffer.alloc(5);
-      header.writeUInt32BE(body.length, 1);
-      return Buffer.concat([header, body]);
+      return grpcFrame(
+        encodeEmulatorImage({
+          format: IMG_FORMAT_RGB888,
+          width,
+          height,
+          image: pixels,
+          seq: sequence,
+        }),
+      );
     };
     let screenshotStream: ServerHttp2Stream | undefined;
     const server = http2.createServer();
@@ -1253,10 +1244,19 @@ describe("startGrpcSession integration", () => {
         screenshotStream!.write(frame(sequence));
       }
       const deadline = performance.now() + 2000;
-      while (performance.now() < deadline && encoders[0]!.lastBuffer!.readUInt32LE() !== frameCount) {
+      while (encoders[0]!.lastBuffer!.readUInt32LE() !== frameCount) {
+        if (performance.now() >= deadline) {
+          throw new Error(
+            `Timed out after 2000ms waiting for RGB888 frame ${frameCount} to reach the encoder; last frame was ${encoders[0]!.lastBuffer!.readUInt32LE()}`,
+          );
+        }
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
-      expect(session.diagnostics!().grpcCapture!.rawGrpcMessagesReceived).toBe(frameCount + 1);
+      expect(session.diagnostics!().grpcCapture).toMatchObject({
+        rawGrpcMessagesReceived: frameCount + 1,
+        rawGrpcMessagesEmitted: frameCount + 1,
+        rawGrpcMessagesCoalesced: 0,
+      });
       expect(encoders[0]!.lastBuffer!.readUInt32LE()).toBe(frameCount);
       expect(encoders[0]!.options).toMatchObject({ fps: 30, inputFormat: "rgb24" });
       expect(encoders[0]!.writes).toBeLessThan(frameCount / 2);

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import http2, { type ServerHttp2Stream } from "node:http2";
 import { describe, expect, test } from "bun:test";
 import {
   GrpcAccessUnitBoundaryCadence,
@@ -27,6 +28,8 @@ import {
   type GrpcSessionRuntime,
 } from "../src/grpc-session.ts";
 import {
+  EmulatorGrpcClient,
+  encodeImageFormat,
   IMG_FORMAT_PNG,
   IMG_FORMAT_RGB888,
   type EmuImage,
@@ -249,7 +252,7 @@ describe("gRPC screenshot session helpers", () => {
 
     const rgbBehavior = grpcImageModeBehavior("rgb888", 24);
     expect(rgbBehavior.encoderInputFormat).toBe("rgb24");
-    expect(rgbBehavior.predecodeMaxFps).toBe(24);
+    expect(rgbBehavior.predecodeMaxFps).toBeUndefined();
     expect(rgbBehavior.needsEncoderFollowUp(false, true)).toBe(true);
     expect(rgbBehavior.needsEncoderFollowUp(true, false)).toBe(false);
 
@@ -1147,7 +1150,7 @@ function integrationImage(rotation = 0, width = 4, height = 6): EmuImage {
 }
 
 function integrationRuntime(
-  client: FakeGrpcClient,
+  client: GrpcSessionClient,
   encoders: FakeGrpcEncoder[],
   encoderBehavior: {
     writeResults?: boolean[];
@@ -1182,6 +1185,88 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("startGrpcSession integration", () => {
+  test("RGB888 drains incoming frames independently of the encoder FPS limit", async () => {
+    const width = 192;
+    const height = 192;
+    const frameCount = 120;
+    const varint = (value: number): Buffer => {
+      const bytes: number[] = [];
+      do {
+        const byte = value & 0x7f;
+        value >>>= 7;
+        bytes.push(value ? byte | 0x80 : byte);
+      } while (value);
+      return Buffer.from(bytes);
+    };
+    const format = encodeImageFormat({ format: IMG_FORMAT_RGB888, width, height });
+    const frame = (sequence: number): Buffer => {
+      const pixels = Buffer.alloc(width * height * 3);
+      pixels.writeUInt32LE(sequence);
+      const body = Buffer.concat([
+        Buffer.from([0x0a]), varint(format.length), format,
+        Buffer.from([0x22]), varint(pixels.length), pixels,
+        Buffer.from([0x28]), varint(sequence),
+      ]);
+      const header = Buffer.alloc(5);
+      header.writeUInt32BE(body.length, 1);
+      return Buffer.concat([header, body]);
+    };
+    let screenshotStream: ServerHttp2Stream | undefined;
+    const server = http2.createServer();
+    server.on("stream", (stream: ServerHttp2Stream, headers) => {
+      stream.on("error", () => {});
+      stream.resume();
+      const streaming = String(headers[":path"]).endsWith("/streamScreenshot");
+      stream.respond({
+        ":status": 200,
+        "content-type": "application/grpc",
+        ...(streaming ? {} : { "grpc-status": "0" }),
+      });
+      if (streaming) {
+        screenshotStream = stream;
+        stream.write(frame(0));
+      } else {
+        stream.end(frame(0));
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing gRPC port");
+    const endpoint = { port: address.port, token: null, avdName: "Pixel_9" };
+    const client = new EmulatorGrpcClient(endpoint);
+    const encoders: FakeGrpcEncoder[] = [];
+    let session: Awaited<ReturnType<typeof startGrpcSession>> | undefined;
+    try {
+      session = await startGrpcSession(
+        { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc", maxFps: 30 },
+        {
+          readDisplaySizeSignal: async () => "physical:192x192",
+          runtime: {
+            ...integrationRuntime(client, encoders),
+            ensureEndpoint: async () => endpoint,
+          },
+        },
+      );
+      // Large messages span multiple HTTP/2 chunks. Pausing the readable stream
+      // must not turn a finite incoming burst into seconds of stale playback.
+      for (let sequence = 1; sequence <= frameCount; sequence++) {
+        screenshotStream!.write(frame(sequence));
+      }
+      const deadline = performance.now() + 2000;
+      while (performance.now() < deadline && encoders[0]!.lastBuffer!.readUInt32LE() !== frameCount) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(session.diagnostics!().grpcCapture!.rawGrpcMessagesReceived).toBe(frameCount + 1);
+      expect(encoders[0]!.lastBuffer!.readUInt32LE()).toBe(frameCount);
+      expect(encoders[0]!.options).toMatchObject({ fps: 30, inputFormat: "rgb24" });
+      expect(encoders[0]!.writes).toBeLessThan(frameCount / 2);
+    } finally {
+      await session?.close();
+      client.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test.each([0, 8, 1280])(
     "streams in-band RGB888 at maxSize=%s with rgb24 input and no MMAP",
     async (maxSize) => {
@@ -1215,7 +1300,7 @@ describe("startGrpcSession integration", () => {
           width: maxSize,
           height: maxSize,
         });
-        expect(client.streamMaxFps).toBe(24);
+        expect(client.streamMaxFps).toBeUndefined();
         expect(encoders[0]!.options).toMatchObject({
           width: 4,
           height: 6,


### PR DESCRIPTION
Fixes delayed RGB888 playback when the emulator produces frames faster than the configured video FPS. The previous implementation paused the gRPC reader at the encoder rate, allowing old frames to accumulate upstream. Update serve-emu to continuously receive RGB888 responses, keep only the latest image, and apply `--video-fps` to fresh encoder submissions.

Stacked on https://github.com/expo/expo-device-hub/pull/80 using `gh stack`. Includes the capture fix and real HTTP/2 regression test from https://github.com/expo/serve-emu/pull/28 directly in the monorepo under `packages/serve-emu` and corrects the pacing documentation. No serve-emu submodule update or separate capture PR is required.

Capture statistics distinguish RGB888 decoded responses from encoder selection. The documentation explains why predecode coalescing remains zero and how usable-image and fresh-encoder rates expose local frame selection. HTTP/2 integration tests share response-framing fixtures and report explicit deadline failures.

Validation:

- `bun run build`, `bun run typecheck`, `bun run lint`, and `bun run test` passed in the monorepo: 1,478 tests, including 932 serve-emu tests and 546 Device Hub/UI tests.
- `bun run --filter serve-emu check` passed on the monorepo layout: 932 tests, coverage, typechecks, builds, documentation checks, and package smoke test.
- A real HTTP/2 regression verifies that a bounded burst of 121 RGB888 responses reaches the newest encoded image promptly while the encoder is configured for 30 FPS and submits fewer frames. Existing encoder-backpressure, rotation, cancellation, PNG, and MMAP tests pass.
- Live WebRTC validation at 30 FPS, `-gpu host`, 540×1170 native images, and the same animated workload: source timestamp → gRPC reception p50 decreased from 5179.5 ms to 14.7 ms; p95 decreased from 5537.4 ms to 126.1 ms. Incoming rates were 27.54 and 27.20 responses/sec; fresh encoder submission rates were 27.54 and 19.61/sec. These capture-boundary measurements show the removal of accumulated delay and are not a general throughput or end-to-end latency guarantee.

Authored with Codex (GPT-6).



