### PR TITLE
feat(hub-client): send two pointers for Android pinch and pan

### DIFF
--- a/.changeset/android-multitouch.md
+++ b/.changeset/android-multitouch.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add pinch and pan on Android. Alt-drag or two fingers on the streamed screen now reach the emulator as two pointers.

--- a/packages/@expo/hub-client/src/__tests__/android-touch.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-touch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+
+import { androidTouchMessage } from '../android-touch';
+
+const A = { x: 0.25, y: 0.5 };
+
+describe('serve-emu touch wire messages', () => {
+  test('maps each gesture phase to its wire action', () => {
+    expect(androidTouchMessage('begin', A, 0).action).toBe('down');
+    expect(androidTouchMessage('move', A, 0).action).toBe('move');
+    expect(androidTouchMessage('end', A, 0).action).toBe('up');
+  });
+
+  test('reproduces the payload the hook sent before this module existed', () => {
+    expect(androidTouchMessage('begin', A, 0)).toEqual({
+      type: 'touch',
+      action: 'down',
+      x: 0.25,
+      y: 0.5,
+      pointerId: 0,
+    });
+  });
+
+  test('carries the pointer id it is given', () => {
+    expect(androidTouchMessage('move', { x: 0.75, y: 0.5 }, 1)).toEqual({
+      type: 'touch',
+      action: 'move',
+      x: 0.75,
+      y: 0.5,
+      pointerId: 1,
+    });
+  });
+
+  test('passes unit coordinates through unrounded', () => {
+    expect(androidTouchMessage('move', { x: 0.123, y: 0.877 }, 0)).toEqual({
+      type: 'touch',
+      action: 'move',
+      x: 0.123,
+      y: 0.877,
+      pointerId: 0,
+    });
+  });
+});

--- a/packages/@expo/hub-client/src/android-touch.ts
+++ b/packages/@expo/hub-client/src/android-touch.ts
@@ -1,0 +1,31 @@
+/**
+ * serve-emu keys its input queue by `touch:<pointerId>`, so each finger needs
+ * its own message with a stable id.
+ */
+
+import { type MultiTouchSample, type TouchSample } from './types';
+
+type UnitPoint = MultiTouchSample['a'];
+type TouchPhase = TouchSample['phase'];
+
+export type AndroidTouchMessage = {
+  type: 'touch';
+  action: 'down' | 'move' | 'up';
+  x: number;
+  y: number;
+  pointerId: number;
+};
+
+const WIRE_ACTION: Record<TouchPhase, AndroidTouchMessage['action']> = {
+  begin: 'down',
+  move: 'move',
+  end: 'up',
+};
+
+export function androidTouchMessage(
+  phase: TouchPhase,
+  point: UnitPoint,
+  pointerId: number,
+): AndroidTouchMessage {
+  return { type: 'touch', action: WIRE_ACTION[phase], x: point.x, y: point.y, pointerId };
+}

