### PR TITLE
Restart Android WebRTC promptly when stream settings change

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,8 +70,10 @@
         "@swc/core": "^1.15.43",
         "@types/bun": "latest",
         "@types/react": "~19.2.2",
+        "@types/react-test-renderer": "19.1.0",
         "oxfmt": "^0.56.0",
         "oxlint": "^1.71.0",
+        "react-test-renderer": "19.2.3",
         "typescript": "~6.0.3",
       },
       "peerDependencies": {
@@ -1147,6 +1149,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
@@ -1899,7 +1903,7 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
-    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+    "react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
     "react-native": ["react-native@0.86.0", "", { "dependencies": { "@react-native/assets-registry": "0.86.0", "@react-native/codegen": "0.86.0", "@react-native/community-cli-plugin": "0.86.0", "@react-native/gradle-plugin": "0.86.0", "@react-native/js-polyfills": "0.86.0", "@react-native/normalize-colors": "0.86.0", "@react-native/virtualized-lists": "0.86.0", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-plugin-syntax-hermes-parser": "0.36.0", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.14", "invariant": "^2.2.4", "memoize-one": "^5.0.0", "metro-runtime": "^0.84.3", "metro-source-map": "^0.84.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@react-native/jest-preset": "0.86.0", "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@react-native/jest-preset", "@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w=="],
 
@@ -1912,6 +1916,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.3", "", { "dependencies": { "react-is": "^19.2.3", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
@@ -2440,6 +2446,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
+
+    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 

--- a/packages/@expo/hub-client/package.json
+++ b/packages/@expo/hub-client/package.json
@@ -44,8 +44,10 @@
     "@swc/core": "^1.15.43",
     "@types/bun": "latest",
     "@types/react": "~19.2.2",
+    "@types/react-test-renderer": "19.1.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "react-test-renderer": "19.2.3",
     "typescript": "~6.0.3"
   },
   "engines": {

--- a/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
@@ -2,8 +2,15 @@ import { afterEach, expect, test } from 'bun:test';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 
 import { androidStreamSettingsPatch, parseAndroidStreamSettings } from '../android-stream-settings';
+import { deviceScreenPresentsMedia } from '../DeviceScreen';
+import { useAndroidDeviceClient } from '../useAndroidDevice';
 import { useStreamSettingsResource } from '../useStreamSettingsResource';
 import { useWebRtcStream } from '../useWebRtcStream';
+
+// These tests exercise hook lifecycles with controlled transport/media events.
+// react-test-renderer keeps them in the existing Bun runner without adding a
+// browser DOM environment. Its deprecation warning is intentionally not hidden;
+// actual decoding and presentation are also checked in the browser recording.
 
 class Peer {
   static instances: Peer[] = [];
@@ -48,6 +55,7 @@ afterEach(async () => {
   }
   originals.clear();
   Peer.instances = [];
+  ControlSocket.instances = [];
 });
 
 test('a known server restart replaces a still-connected peer without waiting for ICE failure', async () => {
@@ -145,5 +153,239 @@ for (const outcome of ['success', 'failure', 'superseded'] as const) {
     expect(settings!.streamSettings?.maxDimension ?? null).toBe(
       outcome === 'success' ? 720 : outcome === 'failure' ? 1280 : null,
     );
+  });
+}
+
+class ControlSocket {
+  static OPEN = 1;
+  static instances: ControlSocket[] = [];
+  readyState = 0;
+  closeCount = 0;
+  onopen?: () => void;
+  onclose?: (event: { code: number }) => void;
+
+  constructor(readonly url: string) {
+    ControlSocket.instances.push(this);
+  }
+  send() {}
+  open() {
+    this.readyState = ControlSocket.OPEN;
+    this.onopen?.();
+  }
+  close() {
+    this.closeCount++;
+    this.serverClose(1000);
+  }
+  serverClose(code: number) {
+    this.readyState = 3;
+    this.onclose?.({ code });
+  }
+}
+
+class Video extends EventTarget {
+  tagName = 'VIDEO';
+  readyState = 2;
+  videoWidth = 360;
+  videoHeight = 720;
+  srcObject: object | null = null;
+  poster = '';
+  async play() {}
+  removeAttribute(name: string) {
+    if (name === 'poster') this.poster = '';
+  }
+  paint() {
+    this.dispatchEvent(new Event('loadeddata'));
+  }
+}
+
+async function androidHarness({ delaySource = false } = {}) {
+  stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const timers = new Map<number, { callback: () => void; delay: number }>();
+  let timerId = 0;
+  const schedule = (callback: () => void, delay: number) => {
+    timers.set(++timerId, { callback, delay });
+    return timerId;
+  };
+  const cancel = (id: number) => {
+    timers.delete(id);
+  };
+  stubGlobal('setTimeout', schedule);
+  stubGlobal('clearTimeout', cancel);
+  stubGlobal('window', {
+    addEventListener() {},
+    removeEventListener() {},
+    setTimeout: schedule,
+    clearTimeout: cancel,
+  });
+  const captures: Video[] = [];
+  stubGlobal('document', {
+    hidden: false,
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({
+      getContext: () => ({ drawImage: (video: Video) => captures.push(video) }),
+      toDataURL: () => 'data:image/png;base64,last-frame',
+    }),
+  });
+  stubGlobal('RTCPeerConnection', Peer);
+  stubGlobal('RTCRtpReceiver', { getCapabilities: () => null });
+  stubGlobal('WebSocket', ControlSocket);
+  const source = {
+    ok: true,
+    mode: 'scrcpy',
+    grpcImageMode: 'mmap',
+    inputSource: 'scrcpy',
+    availableModes: ['scrcpy', 'grpc-screenshot'],
+    availableInputSources: ['scrcpy', 'grpc'],
+    sessionGeneration: 1,
+  };
+  const writes: { path: string; finish: (response: Response) => void }[] = [];
+  let finishSource!: (response: Response) => void;
+  const sourceRead = new Promise<Response>((resolve) => {
+    finishSource = resolve;
+  });
+  stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    const path = new URL(url).pathname;
+    if (init?.method === 'PATCH' || init?.method === 'PUT') {
+      return new Promise<Response>((finish) => {
+        writes.push({ path, finish });
+      });
+    }
+    if (path === '/api/stream-settings') return Response.json({ maxDimension: 1280 });
+    if (path === '/api/stream-mode') return delaySource ? sourceRead : Response.json(source);
+    if (path === '/api') {
+      return Response.json({
+        stream: { transport: 'webrtc', codec: 'h264', iceServers: [], iceTransportPolicy: 'all' },
+      });
+    }
+    if (path === '/webrtc/offer') return Response.json({ type: 'answer', sdp: 'answer' });
+    return Response.json({}, { status: 404 });
+  });
+  let client!: ReturnType<typeof useAndroidDeviceClient>;
+  function Harness({ device = 'emulator-test' }: { device?: string }) {
+    client = useAndroidDeviceClient({ baseUrl: 'https://hub.test', device, streamMode: 'webrtc' });
+    return null;
+  }
+  await act(async () => {
+    renderer = create(<Harness />);
+  });
+  const attach = async (video: Video) => {
+    await act(async () => client.attachVideo(video as unknown as HTMLVideoElement));
+  };
+  const video = new Video();
+  await attach(video);
+  await act(async () => {
+    ControlSocket.instances.at(-1)!.open();
+    Peer.instances.at(-1)!.receive({ id: 'initial' });
+  });
+  await act(async () => video.paint());
+  expect(client.status).toBe('streaming');
+  return {
+    get client() {
+      return client;
+    },
+    video,
+    captures,
+    writes,
+    source,
+    attach,
+    finishSource: async () => {
+      await act(async () => finishSource(Response.json(source)));
+    },
+    finishWrite: async (payload: object, status = 200) => {
+      await act(async () => writes.at(-1)!.finish(Response.json(payload, { status })));
+    },
+    changeDevice: async () => {
+      await act(async () => renderer!.update(<Harness device="another-emulator" />));
+    },
+    fireTimer: async (delay: number) => {
+      const matching = [...timers].filter(([, timer]) => timer.delay === delay);
+      expect(matching.length).toBeGreaterThan(0);
+      await act(async () => {
+        for (const [id, timer] of matching) {
+          timers.delete(id);
+          timer.callback();
+        }
+      });
+    },
+    paintReplacement: async () => {
+      await act(async () => Peer.instances.at(-1)!.receive({ id: 'replacement' }));
+      await act(async () => video.paint());
+    },
+  };
+}
+
+test('attaching and remounting the Android video keeps one control socket and uses the latest node', async () => {
+  const hub = await androidHarness();
+  expect(ControlSocket.instances).toHaveLength(1);
+  const socket = ControlSocket.instances[0]!;
+  const remounted = new Video();
+  await hub.attach(remounted);
+  await act(async () => remounted.paint());
+  expect(ControlSocket.instances).toHaveLength(1);
+  expect(socket.closeCount).toBe(0);
+  await act(async () => socket.serverClose(1012));
+  expect(Peer.instances).toHaveLength(2);
+  expect(hub.captures).toEqual([remounted]);
+  expect(hub.client.status).toBe('reconnecting');
+});
+
+test('Android settings wait for fresh video, preserve the poster past grace, and still time out', async () => {
+  const hub = await androidHarness();
+  await act(async () => hub.client.updateStreamSettings({ maxDimension: 720 }));
+  expect(hub.client.status).toBe('reconnecting');
+  expect(hub.client.streamSettingsPending).toBe(true);
+  expect(Peer.instances).toHaveLength(1);
+  await hub.finishWrite({ maxDimension: 720 });
+  expect(Peer.instances).toHaveLength(2);
+  expect(hub.video.poster).toContain('data:image/png');
+  expect(hub.captures).toEqual([hub.video]);
+  await hub.fireTimer(5000);
+  expect(hub.client.status).toBe('reconnecting');
+  expect(deviceScreenPresentsMedia(hub.client.status)).toBe(true);
+  expect(hub.client.streamSettingsPending).toBe(true);
+  await hub.fireTimer(8000);
+  expect(hub.client.status).toBe('connecting');
+  expect(hub.client.streamSettingsPending).toBe(false);
+  await hub.paintReplacement();
+  expect(hub.client.status).toBe('streaming');
+  expect(hub.video.poster).toBe('');
+});
+
+test('Android source changes reject overlapping settings writes and wait for replacement frames', async () => {
+  const hub = await androidHarness({ delaySource: true });
+  await act(async () => hub.client.updateStreamSettings({ maxDimension: 720 }));
+  expect(hub.writes).toHaveLength(0);
+  await hub.finishSource();
+  await act(async () => hub.client.setStreamSource('grpc-screenshot'));
+  await act(async () => hub.client.updateStreamSettings({ maxDimension: 720 }));
+  expect(hub.writes.map((write) => write.path)).toEqual(['/api/stream-mode']);
+  await act(async () => ControlSocket.instances.at(-1)!.serverClose(1012));
+  await hub.finishWrite({ ...hub.source, mode: 'grpc-screenshot', sessionGeneration: 2 });
+  await hub.fireTimer(100);
+  await act(async () => ControlSocket.instances.at(-1)!.open());
+  expect(hub.client.status).toBe('reconnecting');
+  expect(hub.client.streamSource?.mode).toBe('scrcpy');
+  await hub.paintReplacement();
+  expect(hub.client.status).toBe('streaming');
+  expect(hub.client.streamSource?.mode).toBe('grpc-screenshot');
+  expect(hub.client.streamSourcePending).toBe(false);
+  expect(hub.client.streamSettingsPending).toBe(false);
+  expect(hub.video.poster).toBe('');
+});
+
+for (const outcome of ['failure', 'superseded'] as const) {
+  test(`Android ${outcome} settings writes do not restart the current peer`, async () => {
+    const hub = await androidHarness();
+    await act(async () => hub.client.updateStreamSettings({ maxDimension: 720 }));
+    if (outcome === 'superseded') await hub.changeDevice();
+    const peersBeforeResponse = Peer.instances.length;
+    await hub.finishWrite({ maxDimension: 720 }, outcome === 'failure' ? 503 : 200);
+    expect(Peer.instances).toHaveLength(peersBeforeResponse);
+    expect(hub.captures).toHaveLength(0);
+    expect(hub.client.streamSettingsPending).toBe(false);
+    expect(hub.client.streamSourcePending).toBe(false);
+    expect(hub.client.streamSettings?.maxDimension).toBe(1280);
+    if (outcome === 'failure') expect(hub.client.status).toBe('streaming');
   });
 }

--- a/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, expect, test } from 'bun:test';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { androidStreamSettingsPatch, parseAndroidStreamSettings } from '../android-stream-settings';
+import { useStreamSettingsResource } from '../useStreamSettingsResource';
+import { useWebRtcStream } from '../useWebRtcStream';
+
+class Peer {
+  static instances: Peer[] = [];
+  iceGatheringState = 'complete';
+  connectionState = 'connected';
+  localDescription = { type: 'offer', sdp: 'offer' };
+  closeCount = 0;
+  ontrack?: (event: { streams: object[]; track: object }) => void;
+
+  constructor() {
+    Peer.instances.push(this);
+  }
+  addTransceiver() {
+    return {};
+  }
+  async createOffer() {
+    return this.localDescription;
+  }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  close() {
+    this.closeCount++;
+  }
+  receive(stream: object) {
+    this.ontrack?.({ streams: [stream], track: {} });
+  }
+}
+
+const originals = new Map<string, PropertyDescriptor | undefined>();
+function stubGlobal(name: string, value: unknown) {
+  originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+
+let renderer: ReactTestRenderer | undefined;
+afterEach(async () => {
+  if (renderer) await act(async () => renderer?.unmount());
+  renderer = undefined;
+  for (const [name, descriptor] of originals) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+  originals.clear();
+  Peer.instances = [];
+});
+
+test('a known server restart replaces a still-connected peer without waiting for ICE failure', async () => {
+  stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  stubGlobal('window', {
+    addEventListener() {},
+    removeEventListener() {},
+    setTimeout,
+    clearTimeout,
+  });
+  stubGlobal('RTCPeerConnection', Peer);
+  stubGlobal('RTCRtpReceiver', { getCapabilities: () => null });
+  const requests: string[] = [];
+  stubGlobal('fetch', async (url: string) => {
+    requests.push(url);
+    return Response.json({ type: 'answer', sdp: 'answer' });
+  });
+
+  let client: ReturnType<typeof useWebRtcStream>;
+  function Harness() {
+    client = useWebRtcStream({
+      offerUrl: 'https://hub.test/webrtc/offer',
+      closeUrl: 'https://hub.test/webrtc/close',
+      enabled: true,
+      codec: 'h264',
+      allowCodecFallback: false,
+    });
+    return null;
+  }
+
+  await act(async () => {
+    renderer = create(<Harness />);
+  });
+  const previousPeer = Peer.instances[0]!;
+  const previousStream = { id: 'previous' };
+  await act(async () => previousPeer.receive(previousStream));
+  await act(async () => client!.markFrameDecoded());
+  expect<object | null>(client!.stream).toBe(previousStream);
+
+  // serve-emu closes its control socket before the browser notices the dead
+  // video peer. Restart without emitting any connectionstatechange event.
+  await act(async () => client!.restart());
+  expect(Peer.instances).toHaveLength(2);
+  expect(previousPeer.closeCount).toBe(1);
+  expect(requests.filter((url) => url.endsWith('/offer'))).toHaveLength(2);
+  expect(requests.filter((url) => url.endsWith('/close'))).toHaveLength(1);
+  expect(client!.stream).toBeNull();
+
+  await act(async () => previousPeer.receive(previousStream));
+  expect(client!.stream).toBeNull();
+  const replacementStream = { id: 'replacement' };
+  await act(async () => Peer.instances[1]!.receive(replacementStream));
+  await act(async () => client!.markFrameDecoded());
+  expect<object | null>(client!.stream).toBe(replacementStream);
+  expect(client!.error).toBeNull();
+});
+
+for (const outcome of ['success', 'failure', 'superseded'] as const) {
+  test(`encoder writes report ${outcome} so only committed settings restart WebRTC`, async () => {
+    stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    let finishWrite!: (response: Response) => void;
+    const response = new Promise<Response>((resolve) => {
+      finishWrite = resolve;
+    });
+    stubGlobal('fetch', async (_url: string, init?: RequestInit) =>
+      init?.method === 'PATCH' ? response : Response.json({ maxDimension: 1280 }),
+    );
+    let settings: ReturnType<typeof useStreamSettingsResource>;
+    function Harness({ url = 'https://hub.test/stream-settings' }: { url?: string | null }) {
+      settings = useStreamSettingsResource({
+        url,
+        initialSettings: null,
+        parse: parseAndroidStreamSettings,
+        toPatch: androidStreamSettingsPatch,
+      });
+      return null;
+    }
+    await act(async () => {
+      renderer = create(<Harness />);
+    });
+    expect(settings!.updateStreamSettings({ h264Fps: 30 })).toBeUndefined();
+    let write: Promise<boolean> | undefined;
+    await act(async () => {
+      write = settings!.updateStreamSettings({ maxDimension: 720 });
+    });
+    expect(settings!.streamSettingsPending).toBe(true);
+    if (outcome === 'superseded') {
+      await act(async () => renderer!.update(<Harness url={null} />));
+    }
+    await act(async () => {
+      finishWrite(Response.json({ maxDimension: 720 }, { status: outcome === 'failure' ? 503 : 200 }));
+      expect(await write).toBe(outcome === 'success');
+    });
+    expect(settings!.streamSettingsPending).toBe(false);
+    expect(settings!.streamSettings?.maxDimension ?? null).toBe(
+      outcome === 'success' ? 720 : outcome === 'failure' ? 1280 : null,
+    );
+  });
+}

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -835,6 +835,12 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     restartWebRtcStream();
   }, [restartWebRtcStream, webRtcVideoElement]);
 
