### PR TITLE
Add strict host hardware H.264 encoding and probes

### DIFF
--- a/packages/serve-emu/packages/serve-emu/docs/hardware-encoder-spike.md
+++ b/packages/serve-emu/packages/serve-emu/docs/hardware-encoder-spike.md
@@ -1,0 +1,66 @@
+# Hardware H.264 encoder spike
+
+Validated on 2026-09-10 on macOS 26.6.2, Apple M4 Pro, Homebrew ffmpeg 9.0.1.
+The plan's older M2 / ffmpeg 8.1.2 environment description does not describe this host.
+
+## VideoToolbox results
+
+The final encoder command uses the existing RGB/PNG input and crop/rotation filters,
+then the following output arguments (shown for a 30 fps, 1 Mbps stream):
+
+```sh
+-pix_fmt nv12 -c:v h264_videotoolbox -allow_sw 0 -realtime 1 \
+-flags +low_delay -profile:v baseline \
+-b:v 1000000 -maxrate 1000000 -bufsize 1000000 -g 30 -bf 0 \
+-bsf:v h264_metadata=aud=insert -f h264 -flush_packets 1 pipe:1
+```
+
+`ffmpeg -hide_banner -h encoder=h264_videotoolbox` describes `allow_sw` as allowing
+software encoding; the smoke and session commands explicitly set it to zero.
+The smoke succeeds with that restriction, so VideoToolbox software fallback cannot
+satisfy hardware selection.
+
+The proposed `-realtime 1 -bf 0` arguments alone retain one encoded frame: supplying
+an original screenshot and exactly one duplicate produces one AUD before EOF.
+The parser cannot publish the original frame without the duplicate's AUD.
+Adding `-flags +low_delay` produces both access units before EOF, preserving the
+existing idle-flush behavior. FFmpeg's [VideoToolbox implementation](https://www.ffmpeg.org/doxygen/7.1/videotoolboxenc_8c_source.html)
+maps this flag to `EnableLowLatencyRateControl`.
+
+With six 128×128 RGB24 frames, 30 fps, 1 Mbps and a two-frame keyframe interval,
+`ffprobe -show_frames -show_streams` reported:
+
+| Encoder | Decoded frame types | Profile | B frames | AUD count | SPS/PPS count |
+| --- | --- | --- | --- | --- | --- |
+| libx264 | I, P, I, P, I, P | Constrained Baseline | 0 | 6 | 3 each |
+| h264_videotoolbox | I, P, I, P, I, P | Baseline | 0 | 6 | 3 each |
+
+VideoToolbox emitted 595 bytes. Each IDR was preceded by SPS/PPS, allowing the
+existing parser/config cache to support a new viewer. Three process-start,
+six-frame encode, and process-exit runs took 320, 306 and 310 ms for VideoToolbox;
+software took 31, 31 and 30 ms. These tiny-frame startup measurements are not a
+sustained CPU or browser-latency benchmark.
+
+The automated real-hardware test keeps stdin open, submits only an original frame
+and one duplicate, and requires configuration plus the original keyframe. Run:
+
+```sh
+bun test packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
+```
+
+The hardware test skips when the host probe cannot provide hardware encoding.
+A companion test requires an actionable error on such hosts. Software command
+regression tests compare the entire argument array, including the PNG variant.
+
+## Other hosts
+
+NVENC and VAAPI arguments have deterministic unit coverage for device selection,
+pixel conversion, rate control, zero B frames/lookahead, AUD insertion, and GOP
+settings. Neither backend exists in this Mac's ffmpeg build, and no Linux GPU was
+available for a live encode. They remain unverified on real Linux hardware.
+
+On Linux, selection tries NVENC then VAAPI. A backend must pass an actual bounded
+encode containing SPS, PPS, an IDR, and multiple AUDs before it can be selected.
+A pinned backend is the sole candidate. Failed attempts retain a bounded stderr
+tail and can be retried; they never select libx264. The VAAPI probe also checks
+read/write access to the chosen render device.

--- a/packages/serve-emu/packages/serve-emu/docs/hardware-encoder-spike.md
+++ b/packages/serve-emu/packages/serve-emu/docs/hardware-encoder-spike.md
@@ -27,7 +27,8 @@ Adding `-flags +low_delay` produces both access units before EOF, preserving the
 existing idle-flush behavior. FFmpeg's [VideoToolbox implementation](https://www.ffmpeg.org/doxygen/7.1/videotoolboxenc_8c_source.html)
 maps this flag to `EnableLowLatencyRateControl`.
 
-With six 128×128 RGB24 frames, 30 fps, 1 Mbps and a two-frame keyframe interval,
+The original spike used six 128×128 RGB24 frames, 30 fps, 1 Mbps and a two-frame
+keyframe interval. For that experiment,
 `ffprobe -show_frames -show_streams` reported:
 
 | Encoder | Decoded frame types | Profile | B frames | AUD count | SPS/PPS count |
@@ -41,8 +42,17 @@ six-frame encode, and process-exit runs took 320, 306 and 310 ms for VideoToolbo
 software took 31, 31 and 30 ms. These tiny-frame startup measurements are not a
 sustained CPU or browser-latency benchmark.
 
