### PR TITLE
Show Reconnecting while Android stream settings change

### DIFF
--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -1648,7 +1648,13 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
   return {
     platform: 'android',
-    status,
+    // The transport can stay live while the server stages new stream settings.
+    // Show the pending change immediately without feeding it back into the
+    // switch tracker, which must observe the actual interruption and recovery.
+    status:
+      status === 'streaming' && (isStreamSwitchPending(streamSwitch) || streamSettingsPending)
+        ? 'reconnecting'
+        : status,
     error,
     screen,
     fps,


### PR DESCRIPTION
Android's device label could stay green and say **Live** while stream settings were disabled and the last frame was held during a restart. The label followed the transport status, which can remain live while the server stages the replacement source.

Report **Reconnecting** immediately while the existing source/settings state is pending. Keep the actual transport status as the input to the switch tracker so the display change cannot manufacture an interruption or recovery. This is a focused change in one file; no refactor is needed.

Validated source, input-source, PNG/MMAP, and resolution changes on Android. The attached recording demonstrates the WebSocket behavior. All 201 client/component tests, client type checking, and lint passed. WebRTC recovery is handled in the follow-up stacked PR #84.

Authored by Codex (GPT-6).

https://github.com/user-attachments/assets/760df46e-8c3a-4f01-b865-2b9329298b88