+  // Media remounts update the restart target without replacing the input socket.
+  const restartWebRtcRef = useRef(restartWebRtc);
+  useLayoutEffect(() => {
+    restartWebRtcRef.current = restartWebRtc;
+  }, [restartWebRtc]);
+
   const updateStreamSettings = useCallback(
     (patch: Partial<DeviceStreamEncoderSettings>) => {
       if (streamSourceLoadingRef.current || isStreamSwitchPending(streamSwitchRef.current)) return;
@@ -850,11 +856,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         }
         // Resolution changes replace the encoder without closing the input
         // socket. A new peer avoids waiting on the old decoder's video state.
-        restartWebRtc();
+        restartWebRtcRef.current();
         dispatchStreamSwitch({ type: 'request-success', replaced: true });
       });
     },
-    [dispatchStreamSwitch, restartWebRtc, useWebRtc, writeStreamSettings],
+    [dispatchStreamSwitch, useWebRtc, writeStreamSettings],
   );
 
   const webRtcLive =
@@ -891,9 +897,11 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     if (webRtcLive) {
       setStatus('streaming');
       setError(null);
-    } else if (webRtcWasLive && !webRtcGraceExpired) {
+    } else if (
+      webRtcWasLive && (!webRtcGraceExpired || streamSwitch.phase === 'awaiting-frame')
+    ) {
       // A source switch replaces both the control socket and the video peer.
-      // Keep the last frame until the replacement peer delivers fresh video.
+      // Its bounded frame wait can outlast the ordinary reconnect grace period.
       setStatus('reconnecting');
       setError(null);
     } else if (webRtcError) {
@@ -906,7 +914,15 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       setStatus('connecting');
       setError(null);
     }