-The automated real-hardware test keeps stdin open, submits only an original frame
-and one duplicate, and requires configuration plus the original keyframe. Run:
+The production smoke encode and the automated real-hardware test use 256×256
+RGB24 frames. This exceeds the H.264 minimum width of 145 pixels on Turing and
+newer NVENC hardware, avoiding a false unavailable result from a too-small probe.
+NVIDIA confirms that [Turing and newer GPUs require larger minimum dimensions](https://forums.developer.nvidia.com/t/minimum-width-in-turing-gpus/155566).
+A resolver regression test checks the NVENC command's actual input dimensions and
+that stdin contains four complete RGB24 frames.
+
+The updated 256×256 real-hardware test keeps stdin open, submits only an original
+frame and one duplicate, and requires configuration plus the original keyframe.
+The VideoToolbox probe and this streaming test passed after the dimension change.
+The 128×128 measurements above remain the original spike results. Run:
 
 ```sh
 bun test packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts

--- a/packages/serve-emu/packages/serve-emu/src/exec.ts
+++ b/packages/serve-emu/packages/serve-emu/src/exec.ts
@@ -2,7 +2,7 @@ import {
   spawn,
   type ChildProcessByStdio,
 } from "node:child_process";
-import type { Readable } from "node:stream";
+import type { Readable, Writable } from "node:stream";
 
 // Bun serves HTTP and pumps video on one JS thread. All short-lived adb and
 // emulator commands go through this bounded executor so request bursts cannot
@@ -35,6 +35,8 @@ export class ExecError extends Error {
 }
 
 export type ExecOpts = {
+  /** Optional finite input, written once and followed by EOF after queue admission. */
+  stdin?: Buffer;
   /** Overall deadline, including time spent waiting for an executor slot. */
   timeout?: number;
   /** Combined stdout and stderr byte budget. */
@@ -86,6 +88,7 @@ export type ExecClock = {
 export type ExecSpawner = (
   cmd: string,
   args: string[],
+  options: { stdin: boolean },
 ) => ExecChild;
 
 export type ProcessExecutorOptions = {
@@ -114,9 +117,10 @@ const LANE_PRIORITY: Record<ExecLane, number> = {
 type ExecEncoding = "utf8" | "buffer";
 type ExecOutput = string | Buffer;
 type JobState = "queued" | "active" | "settled";
-type ExecChild = ChildProcessByStdio<null, Readable, Readable>;
+type ExecChild = ChildProcessByStdio<Writable | null, Readable, Readable>;
 
 type NormalizedExecOpts = {
+  stdin?: Buffer;
   timeout: number;
   maxBuffer: number;
   signal?: AbortSignal;
@@ -184,7 +188,10 @@ function normalizedOptions(
   ) {
     throw new TypeError("lane must be interactive, default, or background");
   }
-  return { timeout, maxBuffer, signal: options.signal, lane };
+  if (options.stdin !== undefined && !Buffer.isBuffer(options.stdin)) {
+    throw new TypeError("stdin must be a Buffer");
+  }
+  return { timeout, maxBuffer, signal: options.signal, lane, stdin: options.stdin };
 }
 
 function abortError(signal: AbortSignal): ExecError {
@@ -284,10 +291,9 @@ export class ProcessExecutor {
     );
     this.#spawn =
       options.spawn ??
-      ((cmd, args) =>
-        spawn(cmd, args, {
-          stdio: ["ignore", "pipe", "pipe"],
-        }));
+      ((cmd, args, { stdin }) => stdin
+        ? spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] })
+        : spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] }));
     this.#clock = options.clock ?? SYSTEM_CLOCK;
   }
 
@@ -428,7 +434,7 @@ export class ProcessExecutor {
 
     let child: ExecChild;
     try {
-      child = this.#spawn(job.cmd, job.args);
+      child = this.#spawn(job.cmd, job.args, { stdin: job.opts.stdin !== undefined });
     } catch (error) {
       job.terminalError =
         error instanceof Error ? error : new Error(String(error));
@@ -447,12 +453,21 @@ export class ProcessExecutor {
     });
     child.stdout.once("error", (error) => this.#processError(job, error));
     child.stderr.once("error", (error) => this.#processError(job, error));
+    child.stdin?.once("error", (error) => this.#processError(job, error));
     child.once("close", (status, signal) => {
       this.#finishActive(job, status, signal);
     });
 
     // Cover an abort/deadline fired synchronously inside an injected spawner.
     if (job.terminalError) this.#kill(job);
+    else if (job.opts.stdin !== undefined) {
+      try {
+        if (!child.stdin) throw new Error("subprocess stdin was not opened");
+        child.stdin.end(job.opts.stdin);
+      } catch (error) {
+        this.#processError(job, error instanceof Error ? error : new Error(String(error)));
+      }
+    }
   }
 
   #collect(

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -2,6 +2,8 @@ import {
   spawn,
   type ChildProcessWithoutNullStreams,
 } from "node:child_process";
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
 import {
   execText,
   type ExecOpts,
@@ -12,17 +14,25 @@ import type { VideoFrame } from "./scrcpy.ts";
 /**
  * Host-side H.264 encoder used by the emulator gRPC screenshot source.
  *
- * RGB frames or complete PNG images enter through stdin and ffmpeg/libx264
- * writes Annex-B H.264 to stdout. `aud=1` gives the parser an explicit
- * access-unit boundary, while zerolatency and disabled B-frames keep input
+ * RGB frames or complete PNG images enter through stdin and ffmpeg writes
+ * Annex-B H.264 to stdout. Every backend inserts AUDs for explicit
+ * access-unit boundaries, while low-delay settings and disabled B-frames keep input
  * timestamps paired with output access units in submission order.
  */
+
+export type FfmpegEncoderName =
+  | "libx264"
+  | "h264_videotoolbox"
+  | "h264_nvenc"
+  | "h264_vaapi";
 
 export type H264EncoderInputFormat = "rgb24" | "png";
 
 export type H264EncoderOpts = {
   width: number;
   height: number;
+  /** Resolved ffmpeg backend. Defaults to the existing software encoder. */
+  encoderName?: FfmpegEncoderName;
   /** Input written to ffmpeg. Defaults to fixed-size raw RGB frames. */
   inputFormat?: H264EncoderInputFormat;
   /** Android display rotation quarter turns applied before encoding. */
@@ -43,6 +53,7 @@ const NAL_SPS = 7;
 const NAL_PPS = 8;
 const NAL_AUD = 9;
 const START_CODE = Buffer.from([0, 0, 0, 1]);
+const MAX_OUTPUT_WITHOUT_AUD_BYTES = 1024 * 1024;
 const MAX_PENDING_OUTPUT_BYTES = 64 * 1024 * 1024;
 const MAX_RAW_FRAME_BYTES = 512 * 1024 * 1024;
 const MAX_PNG_FRAME_BYTES = 64 * 1024 * 1024;
@@ -53,6 +64,8 @@ const PROCESS_GRACE_MS = 250;
 const PROCESS_TERM_MS = 500;
 const PROCESS_KILL_MS = 500;
 const FFMPEG_PROBE_TIMEOUT_MS = 10_000;
+const HARDWARE_PROBE_TIMEOUT_MS = 3_000;
+const HARDWARE_PROBE_MAX_BYTES = 1024 * 1024;
 const FFMPEG_PROBE_MAX_BYTES = 8 * 1024 * 1024;
 const MAX_FFMPEG_STDERR_BYTES = 16 * 1024;
 
@@ -131,6 +144,13 @@ function validateOptions(opts: H264EncoderOpts): number | null {
     throw new RangeError("quarterTurn must be an integer from 0 through 3");
   }
 
+  if (
+    opts.encoderName !== undefined &&
+    !["libx264", "h264_videotoolbox", "h264_nvenc", "h264_vaapi"].includes(opts.encoderName)
+  ) {
+    throw new RangeError(`unsupported ffmpeg H.264 encoder ${opts.encoderName}`);
+  }
+
   const inputFormat = opts.inputFormat ?? "rgb24";
   if (inputFormat !== "rgb24" && inputFormat !== "png") {
     throw new RangeError(`unsupported H.264 encoder input format ${inputFormat}`);
@@ -194,6 +214,93 @@ export function videoFilter(quarterTurn: QuarterTurn): string {
   return filters.join(",");
 }
 
+type FfmpegEncoderArgsOptions = Pick<
+  H264EncoderOpts,
+  | "width"
+  | "height"
+  | "fps"
+  | "bitRate"
+  | "keyFrameInterval"
+  | "quarterTurn"
+  | "inputFormat"
+  | "encoderName"
+>;
+
+export function resolveVaapiDevice(): string {
+  return process.env.SERVE_EMU_VAAPI_DEVICE?.trim() || "/dev/dri/renderD128";
+}
+
+/** Shared input, geometry and Annex-B output, with backend-specific encoding. */
+export function ffmpegEncoderArgs(
+  opts: FfmpegEncoderArgsOptions,
+  vaapiDevice = resolveVaapiDevice(),
+): string[] {
+  const encoderName = opts.encoderName ?? "libx264";
+  const keyint = opts.keyFrameInterval > 0
+    ? Math.max(1, Math.round(opts.fps * opts.keyFrameInterval))
+    : 250;
+  const rate = [
+    "-b:v", String(opts.bitRate),
+    "-maxrate", String(opts.bitRate),
+    "-bufsize", String(opts.bitRate),
+  ];
+  const filter = videoFilter(opts.quarterTurn ?? 0);
+  const args = ["-hide_banner", "-loglevel", "error"];
+  if (encoderName === "h264_vaapi") {
+    args.push("-init_hw_device", `vaapi=va:${vaapiDevice}`, "-filter_hw_device", "va");
+  }
+  args.push(
+    ...ffmpegInputArgs(opts.inputFormat ?? "rgb24", opts.width, opts.height, opts.fps),
+    "-an",
+    "-vf",
+    encoderName === "h264_vaapi" ? `${filter},format=nv12,hwupload` : filter,
+  );
+  switch (encoderName) {
+    case "libx264":
+      // Preserve this command line byte for byte for existing software users.
+      args.push(
+        "-pix_fmt", "yuv420p", "-c:v", "libx264",
+        "-preset", "ultrafast", "-tune", "zerolatency",
+        "-profile:v", "baseline", ...rate,
+        "-x264-params",
+        `keyint=${keyint}:min-keyint=${keyint}:scenecut=0:repeat-headers=1:aud=1`,
+      );
+      break;
+    case "h264_videotoolbox":
+      // Real-time alone retains a frame: low_delay lets one idle duplicate
+      // provide the next AUD without waiting for further screenshot input.
+      args.push(
+        "-pix_fmt", "nv12", "-c:v", encoderName,
+        "-allow_sw", "0", "-realtime", "1", "-flags", "+low_delay",
+        "-profile:v", "baseline",
+        ...rate, "-g", String(keyint), "-bf", "0",
+        "-bsf:v", "h264_metadata=aud=insert",
+      );
+      break;
+    case "h264_nvenc":
+      args.push(
+        "-pix_fmt", "nv12", "-c:v", encoderName,
+        "-preset", "p1", "-tune", "ull", "-zerolatency", "1",
+        "-delay", "0", "-bf", "0", "-rc-lookahead", "0", "-rc", "cbr",
+        ...rate, "-g", String(keyint), "-forced-idr", "1", "-aud", "1",
+        "-profile:v", "baseline",
+      );
+      break;
+    case "h264_vaapi":
+      args.push(
+        "-c:v", encoderName, "-rc_mode", "CBR", ...rate,
+        "-g", String(keyint), "-bf", "0", "-async_depth", "1",
+        "-profile:v", "constrained_baseline",
+        "-bsf:v", "h264_metadata=aud=insert",
+      );
+      break;
+    default:
+      throw new RangeError(`unsupported ffmpeg H.264 encoder ${encoderName}`);
+  }
+  args.push("-f", "h264", "-flush_packets", "1", "pipe:1");
+  return args;
+}
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => {
     const timer = setTimeout(resolve, ms);
@@ -248,6 +355,14 @@ export class H264OutputParser {
       ? Buffer.concat([this.#pending, incoming])
       : incoming;
     this.#scanNals();
+    if (
+      this.#pending.length > MAX_OUTPUT_WITHOUT_AUD_BYTES &&
+      !this.#nals.some((nal) => nal.type === NAL_AUD)
+    ) {
+      throw new Error(
+        `ffmpeg H.264 output exceeded ${MAX_OUTPUT_WITHOUT_AUD_BYTES} bytes without an AUD (access unit delimiter)`,
+      );
+    }
     this.#emitCompleteAccessUnits();
   }
 
@@ -427,6 +542,254 @@ export function createFfmpegAvailabilityProbe(
 
 export const assertFfmpegAvailable = createFfmpegAvailabilityProbe();
 
+export type FfmpegSmokeRunner = (
+  binary: string,
+  args: string[],
+  input: Buffer,
+  options: ExecOpts,
+) => Promise<ExecResult<Buffer>>;
+
+/** The smoke encode needs stdin; keep its process, output and lifetime bounded. */
+export const runFfmpegSmokeEncode: FfmpegSmokeRunner = (
+  binary,
+  args,
+  input,
+  options,
+) => new Promise((resolve) => {
+  const stderr = new FfmpegStderrTail();
+  const stdout: Buffer[] = [];
+  let outputBytes = 0;
+  let settled = false;
+  let terminalError: Error | null = null;
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let proc: ChildProcessWithoutNullStreams | undefined;
+  const finish = (status: number | null, signal: NodeJS.Signals | null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    clearTimeout(killTimer);
+    options.signal?.removeEventListener("abort", onAbort);
+    resolve({
+      status, signal, stdout: Buffer.concat(stdout), stderr: stderr.text(),
+      timedOut, error: terminalError,
+    });
+  };
+  const fail = (error: Error) => {
+    if (settled || terminalError) return;
+    terminalError = error;
+    if (!proc) {
+      finish(null, null);
+      return;
+    }
+    try { proc.kill("SIGKILL"); } catch {}
+    // Even a broken driver/process must not retain the caller indefinitely.
+    killTimer = setTimeout(() => {
+      proc?.stdin.destroy();
+      proc?.stdout.destroy();
+      proc?.stderr.destroy();
+      finish(null, "SIGKILL");
+    }, PROCESS_KILL_MS);
+  };
+  const onAbort = () => fail(probeAbortReason(options.signal!));
+  if (options.signal?.aborted) {
+    onAbort();
+    return;
+  }
+  try {
+    proc = spawn(binary, args, { stdio: ["pipe", "pipe", "pipe"] });
+  } catch (error) {
+    fail(error instanceof Error ? error : new Error(String(error)));
+    return;
+  }
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+  timer = setTimeout(() => {
+    timedOut = true;
+    fail(new Error(`smoke encode timed out after ${options.timeout}ms`));
+  }, options.timeout ?? HARDWARE_PROBE_TIMEOUT_MS);
+  const collect = (chunk: Buffer, isStderr: boolean) => {
+    if (settled) return;
+    if (isStderr) stderr.append(chunk);
+    if (terminalError) return;
+    outputBytes += chunk.length;
+    if (outputBytes > (options.maxBuffer ?? HARDWARE_PROBE_MAX_BYTES)) {
+      fail(new Error("smoke encode exceeded its output limit"));
+    } else if (!isStderr) {
+      stdout.push(chunk);
+    }
+  };
+  proc.stdout.on("data", (chunk: Buffer) => collect(chunk, false));
+  proc.stderr.on("data", (chunk: Buffer) => collect(chunk, true));
+  proc.stdin.once("error", fail);
+  proc.stdout.once("error", fail);
+  proc.stderr.once("error", fail);
+  proc.once("error", fail);
+  proc.once("close", finish);
+  if (options.signal?.aborted) onAbort();
+  if (!terminalError) proc.stdin.end(input);
+});
+
+export type FfmpegEncoderResolverOptions = FfmpegAvailabilityProbeOptions & {
+  platform?: () => NodeJS.Platform;
+  hardwareEncoder?: () => string | undefined;
+  vaapiDevice?: () => string;
+  checkVaapiDevice?: (path: string) => Promise<void>;
+  runSmoke?: FfmpegSmokeRunner;
+};
+
+type GrpcEncoderSelection = "software" | "hardware";
+
+/** Require decodable Annex-B configuration, an IDR and frame boundaries. */
+function validateSmokeOutput(output: Buffer): void {
+  const types = new Set<number>();
+  let audCount = 0;
+  for (let i = 0; i + 3 < output.length; i++) {
+    if (output[i] === 0 && output[i + 1] === 0 && output[i + 2] === 1) {
+      const type = output[i + 3]! & 0x1f;
+      types.add(type);
+      if (type === NAL_AUD) audCount++;
+    }
+  }
+  const missing = [
+    ...(!types.has(NAL_SPS) ? ["SPS"] : []),
+    ...(!types.has(NAL_PPS) ? ["PPS"] : []),
+    ...(!types.has(NAL_IDR) ? ["IDR"] : []),
+    ...(audCount < 2 ? ["AUD boundaries"] : []),
+  ];
+  if (missing.length) {
+    throw new Error(`smoke encode produced H.264 without ${missing.join(", ")}`);
+  }
+}
+
+/** Strict hardware selection; cache only successes for the binary and config. */
+export function createFfmpegEncoderResolver(
+  options: FfmpegEncoderResolverOptions = {},
+): {
+  resolveEncoder: (encoder: GrpcEncoderSelection, signal?: AbortSignal) => Promise<FfmpegEncoderName>;
+  getHardwareEncoderError: () => string | undefined;
+} {
+  const resolveBinary = options.resolveBinary ?? resolveFfmpeg;
+  const softwareProbe = createFfmpegAvailabilityProbe(options);
+  const runExec = options.runExec ?? execText;
+  const runSmoke = options.runSmoke ?? runFfmpegSmokeEncode;
+  const platform = options.platform ?? (() => process.platform);
+  const hardwareEncoder = options.hardwareEncoder ??
+    (() => process.env.SERVE_EMU_HARDWARE_ENCODER?.trim());
+  const vaapiDevice = options.vaapiDevice ?? resolveVaapiDevice;
+  const checkVaapiDevice = options.checkVaapiDevice ??
+    ((path: string) => access(path, constants.R_OK | constants.W_OK));
+  const successes = new Map<string, FfmpegEncoderName>();
+  const errors = new Map<string, string>();
+  const config = () => {
+    const binary = resolveBinary();
+    const host = platform();
+    const pin = hardwareEncoder() || "";
+    const device = vaapiDevice();
+    return { binary, host, pin, device, key: JSON.stringify([binary, host, pin, device]) };
+  };
+  return {
+    getHardwareEncoderError: () => errors.get(config().key),
+    async resolveEncoder(encoder, signal) {
+      if (signal?.aborted) throw probeAbortReason(signal);
+      if (encoder === "software") {
+        await softwareProbe(signal);
+        return "libx264";
+      }
+      if (encoder !== "hardware") {
+        throw new RangeError(`unsupported gRPC encoder ${encoder}`);
+      }
+      const { binary, host, pin, device, key } = config();
+      const cached = successes.get(key);
+      if (cached) return cached;
+      try {
+        const backendNames = {
+          videotoolbox: "h264_videotoolbox",
+          nvenc: "h264_nvenc",
+          vaapi: "h264_vaapi",
+        } as const;
+        if (pin && !Object.hasOwn(backendNames, pin)) {
+          throw new Error(
+            `SERVE_EMU_HARDWARE_ENCODER must be videotoolbox, nvenc, or vaapi (received "${pin}")`,
+          );
+        }
+        const candidates: FfmpegEncoderName[] = pin
+          ? [backendNames[pin as keyof typeof backendNames]]
+          : host === "darwin" ? ["h264_videotoolbox"]
+          : host === "linux" ? ["h264_nvenc", "h264_vaapi"] : [];
+        if (!candidates.length) {
+          throw new Error(`hardware H.264 encoding is not supported on ${host}`);
+        }
+        const listing = await runExec(binary, ["-hide_banner", "-encoders"], {
+          timeout: FFMPEG_PROBE_TIMEOUT_MS,
+          maxBuffer: FFMPEG_PROBE_MAX_BYTES,
+          signal,
+          lane: "background",
+        });
+        if (signal?.aborted) throw probeAbortReason(signal);
+        if (listing.error || listing.status !== 0) {
+          throw new Error(listing.timedOut
+            ? `capability probe timed out after ${FFMPEG_PROBE_TIMEOUT_MS}ms`
+            : listing.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
+              listing.error?.message || `exit ${listing.status}`);
+        }
+        const listed = `${listing.stdout}\n${listing.stderr}`;
+        const failures: string[] = [];
+        for (const encoderName of candidates) {
+          try {
+            if (!new RegExp(`\\b${encoderName}\\b`).test(listed)) {
+              throw new Error("encoder is not included in this ffmpeg build");
+            }
+            if (encoderName === "h264_vaapi") {
+              try {
+                await checkVaapiDevice(device);
+              } catch {
+                throw new Error(
+                  `cannot access VAAPI device "${device}"; check the render group, driver and SERVE_EMU_VAAPI_DEVICE`,
+                );
+              }
+            }
+            if (signal?.aborted) throw probeAbortReason(signal);
+            const smoke = await runSmoke(binary, ffmpegEncoderArgs({
+              width: 128, height: 128, fps: 30, bitRate: 1_000_000,
+              keyFrameInterval: 1, encoderName,
+            }, device), Buffer.alloc(128 * 128 * 3 * 4, 96), {
+              timeout: HARDWARE_PROBE_TIMEOUT_MS,
+              maxBuffer: HARDWARE_PROBE_MAX_BYTES,
+              signal,
+              lane: "background",
+            });
+            if (signal?.aborted) throw probeAbortReason(signal);
+            if (smoke.error || smoke.status !== 0) {
+              throw new Error(smoke.timedOut
+                ? `smoke encode timed out after ${HARDWARE_PROBE_TIMEOUT_MS}ms`
+                : smoke.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
+                  smoke.error?.message || `exit ${smoke.status}`);
+            }
+            validateSmokeOutput(smoke.stdout);
+            successes.set(key, encoderName);
+            errors.delete(key);
+            return encoderName;
+          } catch (error) {
+            if (signal?.aborted) throw probeAbortReason(signal);
+            failures.push(`${encoderName}: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+        throw new Error(failures.join("; "));
+      } catch (error) {
+        if (signal?.aborted) throw probeAbortReason(signal);
+        const message = `Hardware H.264 encoder unavailable (ffmpeg "${binary}"): ${error instanceof Error ? error.message : String(error)}`;
+        errors.set(key, message);
+        throw new Error(message);
+      }
+    },
+  };
+}
+
+const defaultEncoderResolver = createFfmpegEncoderResolver();
+export const resolveFfmpegEncoder = defaultEncoderResolver.resolveEncoder;
+export const getHardwareEncoderError = defaultEncoderResolver.getHardwareEncoderError;
+
 export class H264Encoder {
   readonly width: number;
   readonly height: number;
@@ -465,56 +828,9 @@ export class H264Encoder {
       this.#resolveProcessDone = resolve;
     });
 