--- a/packages/@expo/hub-client/src/types.ts
+++ b/packages/@expo/hub-client/src/types.ts
@@ -566,7 +566,7 @@ export interface DeviceClient {
 
   /** Forward a normalized touch/drag to the device. */
   sendTouch: (sample: TouchSample) => void;
-  /** Forward a two-finger pinch/pan. Present only on backends that support it (serve-sim). */
+  /** Forward a two-finger pinch/pan. Absent only on the no-op client. */
   sendMultiTouch?: (sample: MultiTouchSample) => void;
   /**
    * Forward a physical browser-keyboard event to the device. Returns true when

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -86,6 +86,7 @@ import {
   type ForegroundApp,
   type HardwareButton,
   type KeyboardInput,
+  type MultiTouchSample,
   type RunningDevice,
   type ScreenSize,
   type TouchSample,
@@ -338,6 +339,15 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
   const sendTouch = useCallback(
     (sample: TouchSample) => {
       send(androidTouchMessage(sample.phase, sample, 0));
+    },
+    [send],
+  );
+
+  // scrcpy derives ACTION_POINTER_DOWN from the second pointer, so 0 goes first.
+  const sendMultiTouch = useCallback(
+    (sample: MultiTouchSample) => {
+      send(androidTouchMessage(sample.phase, sample.a, 0));
+      send(androidTouchMessage(sample.phase, sample.b, 1));
     },
     [send],
   );
@@ -1810,6 +1820,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
     videoKind: useWebRtc ? 'video' : 'canvas',
     attachVideo,
     sendTouch,
+    sendMultiTouch,
     sendKey,
     pressButton,
     reload,

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -44,6 +44,7 @@ import {
   androidStreamSourceErrorMessage,
   parseAndroidStreamSource,
 } from './android-stream-source';
+import { androidTouchMessage } from './android-touch';
 import { mergeAuthoritativeDeviceSetting } from './device-setting-writes';
 import { buildCodecString, isWebCodecsSupported, parseFramePacket, scanAU } from './h264';
 import { KeyedWriteTracker } from './keyed-write-tracker';
@@ -126,8 +127,6 @@ const BUTTON_MESSAGE: Record<HardwareButton, Record<string, unknown> | null> = {
   appSwitcher: { type: 'recents' },
   power: { type: 'power' },
 };
-
-const TOUCH_ACTION = { begin: 'down', move: 'move', end: 'up' } as const;
 
 export function androidWsUrlFor(
   baseUrl: string,
@@ -338,7 +337,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
 
   const sendTouch = useCallback(
     (sample: TouchSample) => {
-      send({ type: 'touch', action: TOUCH_ACTION[sample.phase], x: sample.x, y: sample.y, pointerId: 0 });
+      send(androidTouchMessage(sample.phase, sample, 0));
     },
     [send],
   );


### PR DESCRIPTION
## Why

Pinch and zoom is a daily gesture for anyone testing maps, photos, or a web view, and Android
did not have it. `sendMultiTouch` is the only optional member of `DeviceClient`, and
`useAndroidDeviceClient` was the one implementation that omitted it, so `DeviceScreen` computed
`canMulti = !!sendMultiTouch` as false and refused both the Alt-drag synthetic pinch and a real
two-finger gesture. iOS had both.

The backend was already done. serve-emu carries `pointerId` end to end, through `input.ts`,
`control-input-queue.ts` and `grpc-session.ts`. This is the client method it was waiting for, so
the change stays inside `@expo/hub-client` and needs no serve-emu PR.

## Scope

New pure module `packages/@expo/hub-client/src/android-touch.ts`. `androidTouchMessage(phase,
point, pointerId)` builds one serve-emu control message from one unit point, passing 0..1
coordinates through unchanged. `WIRE_ACTION` replaces the `TOUCH_ACTION` constant that this change
deletes from `useAndroidDevice.ts`.

`useAndroidDeviceClient` routes `sendTouch` through it at pointer 0, so the wire payload is
unchanged. New `sendMultiTouch` calls it twice, point `a` at pointer 0 then point `b` at pointer 1.
Order matters: serve-emu emits a plain `ACTION_DOWN` for the second pointer and leaves scrcpy to
derive `ACTION_POINTER_DOWN`, so pointer 0 has to go down first.

`packages/@expo/hub-client/src/__tests__/android-touch.test.ts` adds five tests, including one that
asserts the single-touch payload field by field against what the hook sent before.

The doc comment on `DeviceClient.sendMultiTouch` loses its list of backends. It named only
serve-sim, this change would have made it stale a second time, and it now names the one client that
omits the method instead, so the `?` keeps a reason a reader can check.

Out of scope: `DeviceScreen.tsx` is untouched, and so is serve-emu. The gesture lifecycle,
including the Alt-drag mirror and the rAF throttle, already lived in `DeviceScreen` and still does.

## Tradeoffs

The new module holds no state. `DeviceScreen` owns the whole gesture lifecycle, including lifting
a single finger before a second one lands, so a stateful pointer tracker in the client would
duplicate that and could disagree with it.

One message per call, with the pointer id passed in, rather than a function over a list of points.
Both call sites have fixed arity, so a list would have added an empty case and an N-greater-than-2
case that neither caller can reach, and it would have hidden the pointer order inside a `map`
instead of showing it as two statements in `sendMultiTouch`.

## Blast Radius

`sendTouch` on Android changes shape but not output. It builds the same five-key payload through a
function instead of an inline object literal, and a test asserts the payload field by field.

Interleaved pointer 0 and pointer 1 moves defeat serve-emu's move coalescing. `ControlInputQueue`
merges a move only into the queue tail when the tail shares its `touch:<pointerId>` key, so
alternating fingers never match and a two-finger drag adds two entries per sample against a depth
cap of 128. `DeviceScreen` already throttles multi-touch samples to one per animation frame, and
the emulator kept up through the verification below. The fix belongs in serve-emu: coalesce against
the newest pending entry with the same key rather than only the tail.

One gap found and not fixed: the emulator gRPC input path sends a single-element `TouchPoint` array
per call and never accumulates concurrent pointers, so a two-finger gesture would arrive there as
two separate one-finger events. It is unreachable by default; the Hub's default input source is
scrcpy. Fixing it belongs in serve-emu.

Three pre-existing `DeviceScreen` gesture bugs become reachable on Android for the first time,
because `canMulti` was false here until now. They are all in the single-finger to two-finger
handover and iOS has had them all along. A third finger re-fires `sendMultiTouch({phase:'begin'})`
with no already-in-two-finger guard. A queued single-touch move can flush after the handover and
drag pointer 0 back for one frame. The handover's `sendTouch({phase:'end'})` uses the second
finger's position, so pointer 0 ends somewhere it never was. Alt-drag, the common path, hits none
of them. Fixing them means editing `DeviceScreen.tsx`, which is deliberately outside this PR.

## Verification

`bun run lint`, `bun run typecheck` and `bun run test` all pass from the repo root. `@expo/hub-client`
goes from 177 to 182 tests, 0 failures. In `packages/expo-device-hub`, `bunx tsc --noEmit` reports
206 errors, every one of them originating in `vendor/` and all present at `main`. `bunx changeset
status` bumps `expo-device-hub` only.

End to end in the Hub website against a booted emulator, driven with Playwright over a real dev
server. I enabled Android's `pointer_location` developer overlay for the run and restored it
afterwards; its header reads `P: <pointers down> / <pointers active>`. In one browser session
against one build, a plain drag on the streamed screen showed `P: 1 / 1` and one crosshair, and an
Alt-drag showed `P: 2 / 2` with two crosshairs mirrored about the screen centre, which is where
`altSecondFinger` puts the synthetic second finger. That also settles the one thing I could not
read off the source: scrcpy-server does derive `ACTION_POINTER_DOWN` from serve-emu's plain second
`ACTION_DOWN`.

`getevent -lt` proves nothing here and I dropped it. scrcpy-server injects through
`InputManager.injectInputEvent`, above the kernel input layer, so `getevent` recorded the device
list and zero events for both gestures.

## Suggested follow-up

Make `sendMultiTouch` required. Both real hooks now implement it and `NOOP_DEVICE_CLIENT` is the
only omitter, so dropping the `?`, giving the no-op client a stub, and deleting `canMulti` and its
four optional calls in `DeviceScreen.tsx` would let the compiler catch the next implementation that
forgets it. That is the trap this PR walked into, and no test can catch it today because the repo
has no React render harness. It needs a `DeviceScreen.tsx` edit, so it is not in this PR.