-  }, [useWebRtc, webRtcError, webRtcGraceExpired, webRtcInputError, webRtcLive, webRtcWasLive]);
+  }, [
+    useWebRtc,
+    webRtcError,
+    webRtcGraceExpired,
+    webRtcInputError,
+    webRtcLive,
+    webRtcWasLive,
+    streamSwitch.phase,
+  ]);
 
   // Attach the negotiated MediaStream to DeviceScreen's current <video> node.
   // The node is stateful (rather than only a ref) so a remount reattaches the
@@ -1398,7 +1414,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
           // serve-emu stops the old video peer along with this control socket.
           // Renegotiate now instead of waiting for ICE loss and its grace period;
           // the new input socket alone must not make the old video read as live.
-          restartWebRtc();
+          restartWebRtcRef.current();
         }
         retryInput('WebRTC input disconnected. Retrying...', event.code, wasHealthy);
       };
@@ -1422,7 +1438,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       if (wsRef.current === ws) wsRef.current = null;
       setWebRtcInputReady(false);
     };
-  }, [active, baseUrl, targetDevice, useWebRtc, restartWebRtc]);
+  }, [active, baseUrl, targetDevice, useWebRtc]);
 
   // ── Logcat (SSE, best-effort) — off by default; opt-in via attach ──
   useEffect(() => {

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -50,6 +50,7 @@ import { KeyedWriteTracker } from './keyed-write-tracker';
 import { androidMessageForKeyboardInput } from './keyboard';
 import { MsePlayer } from './mse-player';
 import {
+  isDeliberateServerClose,
   RECONNECT_BASE_DELAY_MS,
   STREAM_RECONNECT_GRACE_MS,
   scheduleReconnect,
@@ -77,6 +78,7 @@ import {
   type DeviceLog,
   type DeviceSettingKey,
   type DeviceSettings,
+  type DeviceStreamEncoderSettings,
   type DeviceStreamSource,
   type DeviceStreamSourceStatus,
   type ForegroundApp,
@@ -489,7 +491,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const {
     streamSettings,
     streamSettingsPending,
-    updateStreamSettings,
+    updateStreamSettings: writeStreamSettings,
     refreshStreamSettings,
   } = useStreamSettingsResource({
     url: streamSettingsUrl,
@@ -793,6 +795,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     stream: webRtcStream,
     error: webRtcError,
     markFrameDecoded: markWebRtcFrameDecoded,
+    restart: restartWebRtcStream,
     streamStats,
     setStreamStatsEnabled,
   } = useWebRtcStream({
@@ -813,6 +816,46 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     allowCodecFallback: false,
     onKeyframeNeeded: requestWebRtcKeyframe,
   });
+
+  const restartWebRtc = useCallback(() => {
+    const video = webRtcVideoElement;
+    // Closing the peer or replacing srcObject can clear the decoded frame.
+    // Capture it before either happens and show it until fresh video arrives.
+    if (video && video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0) {
+      const snapshot = document.createElement('canvas');
+      snapshot.width = video.videoWidth;
+      snapshot.height = video.videoHeight;
+      const context = snapshot.getContext('2d');
+      if (context) {
+        context.drawImage(video, 0, 0);
+        video.poster = snapshot.toDataURL('image/png');
+      }
+      video.srcObject = null;
+    }
+    restartWebRtcStream();
+  }, [restartWebRtcStream, webRtcVideoElement]);
+
+  const updateStreamSettings = useCallback(
+    (patch: Partial<DeviceStreamEncoderSettings>) => {
+      if (streamSourceLoadingRef.current || isStreamSwitchPending(streamSwitchRef.current)) return;
+      const write = writeStreamSettings(patch);
+      if (!write || !useWebRtc) return;
+      const request = ++streamSourceRequestRef.current;
+      dispatchStreamSwitch({ type: 'request-start', live: streamLiveRef.current });
+      void write.then((updated) => {
+        if (streamSourceRequestRef.current !== request) return;
+        if (!updated) {
+          dispatchStreamSwitch({ type: 'request-failure' });
+          return;
+        }
+        // Resolution changes replace the encoder without closing the input
+        // socket. A new peer avoids waiting on the old decoder's video state.
+        restartWebRtc();
+        dispatchStreamSwitch({ type: 'request-success', replaced: true });
+      });
+    },
+    [dispatchStreamSwitch, restartWebRtc, useWebRtc, writeStreamSettings],
+  );
 
   const webRtcLive =
     useWebRtc &&
@@ -849,9 +892,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       setStatus('streaming');
       setError(null);
     } else if (webRtcWasLive && !webRtcGraceExpired) {
-      // When serve-emu swaps the capture source the RTP video usually keeps
-      // flowing; only the control socket is closed and reopened. Keep the frame
-      // and report a reconnect instead of an error while that settles.
+      // A source switch replaces both the control socket and the video peer.
+      // Keep the last frame until the replacement peer delivers fresh video.
       setStatus('reconnecting');
       setError(null);
     } else if (webRtcError) {
@@ -872,9 +914,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   useEffect(() => {
     if (!useWebRtc) return;
     const video = webRtcVideoElement;
-    // While the peer renegotiates (`webRtcStream` null) the element keeps its
-    // previous MediaStream, whose ended track leaves the last frame visible —
-    // the same "hold the last frame" the canvas path gets for free.
+    // A pending negotiation leaves the existing media or saved poster in place.
     if (!video || !webRtcStream) return;
 
     let stopped = false;
@@ -895,6 +935,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       }
       if (firstFrame) {
         firstFrame = false;
+        video.removeAttribute('poster');
         setWebRtcVideoReady(true);
       }
       markWebRtcFrameDecoded(presentedFrameDelta);
@@ -953,6 +994,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     const video = webRtcVideoElement;
     if (!video) return;
     return () => {
+      video.removeAttribute('poster');
       video.srcObject = null;
     };
   }, [useWebRtc, webRtcVideoElement, baseUrl, targetDevice]);
@@ -1348,9 +1390,16 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
         // onclose owns retry scheduling.
       };
       ws.onclose = (event) => {
+        if (cancelled) return;
         if (wsRef.current === ws) wsRef.current = null;
         const wasHealthy = opened;
         opened = false;
+        if (wasHealthy && isDeliberateServerClose(event.code)) {
+          // serve-emu stops the old video peer along with this control socket.
+          // Renegotiate now instead of waiting for ICE loss and its grace period;
+          // the new input socket alone must not make the old video read as live.
+          restartWebRtc();
+        }
         retryInput('WebRTC input disconnected. Retrying...', event.code, wasHealthy);
       };
       ws.onmessage = (event) => {
@@ -1373,7 +1422,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       if (wsRef.current === ws) wsRef.current = null;
       setWebRtcInputReady(false);
     };
-  }, [active, baseUrl, targetDevice, useWebRtc]);
+  }, [active, baseUrl, targetDevice, useWebRtc, restartWebRtc]);
 
   // ── Logcat (SSE, best-effort) — off by default; opt-in via attach ──
   useEffect(() => {
@@ -1680,7 +1729,8 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     setCameraImage,
     clearCameraImage,
     streamSettings,
-    streamSettingsPending,
+    streamSettingsPending:
+      streamSettingsPending || streamSourceLoading || isStreamSwitchPending(streamSwitch),
     updateStreamSettings,
     streamSource,
     streamSourcePending: streamSourceLoading || isStreamSwitchPending(streamSwitch),

--- a/packages/@expo/hub-client/src/useStreamSettingsResource.ts
+++ b/packages/@expo/hub-client/src/useStreamSettingsResource.ts
@@ -108,7 +108,8 @@ export function useStreamSettingsResource({
       settingsRef.current = optimistic;
       setStreamSettings(optimistic);
       setStreamSettingsPending(true);
-      void fetch(url, {
+      // Let the device client wait for the write before replacing its transport.
+      return fetch(url, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestPatch),
@@ -121,13 +122,16 @@ export function useStreamSettingsResource({
           if (!controller.signal.aborted && requestRef.current === request) {
             settingsRef.current = next;
             setStreamSettings(next);
+            return true;
           }
+          return false;
         })
         .catch(() => {
           if (!controller.signal.aborted && requestRef.current === request) {
             settingsRef.current = previous;
             setStreamSettings(previous);
           }
+          return false;
         })
         .finally(() => {
           if (writeControllerRef.current === controller) writeControllerRef.current = null;

--- a/packages/@expo/hub-client/src/useWebRtcStream.ts
+++ b/packages/@expo/hub-client/src/useWebRtcStream.ts
@@ -161,6 +161,13 @@ export function useWebRtcStream({
     setError(null);
   }, []);
 
+  // A server restart can be known before ICE detects that the old peer is gone.
+  const restart = useCallback(() => {
+    transportRetryAttemptRef.current = 0;
+    setStream(null);
+    setRetryGeneration((generation) => generation + 1);
+  }, []);
+
   useEffect(() => {
     transportRetryAttemptRef.current = 0;
   }, [
@@ -448,5 +455,5 @@ export function useWebRtcStream({
     retryGeneration,
   ]);
 
-  return { stream, failure, error, markFrameDecoded, streamStats, setStreamStatsEnabled };
+  return { stream, failure, error, markFrameDecoded, restart, streamStats, setStreamStatsEnabled };
 }


### PR DESCRIPTION
Changing Android stream settings could bring back a green **Live** label while WebRTC still displayed a frozen frame. Source switches reopened the input socket without replacing the dead video peer; the browser then had to detect ICE loss and wait through a 10-second grace period and retry backoff. In the reproduction, the replacement peer started roughly 18 seconds after the server closed the control socket.

Restart WebRTC immediately when that socket reports a deliberate server shutdown. Resolution changes leave the socket open, so restart after their settings PATCH succeeds instead. Reuse the existing switch tracker to keep the label and stream options pending until fresh video arrives. Save the last decoded frame as the video poster before closing the peer, so replacement does not flash black. Failed or superseded settings writes do not restart the peer.

This is stacked on #82. The change stays in the client hooks; it does not alter server capture staging or the existing recovery timeouts. The control socket reads the latest restart callback through a layout-synchronized ref, so video remounts do not reopen it. The existing eight-second frame wait keeps the poster visible beyond the ordinary five-second reconnect grace. A future cleanup could give encoder replacements one explicit lifecycle signal, but a larger refactor is not needed for this fix. PNG snapshot conversion optimization is deferred to a follow-up.

Validation:

- 210 client/component tests pass, including Android-client orchestration: stable control sockets across video remounts, pending guards, successful/failed/superseded settings writes, poster capture/removal, and the frame-wait timeout.
- Client type checking, lint, client build, and web export pass.
- Tested on a newly booted `Codex_WebRTC_Reconnect_API_36_1` emulator (`emulator-5556`) with an animated page on port 3499 and the Hub from this worktree on port 50240.
- Browser checks covered capture source, input source, PNG/MMAP, and resolution changes. The final recording started a new peer 21 ms after the server close, removing the previous ~18-second client wait. Total recovery still includes encoder startup and negotiation: the recorded changes took about 9 seconds under local emulator load, with approximately 5 seconds spent staging the replacement on the server.

The recording shows resolution, capture-source, and image-mode changes: **Reconnecting** appears immediately, the last frame remains visible, and **Live** returns with fresh video as the options become available.

Authored by Codex (GPT-6).

https://github.com/user-attachments/assets/ea7baee7-899f-4f80-ad9f-0b5e50694af9