-    const keyint = opts.keyFrameInterval > 0
-      ? Math.max(1, Math.round(opts.fps * opts.keyFrameInterval))
-      : 250;
-    const x264Params = [
-      `keyint=${keyint}`,
-      `min-keyint=${keyint}`,
-      "scenecut=0",
-      "repeat-headers=1",
-      "aud=1",
-    ].join(":");
-
     this.#proc = spawn(
       resolveFfmpeg(),
-      [
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        ...ffmpegInputArgs(
-          this.inputFormat,
-          opts.width,
-          opts.height,
-          opts.fps,
-        ),
-        "-an",
-        "-vf",
-        videoFilter(this.quarterTurn),
-        "-pix_fmt",
-        "yuv420p",
-        "-c:v",
-        "libx264",
-        "-preset",
-        "ultrafast",
-        "-tune",
-        "zerolatency",
-        "-profile:v",
-        "baseline",
-        "-b:v",
-        String(opts.bitRate),
-        "-maxrate",
-        String(opts.bitRate),
-        "-bufsize",
-        String(opts.bitRate),
-        "-x264-params",
-        x264Params,
-        "-f",
-        "h264",
-        "-flush_packets",
-        "1",
-        "pipe:1",
-      ],
+      ffmpegEncoderArgs(opts),
       { stdio: ["pipe", "pipe", "pipe"] },
     );
 

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -6,6 +6,7 @@ import { access } from "node:fs/promises";
 import { constants } from "node:fs";
 import {
   execText,
+  execBuffer,
   type ExecOpts,
   type ExecResult,
 } from "./exec.ts";
@@ -20,11 +21,11 @@ import type { VideoFrame } from "./scrcpy.ts";
  * timestamps paired with output access units in submission order.
  */
 
-export type FfmpegEncoderName =
-  | "libx264"
-  | "h264_videotoolbox"
-  | "h264_nvenc"
-  | "h264_vaapi";
+const FFMPEG_ENCODER_NAMES = [
+  "libx264", "h264_videotoolbox", "h264_nvenc", "h264_vaapi",
+] as const;
+
+export type FfmpegEncoderName = typeof FFMPEG_ENCODER_NAMES[number];
 
 export type H264EncoderInputFormat = "rgb24" | "png";
 
@@ -148,7 +149,7 @@ function validateOptions(opts: H264EncoderOpts): number | null {
 
   if (
     opts.encoderName !== undefined &&
-    !["libx264", "h264_videotoolbox", "h264_nvenc", "h264_vaapi"].includes(opts.encoderName)
+    !FFMPEG_ENCODER_NAMES.includes(opts.encoderName)
   ) {
     throw new RangeError(`unsupported ffmpeg H.264 encoder ${opts.encoderName}`);
   }
@@ -551,85 +552,17 @@ export type FfmpegSmokeRunner = (
   options: ExecOpts,
 ) => Promise<ExecResult<Buffer>>;
 
-/** The smoke encode needs stdin; keep its process, output and lifetime bounded. */
+/** Share subprocess lanes, deadlines, output bounds and cancellation with other commands. */
 export const runFfmpegSmokeEncode: FfmpegSmokeRunner = (
   binary,
   args,
   input,
   options,
-) => new Promise((resolve) => {
-  const stderr = new FfmpegStderrTail();
-  const stdout: Buffer[] = [];
-  let outputBytes = 0;
-  let settled = false;
-  let terminalError: Error | null = null;
-  let timedOut = false;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let killTimer: ReturnType<typeof setTimeout> | undefined;
-  let proc: ChildProcessWithoutNullStreams | undefined;
-  const finish = (status: number | null, signal: NodeJS.Signals | null) => {
-    if (settled) return;
-    settled = true;
-    clearTimeout(timer);
-    clearTimeout(killTimer);
-    options.signal?.removeEventListener("abort", onAbort);
-    resolve({
-      status, signal, stdout: Buffer.concat(stdout), stderr: stderr.text(),
-      timedOut, error: terminalError,
-    });
-  };
-  const fail = (error: Error) => {
-    if (settled || terminalError) return;
-    terminalError = error;
-    if (!proc) {
-      finish(null, null);
-      return;
-    }
-    try { proc.kill("SIGKILL"); } catch {}
-    // Even a broken driver/process must not retain the caller indefinitely.
-    killTimer = setTimeout(() => {
-      proc?.stdin.destroy();
-      proc?.stdout.destroy();
-      proc?.stderr.destroy();
-      finish(null, "SIGKILL");
-    }, PROCESS_KILL_MS);
-  };
-  const onAbort = () => fail(probeAbortReason(options.signal!));
-  if (options.signal?.aborted) {
-    onAbort();
-    return;
-  }
-  try {
-    proc = spawn(binary, args, { stdio: ["pipe", "pipe", "pipe"] });
-  } catch (error) {
-    fail(error instanceof Error ? error : new Error(String(error)));
-    return;
-  }
-  options.signal?.addEventListener("abort", onAbort, { once: true });
-  timer = setTimeout(() => {
-    timedOut = true;
-    fail(new Error(`smoke encode timed out after ${options.timeout}ms`));
-  }, options.timeout ?? HARDWARE_PROBE_TIMEOUT_MS);
-  const collect = (chunk: Buffer, isStderr: boolean) => {
-    if (settled) return;
-    if (isStderr) stderr.append(chunk);
-    if (terminalError) return;
-    outputBytes += chunk.length;
-    if (outputBytes > (options.maxBuffer ?? HARDWARE_PROBE_MAX_BYTES)) {
-      fail(new Error("smoke encode exceeded its output limit"));
-    } else if (!isStderr) {
-      stdout.push(chunk);
-    }
-  };
-  proc.stdout.on("data", (chunk: Buffer) => collect(chunk, false));
-  proc.stderr.on("data", (chunk: Buffer) => collect(chunk, true));
-  proc.stdin.once("error", fail);
-  proc.stdout.once("error", fail);
-  proc.stderr.once("error", fail);
-  proc.once("error", fail);
-  proc.once("close", finish);
-  if (options.signal?.aborted) onAbort();
-  if (!terminalError) proc.stdin.end(input);
+) => execBuffer(binary, args, {
+  ...options,
+  stdin: input,
+  timeout: options.timeout ?? HARDWARE_PROBE_TIMEOUT_MS,
+  maxBuffer: options.maxBuffer ?? HARDWARE_PROBE_MAX_BYTES,
 });
 
 export type FfmpegEncoderResolverOptions = FfmpegAvailabilityProbeOptions & {
@@ -670,6 +603,7 @@ export function createFfmpegEncoderResolver(
 ): {
   resolveEncoder: (encoder: GrpcEncoderSelection, signal?: AbortSignal) => Promise<FfmpegEncoderName>;
   getHardwareEncoderError: () => string | undefined;
+  reportEncoderFailure: (encoderName: FfmpegEncoderName, message: string) => void;
 } {
   const resolveBinary = options.resolveBinary ?? resolveFfmpeg;
   const softwareProbe = createFfmpegAvailabilityProbe(options);
@@ -690,8 +624,115 @@ export function createFfmpegEncoderResolver(
     const device = vaapiDevice();
     return { binary, host, pin, device, key: JSON.stringify([binary, host, pin, device]) };
   };
+  type PendingProbe = {
+    controller: AbortController;
+    promise: Promise<FfmpegEncoderName>;
+    waiters: number;
+  };
+  const pending = new Map<string, PendingProbe>();
+  async function probeHardware(
+    { binary, host, pin, device, key }: ReturnType<typeof config>,
+    signal: AbortSignal,
+  ): Promise<FfmpegEncoderName> {
+    try {
+      const backendNames = {
+        videotoolbox: "h264_videotoolbox",
+        nvenc: "h264_nvenc",
+        vaapi: "h264_vaapi",
+      } as const;
+      if (pin && !Object.hasOwn(backendNames, pin)) {
+        throw new Error(
+          `SERVE_EMU_HARDWARE_ENCODER must be videotoolbox, nvenc, or vaapi (received "${pin}")`,
+        );
+      }
+      const candidates: FfmpegEncoderName[] = pin
+        ? [backendNames[pin as keyof typeof backendNames]]
+        : host === "darwin" ? ["h264_videotoolbox"]
+        : host === "linux" ? ["h264_nvenc", "h264_vaapi"] : [];
+      if (!candidates.length) {
+        throw new Error(`hardware H.264 encoding is not supported on ${host}`);
+      }
+      const listing = await runExec(binary, ["-hide_banner", "-encoders"], {
+        timeout: FFMPEG_PROBE_TIMEOUT_MS,
+        maxBuffer: FFMPEG_PROBE_MAX_BYTES,
+        signal,
+        lane: "background",
+      });
+      if (signal?.aborted) throw probeAbortReason(signal);
+      if (listing.error || listing.status !== 0) {
+        throw new Error(listing.timedOut
+          ? `capability probe timed out after ${FFMPEG_PROBE_TIMEOUT_MS}ms`
+          : listing.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
+            listing.error?.message || `exit ${listing.status}`);
+      }
+      const listed = `${listing.stdout}\n${listing.stderr}`;
+      const failures: string[] = [];
+      for (const encoderName of candidates) {
+        try {
+          if (!new RegExp(`\\b${encoderName}\\b`).test(listed)) {
+            throw new Error("encoder is not included in this ffmpeg build");
+          }
+          if (encoderName === "h264_vaapi") {
+            try {
+              await checkVaapiDevice(device);
+            } catch {
+              throw new Error(
+                `cannot access VAAPI device "${device}"; check the render group, driver and SERVE_EMU_VAAPI_DEVICE`,
+              );
+            }
+          }
+          if (signal?.aborted) throw probeAbortReason(signal);
+          const smoke = await runSmoke(binary, ffmpegEncoderArgs({
+            width: HARDWARE_PROBE_DIMENSION, height: HARDWARE_PROBE_DIMENSION,
+            fps: 30, bitRate: 1_000_000, keyFrameInterval: 1, encoderName,
+          }, device), Buffer.alloc(HARDWARE_PROBE_DIMENSION ** 2 * 3 * 4, 96), {
+            timeout: HARDWARE_PROBE_TIMEOUT_MS,
+            maxBuffer: HARDWARE_PROBE_MAX_BYTES,
+            signal,
+            lane: "background",
+          });
+          if (signal?.aborted) throw probeAbortReason(signal);
+          if (smoke.error || smoke.status !== 0) {
+            throw new Error(smoke.timedOut
+              ? `smoke encode timed out after ${HARDWARE_PROBE_TIMEOUT_MS}ms`
+              : smoke.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
+                smoke.error?.message || `exit ${smoke.status}`);
+          }
+          validateSmokeOutput(smoke.stdout);
+          successes.set(key, encoderName);
+          errors.delete(key);
+          return encoderName;
+        } catch (error) {
+          if (signal?.aborted) throw probeAbortReason(signal);
+          failures.push(`${encoderName}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      throw new Error(failures.join("; "));
+    } catch (error) {
+      if (signal?.aborted) throw probeAbortReason(signal);
+      const message = `Hardware H.264 encoder unavailable (ffmpeg "${binary}"): ${error instanceof Error ? error.message : String(error)}`;
+      errors.set(key, message);
+      throw new Error(message);
+    }
+  }
   return {
     getHardwareEncoderError: () => errors.get(config().key),
+    reportEncoderFailure(encoderName, detail) {
+      if (encoderName === "libx264") return;
+      const message = `Hardware H.264 encoder unavailable: ${encoderName}: ${detail.slice(-MAX_FFMPEG_STDERR_BYTES)}`;
+      for (const [key, cached] of successes) {
+        if (cached !== encoderName) continue;
+        successes.delete(key);
+        errors.set(key, message);
+      }
+      const { key } = config();
+      if (!successes.has(key)) {
+        errors.set(key, message);
+        const task = pending.get(key);
+        pending.delete(key);
+        task?.controller.abort(new Error(message));
+      }
+    },
     async resolveEncoder(encoder, signal) {
       if (signal?.aborted) throw probeAbortReason(signal);
       if (encoder === "software") {
@@ -701,89 +742,50 @@ export function createFfmpegEncoderResolver(
       if (encoder !== "hardware") {
         throw new RangeError(`unsupported gRPC encoder ${encoder}`);
       }
-      const { binary, host, pin, device, key } = config();
+      const configuration = config();
+      const { key } = configuration;
       const cached = successes.get(key);
       if (cached) return cached;
-      try {
-        const backendNames = {
-          videotoolbox: "h264_videotoolbox",
-          nvenc: "h264_nvenc",
-          vaapi: "h264_vaapi",
-        } as const;
-        if (pin && !Object.hasOwn(backendNames, pin)) {
-          throw new Error(
-            `SERVE_EMU_HARDWARE_ENCODER must be videotoolbox, nvenc, or vaapi (received "${pin}")`,
-          );
-        }
-        const candidates: FfmpegEncoderName[] = pin
-          ? [backendNames[pin as keyof typeof backendNames]]
-          : host === "darwin" ? ["h264_videotoolbox"]
-          : host === "linux" ? ["h264_nvenc", "h264_vaapi"] : [];
-        if (!candidates.length) {
-          throw new Error(`hardware H.264 encoding is not supported on ${host}`);
-        }
-        const listing = await runExec(binary, ["-hide_banner", "-encoders"], {
-          timeout: FFMPEG_PROBE_TIMEOUT_MS,
-          maxBuffer: FFMPEG_PROBE_MAX_BYTES,
-          signal,
-          lane: "background",
-        });
-        if (signal?.aborted) throw probeAbortReason(signal);
-        if (listing.error || listing.status !== 0) {
-          throw new Error(listing.timedOut
-            ? `capability probe timed out after ${FFMPEG_PROBE_TIMEOUT_MS}ms`
-            : listing.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
-              listing.error?.message || `exit ${listing.status}`);
-        }
-        const listed = `${listing.stdout}\n${listing.stderr}`;
-        const failures: string[] = [];
-        for (const encoderName of candidates) {
-          try {
-            if (!new RegExp(`\\b${encoderName}\\b`).test(listed)) {
-              throw new Error("encoder is not included in this ffmpeg build");
-            }
-            if (encoderName === "h264_vaapi") {
-              try {
-                await checkVaapiDevice(device);
-              } catch {
-                throw new Error(
-                  `cannot access VAAPI device "${device}"; check the render group, driver and SERVE_EMU_VAAPI_DEVICE`,
-                );
-              }
-            }
-            if (signal?.aborted) throw probeAbortReason(signal);
-            const smoke = await runSmoke(binary, ffmpegEncoderArgs({
-              width: HARDWARE_PROBE_DIMENSION, height: HARDWARE_PROBE_DIMENSION,
-              fps: 30, bitRate: 1_000_000, keyFrameInterval: 1, encoderName,
-            }, device), Buffer.alloc(HARDWARE_PROBE_DIMENSION ** 2 * 3 * 4, 96), {
-              timeout: HARDWARE_PROBE_TIMEOUT_MS,
-              maxBuffer: HARDWARE_PROBE_MAX_BYTES,
-              signal,
-              lane: "background",
-            });
-            if (signal?.aborted) throw probeAbortReason(signal);
-            if (smoke.error || smoke.status !== 0) {
-              throw new Error(smoke.timedOut
-                ? `smoke encode timed out after ${HARDWARE_PROBE_TIMEOUT_MS}ms`
-                : smoke.stderr.trim().slice(-MAX_FFMPEG_STDERR_BYTES) ||
-                  smoke.error?.message || `exit ${smoke.status}`);
-            }
-            validateSmokeOutput(smoke.stdout);
-            successes.set(key, encoderName);
-            errors.delete(key);
-            return encoderName;
-          } catch (error) {
-            if (signal?.aborted) throw probeAbortReason(signal);
-            failures.push(`${encoderName}: ${error instanceof Error ? error.message : String(error)}`);
-          }
-        }
-        throw new Error(failures.join("; "));
-      } catch (error) {
-        if (signal?.aborted) throw probeAbortReason(signal);
-        const message = `Hardware H.264 encoder unavailable (ffmpeg "${binary}"): ${error instanceof Error ? error.message : String(error)}`;
-        errors.set(key, message);
-        throw new Error(message);
+      let task = pending.get(key);
+      if (!task) {
+        const controller = new AbortController();
+        task = { controller, promise: probeHardware(configuration, controller.signal), waiters: 0 };
+        pending.set(key, task);
+        const started = task;
+        // A departing last waiter removes the task before its process settles.
+        // Its cleanup must never remove a newer retry for the same key.
+        void task.promise.finally(() => {
+          if (pending.get(key) === started) pending.delete(key);
+        }).catch(() => {});
       }
+      const shared = task;
+      shared.waiters++;
+      return new Promise<FfmpegEncoderName>((resolve, reject) => {
+        let settled = false;
+        const settle = (finish: () => void) => {
+          if (settled) return;
+          settled = true;
+          signal?.removeEventListener("abort", onAbort);
+          shared.waiters--;
+          finish();
+        };
+        const onAbort = () => {
+          if (settled) return;
+          const reason = probeAbortReason(signal!);
+          settle(() => reject(reason));
+          // One request never aborts a probe another device is still awaiting.
+          if (shared.waiters === 0) {
+            if (pending.get(key) === shared) pending.delete(key);
+            shared.controller.abort(reason);
+          }
+        };
+        shared.promise.then(
+          (name) => settle(() => resolve(name)),
+          (error) => settle(() => reject(error)),
+        );
+        signal?.addEventListener("abort", onAbort, { once: true });
+        if (signal?.aborted) onAbort();
+      });
     },
   };
 }
@@ -791,6 +793,7 @@ export function createFfmpegEncoderResolver(
 const defaultEncoderResolver = createFfmpegEncoderResolver();
 export const resolveFfmpegEncoder = defaultEncoderResolver.resolveEncoder;
 export const getHardwareEncoderError = defaultEncoderResolver.getHardwareEncoderError;
+export const reportFfmpegEncoderFailure = defaultEncoderResolver.reportEncoderFailure;
 
 export class H264Encoder {
   readonly width: number;

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -64,6 +64,8 @@ const PROCESS_GRACE_MS = 250;
 const PROCESS_TERM_MS = 500;
 const PROCESS_KILL_MS = 500;
 const FFMPEG_PROBE_TIMEOUT_MS = 10_000;
+// Turing and newer NVENC require an H.264 input width of at least 145 pixels.
+const HARDWARE_PROBE_DIMENSION = 256;
 const HARDWARE_PROBE_TIMEOUT_MS = 3_000;
 const HARDWARE_PROBE_MAX_BYTES = 1024 * 1024;
 const FFMPEG_PROBE_MAX_BYTES = 8 * 1024 * 1024;
@@ -751,9 +753,9 @@ export function createFfmpegEncoderResolver(
             }
             if (signal?.aborted) throw probeAbortReason(signal);
             const smoke = await runSmoke(binary, ffmpegEncoderArgs({
-              width: 128, height: 128, fps: 30, bitRate: 1_000_000,
-              keyFrameInterval: 1, encoderName,
-            }, device), Buffer.alloc(128 * 128 * 3 * 4, 96), {
+              width: HARDWARE_PROBE_DIMENSION, height: HARDWARE_PROBE_DIMENSION,
+              fps: 30, bitRate: 1_000_000, keyFrameInterval: 1, encoderName,
+            }, device), Buffer.alloc(HARDWARE_PROBE_DIMENSION ** 2 * 3 * 4, 96), {
               timeout: HARDWARE_PROBE_TIMEOUT_MS,
               maxBuffer: HARDWARE_PROBE_MAX_BYTES,
               signal,

--- a/packages/serve-emu/packages/serve-emu/tests/exec.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/exec.test.ts
@@ -48,6 +48,7 @@ class ManualClock implements ExecClock {
 }
 
 class FakeChild extends EventEmitter {
+  readonly stdin = new PassThrough();
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
   readonly killSignals: NodeJS.Signals[] = [];
@@ -100,6 +101,32 @@ async function flush(): Promise<void> {
 }
 
 describe("ProcessExecutor", () => {
+  test("sends stdin only after its background job receives a slot", async () => {
+    const { executor, children } = harness({ maxActive: 1 });
+    const active = executor.execText("active", []);
+    const queued = executor.execBuffer("with-input", [], {
+      lane: "background", stdin: Buffer.from("probe input"),
+    });
+    expect(executor.snapshot().lanes.background.queued).toBe(1);
+    expect(children).toHaveLength(1);
+    children[0]!.child.close();
+    expect(children[1]!.child.stdin.read()?.toString()).toBe("probe input");
+    expect(children[1]!.child.stdin.writableEnded).toBe(true);
+    children[1]!.child.close();
+    await Promise.all([active, queued]);
+  });
+
+  test("holds the active slot until close after a stdin error", async () => {
+    const { executor, children } = harness({ maxActive: 1 });
+    const result = executor.execBuffer("broken-input", [], { stdin: Buffer.alloc(1) });
+    const error = new Error("stdin EPIPE");
+    children[0]!.child.stdin.emit("error", error);
+    expect(children[0]!.child.killSignals).toEqual(["SIGKILL"]);
+    expect(executor.snapshot().active).toBe(1);
+    children[0]!.child.close(null, "SIGKILL");
+    expect((await result).error).toBe(error);
+  });
+
   test("handles synchronous deadlines and validates timer range", async () => {
     let cleared = 0;
     const clock: ExecClock = {

--- a/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
@@ -311,7 +311,7 @@ describe("ffmpeg hardware resolver", () => {
       runSmoke: async (exe, args, input, opts) => {
         calls.push(exe);
         expect(args).toContain(pin === "nvenc" ? "h264_nvenc" : "h264_videotoolbox");
-        expect(input.length).toBe(128 * 128 * 3 * 4);
+        expect(input.length).toBe(256 * 256 * 3 * 4);
         expect(opts).toMatchObject({ timeout: 3_000, maxBuffer: 1024 * 1024 });
         return smokeResult();
       },
@@ -324,6 +324,20 @@ describe("ffmpeg hardware resolver", () => {
     pin = "nvenc";
     expect(await resolver.resolveEncoder("hardware")).toBe("h264_nvenc");
     expect(calls).toEqual(["ffmpeg-one", "ffmpeg-two", "ffmpeg-two"]);
+  });
+
+  test("probes NVENC above its Turing minimum dimensions with complete RGB frames", async () => {
+    const resolver = createFfmpegEncoderResolver({
+      platform: () => "linux", hardwareEncoder: () => "nvenc",
+      runExec: hardwareListing,
+      runSmoke: async (_binary, args, input) => {
+        expect(args[args.indexOf("-c:v") + 1]).toBe("h264_nvenc");
+        expect(args[args.indexOf("-video_size") + 1]).toBe("256x256");
+        expect(input.length).toBe(256 * 256 * 3 * 4);
+        return smokeResult();
+      },
+    });
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_nvenc");
   });
 
   test("tries NVENC then VAAPI on Linux, passing the configured VAAPI device", async () => {
@@ -866,14 +880,14 @@ realHardwareTest("streams real hardware H.264 after only one idle duplicate, bef
     rejectFrame = reject;
   });
   const encoder = new H264Encoder({
-    width: 128, height: 128, fps: 30, bitRate: 1_000_000, keyFrameInterval: 1,
+    width: 256, height: 256, fps: 30, bitRate: 1_000_000, keyFrameInterval: 1,
     encoderName: hostHardwareEncoder as FfmpegEncoderName,
     onFrame(frame) { frames.push(frame); if (frame.isKey) resolveFrame(); },
     onExit(reason) { rejectFrame(new Error(reason)); },
   });
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    const image = Buffer.alloc(128 * 128 * 3, 96);
+    const image = Buffer.alloc(256 * 256 * 3, 96);
     // Honour pipe backpressure, as the actual gRPC capture session does.
     for (let index = 1; index <= 2; index++) {
       const deadline = Date.now() + 1_000;

--- a/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
@@ -2,6 +2,9 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, test } from "bun:test";
 import {
   createFfmpegAvailabilityProbe,
+  createFfmpegEncoderResolver,
+  ffmpegEncoderArgs,
+  runFfmpegSmokeEncode,
   FfmpegStderrTail,
   ffmpegInputArgs,
   H264Encoder,
@@ -9,6 +12,7 @@ import {
   resolveFfmpeg,
   videoFilter,
   type H264EncoderOpts,
+  type FfmpegEncoderName,
 } from "../src/h264-encoder.ts";
 import type { ExecResult } from "../src/exec.ts";
 import type { VideoFrame } from "../src/scrcpy.ts";
@@ -51,6 +55,9 @@ function hasFfmpegWithLibx264(): boolean {
 }
 
 const realFfmpegTest = hasFfmpegWithLibx264() ? test : test.skip;
+const hostResolver = createFfmpegEncoderResolver();
+const hostHardwareEncoder = await hostResolver.resolveEncoder("hardware").catch(() => null);
+const realHardwareTest = hostHardwareEncoder ? test : test.skip;
 
 function nal(
   typeByte: number,
@@ -188,12 +195,288 @@ describe("H264OutputParser", () => {
     expect(frames.map((frame) => frame.pts)).toEqual([16_667n, 33_334n]);
   });
 
+  test("fails bounded output with no AUD instead of silently buffering forever", () => {
+    const parser = new H264OutputParser({ fps: 30, onFrame: () => {} });
+    parser.push(nal(0x65));
+    expect(() => parser.push(Buffer.alloc(1024 * 1024, 0xff))).toThrow(
+      "without an AUD (access unit delimiter)",
+    );
+  });
+
   test("rejects invalid parser timing and timestamps", () => {
     expect(() => new H264OutputParser({ fps: 0, onFrame: () => {} })).toThrow(
       "fps must be greater than 0",
     );
     const parser = new H264OutputParser({ fps: 60, onFrame: () => {} });
     expect(() => parser.enqueuePts(-1n)).toThrow("non-negative bigint");
+  });
+});
+
+describe("ffmpeg backend arguments", () => {
+  const options = {
+    width: 360, height: 641, fps: 30, bitRate: 8_000_000,
+    keyFrameInterval: 2, quarterTurn: 1 as const,
+  };
+
+  test("preserves the complete existing software command exactly", () => {
+    const expected = [
+      "-hide_banner", "-loglevel", "error",
+      "-f", "rawvideo", "-pix_fmt", "rgb24", "-video_size", "360x641",
+      "-framerate", "30", "-i", "pipe:0", "-an", "-vf",
+      "crop=trunc(iw/2)*2:trunc(ih/2)*2,transpose=cclock",
+      "-pix_fmt", "yuv420p", "-c:v", "libx264",
+      "-preset", "ultrafast", "-tune", "zerolatency", "-profile:v", "baseline",
+      "-b:v", "8000000", "-maxrate", "8000000", "-bufsize", "8000000",
+      "-x264-params", "keyint=60:min-keyint=60:scenecut=0:repeat-headers=1:aud=1",
+      "-f", "h264", "-flush_packets", "1", "pipe:1",
+    ];
+    expect(ffmpegEncoderArgs(options)).toEqual(expected);
+    expect(ffmpegEncoderArgs({ ...options, encoderName: "libx264" })).toEqual(expected);
+    expect(ffmpegEncoderArgs({ ...options, keyFrameInterval: 0 })).toContain(
+      "keyint=250:min-keyint=250:scenecut=0:repeat-headers=1:aud=1",
+    );
+    expect(ffmpegEncoderArgs({ ...options, inputFormat: "png" })).toEqual([
+      ...expected.slice(0, 3), ...ffmpegInputArgs("png", 360, 641, 30),
+      ...expected.slice(13),
+    ]);
+  });
+
+  test.each([
+    ["h264_videotoolbox", [
+      "-pix_fmt", "nv12", "-c:v", "h264_videotoolbox",
+      "-allow_sw", "0", "-realtime", "1", "-flags", "+low_delay",
+      "-profile:v", "baseline",
+      "-b:v", "8000000", "-maxrate", "8000000", "-bufsize", "8000000",
+      "-g", "60", "-bf", "0", "-bsf:v", "h264_metadata=aud=insert",
+    ]],
+    ["h264_nvenc", [
+      "-pix_fmt", "nv12", "-c:v", "h264_nvenc",
+      "-preset", "p1", "-tune", "ull", "-zerolatency", "1",
+      "-delay", "0", "-bf", "0", "-rc-lookahead", "0", "-rc", "cbr",
+      "-b:v", "8000000", "-maxrate", "8000000", "-bufsize", "8000000",
+      "-g", "60", "-forced-idr", "1", "-aud", "1", "-profile:v", "baseline",
+    ]],
+    ["h264_vaapi", [
+      "-c:v", "h264_vaapi", "-rc_mode", "CBR",
+      "-b:v", "8000000", "-maxrate", "8000000", "-bufsize", "8000000",
+      "-g", "60", "-bf", "0", "-async_depth", "1",
+      "-profile:v", "constrained_baseline", "-bsf:v", "h264_metadata=aud=insert",
+    ]],
+  ] as const)("builds low-delay %s with the shared geometry and Annex-B tail", (encoderName, backendArgs) => {
+    const args = ffmpegEncoderArgs({ ...options, encoderName }, "/dev/dri/custom");
+    expect(args).toEqual([
+      "-hide_banner", "-loglevel", "error",
+      ...(encoderName === "h264_vaapi"
+        ? ["-init_hw_device", "vaapi=va:/dev/dri/custom", "-filter_hw_device", "va"] : []),
+      ...ffmpegInputArgs("rgb24", 360, 641, 30), "-an", "-vf",
+      "crop=trunc(iw/2)*2:trunc(ih/2)*2,transpose=cclock" +
+        (encoderName === "h264_vaapi" ? ",format=nv12,hwupload" : ""),
+      ...backendArgs, "-f", "h264", "-flush_packets", "1", "pipe:1",
+    ]);
+    expect(args).not.toContain("libx264");
+    expect(args).not.toContain("-x264-params");
+  });
+});
+
+function smokeResult(overrides: Partial<ExecResult<Buffer>> = {}): ExecResult<Buffer> {
+  return {
+    ...execResult(),
+    stdout: Buffer.concat([aud(), nal(0x67), nal(0x68), nal(0x65), aud(), nal(0x41)]),
+    ...overrides,
+  };
+}
+
+const hardwareListing = () => Promise.resolve(execResult({
+  stdout: "V..... libx264\nV..... h264_videotoolbox\nV..... h264_nvenc\nV..... h264_vaapi",
+}));
+
+describe("ffmpeg hardware resolver", () => {
+  test("software ignores hardware configuration and retains the libx264 check", async () => {
+    const resolver = createFfmpegEncoderResolver({
+      runExec: hardwareListing,
+      hardwareEncoder: () => "invalid",
+      runSmoke: async () => { throw new Error("unexpected smoke encode"); },
+    });
+    expect(await resolver.resolveEncoder("software")).toBe("libx264");
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+  });
+
+  test("selects VideoToolbox on macOS, passes bounded input, and caches the binary/config", async () => {
+    let binary = "ffmpeg-one";
+    let pin: string | undefined;
+    const calls: string[] = [];
+    const resolver = createFfmpegEncoderResolver({
+      platform: () => "darwin", resolveBinary: () => binary,
+      hardwareEncoder: () => pin, runExec: hardwareListing,
+      runSmoke: async (exe, args, input, opts) => {
+        calls.push(exe);
+        expect(args).toContain(pin === "nvenc" ? "h264_nvenc" : "h264_videotoolbox");
+        expect(input.length).toBe(128 * 128 * 3 * 4);
+        expect(opts).toMatchObject({ timeout: 3_000, maxBuffer: 1024 * 1024 });
+        return smokeResult();
+      },
+    });
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_videotoolbox");
+    await resolver.resolveEncoder("hardware");
+    expect(calls).toHaveLength(1);
+    binary = "ffmpeg-two";
+    await resolver.resolveEncoder("hardware");
+    pin = "nvenc";
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_nvenc");
+    expect(calls).toEqual(["ffmpeg-one", "ffmpeg-two", "ffmpeg-two"]);
+  });
+
+  test("tries NVENC then VAAPI on Linux, passing the configured VAAPI device", async () => {
+    const calls: string[] = [];
+    const checked: string[] = [];
+    const resolver = createFfmpegEncoderResolver({
+      platform: () => "linux", hardwareEncoder: () => undefined,
+      runExec: hardwareListing, vaapiDevice: () => "/dev/dri/renderD129",
+      checkVaapiDevice: async (path) => { checked.push(path); },
+      runSmoke: async (_binary, args) => {
+        const name = args[args.indexOf("-c:v") + 1]!;
+        calls.push(name);
+        if (name === "h264_nvenc") return smokeResult({ status: 1, stderr: "Cannot load libcuda.so.1" });
+        expect(args).toContain("vaapi=va:/dev/dri/renderD129");
+        return smokeResult();
+      },
+    });
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_vaapi");
+    expect(calls).toEqual(["h264_nvenc", "h264_vaapi"]);
+    expect(checked).toEqual(["/dev/dri/renderD129"]);
+  });
+
+  test("a pinned backend never falls back, and failed probes remain retryable", async () => {
+    let fail = true;
+    const calls: string[] = [];
+    const resolver = createFfmpegEncoderResolver({
+      platform: () => "linux", hardwareEncoder: () => "nvenc", runExec: hardwareListing,
+      runSmoke: async (_binary, args) => {
+        calls.push(args[args.indexOf("-c:v") + 1]!);
+        return fail ? smokeResult({ status: 1, stderr: "NVIDIA driver unavailable" }) : smokeResult();
+      },
+    });
+    await expect(resolver.resolveEncoder("hardware")).rejects.toThrow("NVIDIA driver unavailable");
+    expect(resolver.getHardwareEncoderError()).toContain("h264_nvenc");
+    fail = false;
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_nvenc");
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+    expect(calls).toEqual(["h264_nvenc", "h264_nvenc"]);
+  });
+
+  test("a changed VAAPI device requires a new probe and scopes its failure", async () => {
+    let device = "/dev/dri/renderD128";
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "vaapi", vaapiDevice: () => device,
+      runExec: hardwareListing, runSmoke: async () => smokeResult(),
+      checkVaapiDevice: async (path) => { if (path.endsWith("129")) throw new Error("EACCES"); },
+    });
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_vaapi");
+    device = "/dev/dri/renderD129";
+    await expect(resolver.resolveEncoder("hardware")).rejects.toThrow("check the render group");
+    expect(resolver.getHardwareEncoderError()).toContain(device);
+    device = "/dev/dri/renderD128";
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+  });
+
+  test.each(["SPS", "PPS", "IDR", "AUD boundaries"])("rejects smoke output missing %s", async (missing) => {
+    const output = Buffer.concat([
+      ...(missing === "AUD boundaries" ? [] : [aud()]),
+      ...(missing === "SPS" ? [] : [nal(0x67)]),
+      ...(missing === "PPS" ? [] : [nal(0x68)]),
+      ...(missing === "IDR" ? [] : [nal(0x65)]),
+      aud(),
+    ]);
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: async () => smokeResult({ stdout: output }),
+    });
+    await expect(resolver.resolveEncoder("hardware")).rejects.toThrow(missing);
+  });
+
+  test("reports invalid pins, unsupported platforms and missing encoder builds", async () => {
+    for (const [pin, platform, message] of [
+      ["unknown", "darwin", "must be videotoolbox, nvenc, or vaapi"],
+      [undefined, "win32", "not supported on win32"],
+      ["nvenc", "linux", "encoder is not included"],
+    ] as const) {
+      const resolver = createFfmpegEncoderResolver({
+        hardwareEncoder: () => pin, platform: () => platform,
+        runExec: async () => execResult(),
+      });
+      await expect(resolver.resolveEncoder("hardware")).rejects.toThrow(message);
+    }
+  });
+
+  test("retains the stderr tail and reports timeout failures", async () => {
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: async () => smokeResult({ status: 1, stderr: "discard" + "x".repeat(20_000) + " useful driver error" }),
+    });
+    await expect(resolver.resolveEncoder("hardware")).rejects.toThrow("useful driver error");
+    expect(resolver.getHardwareEncoderError()).not.toContain("discard");
+    const timeout = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: async () => smokeResult({ status: null, timedOut: true, error: new Error("deadline") }),
+    });
+    await expect(timeout.resolveEncoder("hardware")).rejects.toThrow("timed out after 3000ms");
+  });
+
+  test("cancels before and during probing without caching a hardware failure", async () => {
+    let calls = 0;
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: async (_binary, _args, _input, options) => {
+        calls++;
+        if (calls === 1) await new Promise<void>((resolve) => {
+          options.signal!.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return smokeResult();
+      },
+    });
+    const controller = new AbortController();
+    const reason = new Error("capture cancelled");
+    const active = resolver.resolveEncoder("hardware", controller.signal);
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort(reason);
+    await expect(active).rejects.toBe(reason);
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+    await expect(resolver.resolveEncoder("hardware", controller.signal)).rejects.toBe(reason);
+    expect(await resolver.resolveEncoder("hardware")).toBe("h264_videotoolbox");
+    expect(calls).toBe(2);
+  });
+
+  realFfmpegTest("the host provides a working hardware encoder or an actionable strict failure", () => {
+    if (hostHardwareEncoder) expect(hostHardwareEncoder).toMatch(/^h264_(videotoolbox|nvenc|vaapi)$/);
+    else expect(hostResolver.getHardwareEncoderError()).toContain("Hardware H.264 encoder unavailable");
+  });
+});
+
+describe("smoke subprocess bounds", () => {
+  test("kills an encode that exceeds its timeout", async () => {
+    const start = Date.now();
+    const result = await runFfmpegSmokeEncode(process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"], Buffer.alloc(0), { timeout: 30 });
+    expect(result.timedOut).toBe(true);
+    expect(Date.now() - start).toBeLessThan(1_500);
+  });
+
+  test("terminates an aborted encode", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancel test encode");
+    const pending = runFfmpegSmokeEncode(process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"], Buffer.alloc(0), { timeout: 1000, signal: controller.signal });
+    controller.abort(reason);
+    expect((await pending).error).toBe(reason);
+  });
+
+  test("limits subprocess output", async () => {
+    const result = await runFfmpegSmokeEncode(process.execPath,
+      ["-e", "process.stdout.write('x'.repeat(65536)); setInterval(() => {}, 1000)"],
+      Buffer.alloc(0), { timeout: 1000, maxBuffer: 100 });
+    expect(result.error?.message).toContain("output limit");
+    expect(result.stdout.length).toBeLessThanOrEqual(100);
   });
 });
 
@@ -572,4 +855,41 @@ describe("ffmpeg diagnostics", () => {
     expect(stderr.text()).not.toContain("discarded:");
     expect(stderr.text()).toEndWith(":actionable failure");
   });
+});
+
+realHardwareTest("streams real hardware H.264 after only one idle duplicate, before stdin closes", async () => {
+  const frames: VideoFrame[] = [];
+  let resolveFrame!: () => void;
+  let rejectFrame!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveFrame = resolve;
+    rejectFrame = reject;
+  });
+  const encoder = new H264Encoder({
+    width: 128, height: 128, fps: 30, bitRate: 1_000_000, keyFrameInterval: 1,
+    encoderName: hostHardwareEncoder as FfmpegEncoderName,
+    onFrame(frame) { frames.push(frame); if (frame.isKey) resolveFrame(); },
+    onExit(reason) { rejectFrame(new Error(reason)); },
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const image = Buffer.alloc(128 * 128 * 3, 96);
+    // Honour pipe backpressure, as the actual gRPC capture session does.
+    for (let index = 1; index <= 2; index++) {
+      const deadline = Date.now() + 1_000;
+      while (!encoder.write(image, BigInt(index))) {
+        if (Date.now() >= deadline) throw new Error("hardware input never drained");
+        await Bun.sleep(10);
+      }
+      await Bun.sleep(100);
+    }
+    await Promise.race([ready, new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error("hardware did not stream before EOF")), 2_000);
+    })]);
+    expect(frames.some((frame) => frame.isConfig)).toBe(true);
+    expect(frames.some((frame) => frame.isKey && frame.pts === 1n)).toBe(true);
+  } finally {
+    clearTimeout(timeout);
+    await encoder.close();
+  }
 });

--- a/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
@@ -14,7 +14,7 @@ import {
   type H264EncoderOpts,
   type FfmpegEncoderName,
 } from "../src/h264-encoder.ts";
-import type { ExecResult } from "../src/exec.ts";
+import { ExecError, getExecSnapshot, type ExecResult } from "../src/exec.ts";
 import type { VideoFrame } from "../src/scrcpy.ts";
 
 type Deferred<T> = {
@@ -291,6 +291,108 @@ const hardwareListing = () => Promise.resolve(execResult({
 }));
 
 describe("ffmpeg hardware resolver", () => {
+  test("shares concurrent probes while cancelling only the departing caller", async () => {
+    const completion = deferred<ExecResult<Buffer>>();
+    const started = deferred<void>();
+    const signals: AbortSignal[] = [];
+    let listings = 0;
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox",
+      runExec: async () => { listings++; return hardwareListing(); },
+      runSmoke: (_binary, _args, _input, options) => {
+        signals.push(options.signal!);
+        started.resolve();
+        return completion.promise;
+      },
+    });
+    const controller = new AbortController();
+    const first = resolver.resolveEncoder("hardware", controller.signal);
+    const second = resolver.resolveEncoder("hardware");
+    await started.promise;
+    controller.abort(new Error("first device disconnected"));
+    await expect(first).rejects.toThrow("first device disconnected");
+    expect(signals).toHaveLength(1);
+    expect(signals[0]!.aborted).toBe(false);
+    expect(listings).toBe(1);
+    completion.resolve(smokeResult());
+    expect(await second).toBe("h264_videotoolbox");
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+  });
+
+  test("runtime failure invalidates hardware success and allows a fresh probe", async () => {
+    let calls = 0;
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: async () => { calls++; return smokeResult(); },
+    });
+    await resolver.resolveEncoder("hardware");
+    resolver.reportEncoderFailure("h264_videotoolbox", "encoder exited unexpectedly");
+    expect(resolver.getHardwareEncoderError()).toContain("encoder exited unexpectedly");
+    await resolver.resolveEncoder("hardware");
+    expect(calls).toBe(2);
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+    resolver.reportEncoderFailure("libx264", "software failure");
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+  });
+
+  test("cancels a shared probe when all callers leave and isolates its late result from retries", async () => {
+    const firstCompletion = deferred<ExecResult<Buffer>>();
+    const retryCompletion = deferred<ExecResult<Buffer>>();
+    const started = deferred<void>();
+    const retryStarted = deferred<void>();
+    const signals: AbortSignal[] = [];
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: (_binary, _args, _input, options) => {
+        signals.push(options.signal!);
+        if (signals.length === 1) {
+          started.resolve();
+          return firstCompletion.promise;
+        }
+        retryStarted.resolve();
+        return retryCompletion.promise;
+      },
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const first = resolver.resolveEncoder("hardware", firstController.signal);
+    const second = resolver.resolveEncoder("hardware", secondController.signal);
+    await started.promise;
+    firstController.abort(new Error("first caller left"));
+    await expect(first).rejects.toThrow("first caller left");
+    expect(signals[0]!.aborted).toBe(false);
+    secondController.abort(new Error("last caller left"));
+    await expect(second).rejects.toThrow("last caller left");
+    expect(signals[0]!.aborted).toBe(true);
+    const retry = resolver.resolveEncoder("hardware");
+    await retryStarted.promise;
+    firstCompletion.resolve(smokeResult());
+    await Promise.resolve();
+    await Promise.resolve();
+    const joinedRetry = resolver.resolveEncoder("hardware");
+    retryCompletion.resolve(smokeResult());
+    expect(await Promise.all([retry, joinedRetry])).toEqual([
+      "h264_videotoolbox", "h264_videotoolbox",
+    ]);
+    expect(signals).toHaveLength(2);
+    expect(resolver.getHardwareEncoderError()).toBeUndefined();
+  });
+
+  test("runtime failure cannot be cleared by a stale pending success", async () => {
+    const completion = deferred<ExecResult<Buffer>>();
+    const started = deferred<void>();
+    const resolver = createFfmpegEncoderResolver({
+      hardwareEncoder: () => "videotoolbox", runExec: hardwareListing,
+      runSmoke: () => { started.resolve(); return completion.promise; },
+    });
+    const pending = resolver.resolveEncoder("hardware");
+    await started.promise;
+    resolver.reportEncoderFailure("h264_videotoolbox", "device lost");
+    completion.resolve(smokeResult());
+    await expect(pending).rejects.toThrow("device lost");
+    expect(resolver.getHardwareEncoderError()).toContain("device lost");
+  });
+
   test("software ignores hardware configuration and retains the libx264 check", async () => {
     const resolver = createFfmpegEncoderResolver({
       runExec: hardwareListing,
@@ -468,6 +570,17 @@ describe("ffmpeg hardware resolver", () => {
 });
 
 describe("smoke subprocess bounds", () => {
+  test("uses executor background accounting and the effective default deadline", async () => {
+    const started = getExecSnapshot().totals.started;
+    const pending = runFfmpegSmokeEncode(process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"], Buffer.alloc(0), { lane: "background" });
+    expect(getExecSnapshot().lanes.background.active).toBeGreaterThan(0);
+    const result = await pending;
+    expect(getExecSnapshot().totals.started).toBe(started + 1);
+    expect(result.timedOut).toBe(true);
+    expect(result.error?.message).toContain("3000ms");
+  });
+
   test("kills an encode that exceeds its timeout", async () => {
     const start = Date.now();
     const result = await runFfmpegSmokeEncode(process.execPath,
@@ -482,14 +595,16 @@ describe("smoke subprocess bounds", () => {
     const pending = runFfmpegSmokeEncode(process.execPath,
       ["-e", "setInterval(() => {}, 1000)"], Buffer.alloc(0), { timeout: 1000, signal: controller.signal });
     controller.abort(reason);
-    expect((await pending).error).toBe(reason);
+    const error = (await pending).error;
+    expect(error).toBeInstanceOf(ExecError);
+    expect(error?.cause).toBe(reason);
   });
 
   test("limits subprocess output", async () => {
     const result = await runFfmpegSmokeEncode(process.execPath,
       ["-e", "process.stdout.write('x'.repeat(65536)); setInterval(() => {}, 1000)"],
       Buffer.alloc(0), { timeout: 1000, maxBuffer: 100 });
-    expect(result.error?.message).toContain("output limit");
+    expect(result.error).toMatchObject({ code: "output-limit" });
     expect(result.stdout.length).toBeLessThanOrEqual(100);
   });
 });


### PR DESCRIPTION
Adds strict host H.264 hardware encoding for Android gRPC screenshots while preserving the software FFmpeg command byte for byte. macOS uses VideoToolbox; Linux tries NVENC then VAAPI. A pinned backend is the only candidate, and hardware selection never falls back to software.

Each hardware backend must pass a real bounded 256×256 smoke encode with SPS/PPS, an IDR and multiple AUDs. Smoke processes use the shared ProcessExecutor with finite stdin, background lane admission, deadlines, output bounds and cancellation. Concurrent requests share a probe per configuration; cancelling one caller leaves other callers running, and cancelling every caller allows a clean retry. Successful probes are cached; failures remain retryable. A runtime-failure hook invalidates cached hardware success for the integration layer.

Backend arguments disable reordering/lookahead as appropriate and add AUDs. VideoToolbox requires `-allow_sw 0` and `-flags +low_delay`; the latter was verified necessary for delivery after one idle duplicate before stdin closes. The parser rejects excessive output without access-unit boundaries.

Validation: 63 focused executor/encoder tests, including real VideoToolbox output, subprocess accounting and stdin errors, concurrent cancellation/retry, runtime cache invalidation, the default 3000ms deadline message, and exact software argument regression. The combined stack passes all 973 serve-emu tests, critical coverage, typechecks, builds, documentation checks and package smoke; the latest Ubuntu CI check passes.

Live validation used Apple M4 Pro, macOS 26.6.2 and FFmpeg 9.0.1. Linux hardware execution remains unverified. Backend spike findings are recorded in the package documentation.

PR 1 of 3.

— Codex (GPT-6)
