### PR TITLE
Expose hardware encoder selection throughout serve-emu

### DIFF
--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -244,8 +244,11 @@ curl -X POST "$BASE/api/devices/select" \
 `GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, `encoder`,
 `encoderName`, `availableEncoders`, the available stream and input sources, and the
 active session generation. `encoderName` identifies the active ffmpeg backend, or is
-`null` for scrcpy. `availableEncoders` includes `software` and lists `hardware` until
-a hardware probe fails; `hardwareEncoderError` then describes the failure.
+`null` for scrcpy. `availableEncoders` includes `software` and `hardware` so a failed
+hardware request can be retried. `hardwareEncoderError` is advisory: it describes
+the latest hardware probe or runtime encoder failure and clears after a successful
+hardware probe. Unexpected hardware encoder failures invalidate the cached probe,
+so the next hardware request probes again.
 `/health` and `/api` also report the active `encoderName`.
 
 `PUT /api/stream-mode` accepts optional `grpcImageMode` (`png`, `mmap`, or `rgb888`),

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -56,7 +56,10 @@ Planned:
 - `adb` on PATH from Android platform-tools
 - A booted device/emulator from `adb devices`, or an AVD name passed with `--avd`
 - A modern browser with H.264 WebRTC support or WebCodecs; MSE is used when WebCodecs is unavailable
-- `ffmpeg` with `libx264` when using `--stream-mode grpc-screenshot`
+- `ffmpeg` with `libx264` when using `--stream-mode grpc-screenshot` (the default software encoder)
+- For `--encoder hardware`: macOS uses VideoToolbox (included in Homebrew ffmpeg); Linux tries NVENC, then VAAPI. NVENC requires the NVIDIA driver. On Ubuntu/Debian, install `ffmpeg` and a VAAPI driver such as `intel-media-va-driver-non-free` or `mesa-va-drivers` for Intel/AMD, with access to `/dev/dri/renderD128` through the `render` group. Docker also needs `--device /dev/dri`.
+
+Hardware selection runs a short encode probe and requires a working hardware backend. It never falls back to software. `SERVE_EMU_HARDWARE_ENCODER=videotoolbox|nvenc|vaapi` pins a backend; `SERVE_EMU_VAAPI_DEVICE` overrides the VAAPI device path.
 
 Node.js 18+ can invoke the published package through `npx`, but local development and server runtime use Bun.
 
@@ -98,7 +101,7 @@ bun run --filter serve-emu start
 ## CLI
 
 ```text
-serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
+serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--encoder software|hardware] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
 serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
 serve-emu --avd <name> [--gpu <mode>] [--restart-avd] [--camera] [--camera-image <path.png>]
 serve-emu --avd-list
@@ -113,6 +116,7 @@ serve-emu --running-avds
 | `--unsafe-no-auth` | false | Allow a non-loopback bind with **no** authentication (dangerous) |
 | `-s, --serial` | auto | adb device serial; required when multiple devices are online |
 | `--stream-mode` | `scrcpy` | Screen capture source: `scrcpy`, or emulator-only host capture through `grpc-screenshot` |
+| `--encoder` | `software` | Host H.264 encoder for gRPC streaming: `software` uses libx264; `hardware` requires VideoToolbox, NVENC, or VAAPI. No software fallback |
 | `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
 | `--max-fps` | `60` | Cap source frame rate |
@@ -237,13 +241,26 @@ curl -X POST "$BASE/api/devices/select" \
   -d '{"serial":"emulator-5554"}'
 ```
 
-`GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, the
-available stream and input sources, and the active session generation. `PUT
-/api/stream-mode` accepts an optional `grpcImageMode` of `png`, `mmap`, or `rgb888` and an
-optional `inputSource` of `scrcpy` or `grpc` when `mode` is `grpc-screenshot`.
-gRPC streaming defaults to the control-only scrcpy input transport.
-Changing either value stages one replacement capture atomically; an MMAP error
-is returned to the caller and never retried as PNG.
+`GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, `encoder`,
+`encoderName`, `availableEncoders`, the available stream and input sources, and the
+active session generation. `encoderName` identifies the active ffmpeg backend, or is
+`null` for scrcpy. `availableEncoders` includes `software` and lists `hardware` until
+a hardware probe fails; `hardwareEncoderError` then describes the failure.
+`/health` and `/api` also report the active `encoderName`.
+
+`PUT /api/stream-mode` accepts optional `grpcImageMode` (`png`, `mmap`, or `rgb888`),
+`inputSource` (`scrcpy` or `grpc`), and `encoder` (`software` or `hardware`) when
+`mode` is `grpc-screenshot`. Omitted settings keep their configured values.
+gRPC streaming defaults to software encoding and the control-only scrcpy input
+transport. Changing these settings stages a replacement capture atomically; any
+failure is returned while the current capture keeps running. Hardware never falls
+back to software, and MMAP never falls back to PNG.
+
+```sh
+curl -X PUT "$BASE/api/stream-mode" \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot","encoder":"hardware"}'
+```
 
 `/health` includes bounded subprocess executor activity, queue depth, lane
 counts, deadlines, overload rejections, and output-limit totals. Device-grid
@@ -675,11 +692,12 @@ when one is present. If an explicitly selected emulator exposes an endpoint
 without a token, `serve-emu` prints a warning before using that local endpoint;
 only select this mode for an emulator you trust.
 
-`serve-emu` encodes all three modes with ffmpeg/libx264 into the same Annex-B H.264
+`serve-emu` encodes all three modes with ffmpeg, using libx264 by default or the
+selected hardware backend, into the same Annex-B H.264
 packet shape, so browser streaming, backpressure recovery, recording, and the
 REST and WebSocket control APIs remain unchanged. The selected gRPC image mode
 never falls back automatically. The UI can replace either source or gRPC image
-mode at runtime; the current stream stays live until the replacement is ready.
+mode or encoder at runtime; the current stream stays live until the replacement is ready.
 
 For MMAP, `--max-size 0` allocates the fixed shared region from the display's
 native size at session startup. Rotation remains native-size, but a foldable or

--- a/packages/serve-emu/packages/serve-emu/CHANGELOG.md
+++ b/packages/serve-emu/packages/serve-emu/CHANGELOG.md
@@ -10,6 +10,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
 
 ## Unreleased
 
+- Add strict host hardware H.264 encoding for Android gRPC streaming with `--encoder hardware` and an Encoder control in the standalone UI. Software remains the default; stream-mode and health APIs report the active backend and hardware probe failures.
+
 ### Added
 
 - Add emulator-only gRPC screenshot streaming with host-side H.264 encoding,

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -58,7 +58,10 @@ Planned:
 - `adb` on PATH from Android platform-tools
 - A booted device/emulator from `adb devices`, or an AVD name passed with `--avd`
 - A modern browser with H.264 WebRTC support or WebCodecs; MSE is used when WebCodecs is unavailable
-- `ffmpeg` with `libx264` when using `--stream-mode grpc-screenshot`
+- `ffmpeg` with `libx264` when using `--stream-mode grpc-screenshot` (the default software encoder)
+- For `--encoder hardware`: macOS uses VideoToolbox (included in Homebrew ffmpeg); Linux tries NVENC, then VAAPI. NVENC requires the NVIDIA driver. On Ubuntu/Debian, install `ffmpeg` and a VAAPI driver such as `intel-media-va-driver-non-free` or `mesa-va-drivers` for Intel/AMD, with access to `/dev/dri/renderD128` through the `render` group. Docker also needs `--device /dev/dri`.
+
+Hardware selection runs a short encode probe and requires a working hardware backend. It never falls back to software. `SERVE_EMU_HARDWARE_ENCODER=videotoolbox|nvenc|vaapi` pins a backend; `SERVE_EMU_VAAPI_DEVICE` overrides the VAAPI device path.
 
 Node.js 18+ can invoke the published package through `npx`, but local development and server runtime use Bun.
 
@@ -100,7 +103,7 @@ bun run --filter serve-emu start
 ## CLI
 
 ```text
-serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
+serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode scrcpy|grpc-screenshot] [--grpc-image-mode png|mmap|rgb888] [--input-source scrcpy|grpc] [--encoder software|hardware] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms] [--max-apk-upload-bytes N] [--max-media-upload-bytes N]
 serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
 serve-emu --avd <name> [--gpu <mode>] [--restart-avd] [--camera] [--camera-image <path.png>]
 serve-emu --avd-list
@@ -115,6 +118,7 @@ serve-emu --running-avds
 | `--unsafe-no-auth` | false | Allow a non-loopback bind with **no** authentication (dangerous) |
 | `-s, --serial` | auto | adb device serial; required when multiple devices are online |
 | `--stream-mode` | `scrcpy` | Screen capture source: `scrcpy`, or emulator-only host capture through `grpc-screenshot` |
+| `--encoder` | `software` | Host H.264 encoder for gRPC streaming: `software` uses libx264; `hardware` requires VideoToolbox, NVENC, or VAAPI. No software fallback |
 | `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
 | `--max-fps` | `60` | Cap source frame rate |
@@ -239,13 +243,26 @@ curl -X POST "$BASE/api/devices/select" \
   -d '{"serial":"emulator-5554"}'
 ```
 
-`GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, the
-available stream and input sources, and the active session generation. `PUT
-/api/stream-mode` accepts an optional `grpcImageMode` of `png`, `mmap`, or `rgb888` and an
-optional `inputSource` of `scrcpy` or `grpc` when `mode` is `grpc-screenshot`.
-gRPC streaming defaults to the control-only scrcpy input transport.
-Changing either value stages one replacement capture atomically; an MMAP error
-is returned to the caller and never retried as PNG.
+`GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, `encoder`,
+`encoderName`, `availableEncoders`, the available stream and input sources, and the
+active session generation. `encoderName` identifies the active ffmpeg backend, or is
+`null` for scrcpy. `availableEncoders` includes `software` and lists `hardware` until
+a hardware probe fails; `hardwareEncoderError` then describes the failure.
+`/health` and `/api` also report the active `encoderName`.
+
+`PUT /api/stream-mode` accepts optional `grpcImageMode` (`png`, `mmap`, or `rgb888`),
+`inputSource` (`scrcpy` or `grpc`), and `encoder` (`software` or `hardware`) when
+`mode` is `grpc-screenshot`. Omitted settings keep their configured values.
+gRPC streaming defaults to software encoding and the control-only scrcpy input
+transport. Changing these settings stages a replacement capture atomically; any
+failure is returned while the current capture keeps running. Hardware never falls
+back to software, and MMAP never falls back to PNG.
+
+```sh
+curl -X PUT "$BASE/api/stream-mode" \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"grpc-screenshot","encoder":"hardware"}'
+```
 
 `/health` includes bounded subprocess executor activity, queue depth, lane
 counts, deadlines, overload rejections, and output-limit totals. Device-grid
@@ -677,11 +694,12 @@ when one is present. If an explicitly selected emulator exposes an endpoint
 without a token, `serve-emu` prints a warning before using that local endpoint;
 only select this mode for an emulator you trust.
 
-`serve-emu` encodes all three modes with ffmpeg/libx264 into the same Annex-B H.264
+`serve-emu` encodes all three modes with ffmpeg, using libx264 by default or the
+selected hardware backend, into the same Annex-B H.264
 packet shape, so browser streaming, backpressure recovery, recording, and the
 REST and WebSocket control APIs remain unchanged. The selected gRPC image mode
 never falls back automatically. The UI can replace either source or gRPC image
-mode at runtime; the current stream stays live until the replacement is ready.
+mode or encoder at runtime; the current stream stays live until the replacement is ready.
 
 For MMAP, `--max-size 0` allocates the fixed shared region from the display's
 native size at session startup. Rotation remains native-size, but a foldable or

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -246,8 +246,11 @@ curl -X POST "$BASE/api/devices/select" \
 `GET /api/stream-mode` reports `mode`, `grpcImageMode`, `inputSource`, `encoder`,
 `encoderName`, `availableEncoders`, the available stream and input sources, and the
 active session generation. `encoderName` identifies the active ffmpeg backend, or is
-`null` for scrcpy. `availableEncoders` includes `software` and lists `hardware` until
-a hardware probe fails; `hardwareEncoderError` then describes the failure.
+`null` for scrcpy. `availableEncoders` includes `software` and `hardware` so a failed
+hardware request can be retried. `hardwareEncoderError` is advisory: it describes
+the latest hardware probe or runtime encoder failure and clears after a successful
+hardware probe. Unexpected hardware encoder failures invalidate the cached probe,
+so the next hardware request probes again.
 `/health` and `/api` also report the active `encoderName`.
 
 `PUT /api/stream-mode` accepts optional `grpcImageMode` (`png`, `mmap`, or `rgb888`),

--- a/packages/serve-emu/packages/serve-emu/src/cli.ts
+++ b/packages/serve-emu/packages/serve-emu/src/cli.ts
@@ -29,6 +29,9 @@ import {
 } from "./stream-settings.ts";
 import packageJson from "../package.json";
 import {
+  DEFAULT_GRPC_ENCODER,
+  GRPC_ENCODERS,
+  isGrpcEncoder,
   DEFAULT_GRPC_INPUT_SOURCE,
   DEFAULT_GRPC_IMAGE_MODE,
   GRPC_IMAGE_MODES,
@@ -55,6 +58,7 @@ const { values } = parseArgs({
     "repeat-frame-ms": { type: "string", default: String(SCRCPY_DEFAULTS.repeatFrameMs) },
     "stream-mode": { type: "string" },
     "grpc-image-mode": { type: "string", default: DEFAULT_GRPC_IMAGE_MODE },
+    encoder: { type: "string", default: DEFAULT_GRPC_ENCODER },
     "input-source": { type: "string", default: DEFAULT_GRPC_INPUT_SOURCE },
     transport: { type: "string", default: "websocket" },
     "stun-url": { type: "string" },
@@ -192,7 +196,7 @@ if (values.help) {
   console.log(`serve-emu — host an Android device over WebSocket/WebRTC
 
 Usage:
-  serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--grpc-image-mode <png|mmap|rgb888>] [--input-source <scrcpy|grpc>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms]
+  serve-emu [-p <port>] [--host <addr>] [--token <secret>] [-s <serial>] [--stream-mode <scrcpy|grpc-screenshot>] [--grpc-image-mode <png|mmap|rgb888>] [--input-source <scrcpy|grpc>] [--encoder <software|hardware>] [--max-fps N] [--bit-rate N] [--max-size N] [--key-frame-interval sec] [--repeat-frame-ms ms]
   serve-emu --transport webrtc [--stun-url url[,url...]] [--turn-url url[,url...] --turn-username user --turn-credential pass]
   serve-emu --avd <name> [--restart-avd]
   serve-emu --avd-list
@@ -238,6 +242,12 @@ Options:
                          RGB888 sends raw pixels over gRPC.
                          MMAP uses shared memory for raw pixels. Capture errors
                          do not fall back to another mode.
+      --encoder <software|hardware>
+                         Host H.264 encoder for gRPC streaming (default: software).
+                         Hardware requires a working host GPU encoder; failures
+                         are returned without falling back to software.
+                         SERVE_EMU_HARDWARE_ENCODER pins videotoolbox, nvenc, or vaapi.
+                         SERVE_EMU_VAAPI_DEVICE overrides /dev/dri/renderD128.
       --input-source <scrcpy|grpc>
                          Input transport for gRPC streaming (default: scrcpy).
                          scrcpy runs a control-only server; grpc sends input
@@ -357,6 +367,13 @@ async function main() {
     );
   }
   const inputSource = requestedInputSource;
+  const requestedEncoder = stringOption("encoder") ?? DEFAULT_GRPC_ENCODER;
+  if (!isGrpcEncoder(requestedEncoder)) {
+    throw new Error(
+      `--encoder must be one of: ${GRPC_ENCODERS.join(", ")}. Received "${requestedEncoder}".`,
+    );
+  }
+  const encoder = requestedEncoder;
 
   let emulatorLaunch: Awaited<ReturnType<typeof startEmulator>> | null = null;
   const serial = values.avd
@@ -457,6 +474,7 @@ async function main() {
     repeatFrameMs,
     streamMode,
     grpcImageMode,
+    encoder,
     inputSource,
     streamSettings,
     maxApkUploadBytes,

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -25,6 +25,7 @@ import { execText, type ExecResult } from "./exec.ts";
 import {
   H264Encoder,
   resolveFfmpegEncoder,
+  reportFfmpegEncoderFailure,
   type FfmpegEncoderName,
   type H264EncoderInputFormat,
   type H264EncoderOpts,
@@ -209,12 +210,17 @@ export class GrpcCaptureDiagnosticsTracker {
   #acceptedEncoderWrites = 0;
   #encoderBackpressureRejections = 0;
 
-  constructor(
-    imageMode: GrpcImageMode,
+  constructor({
+    imageMode,
     windowCapacity = CAPTURE_DIAGNOSTIC_WINDOW,
     cadenceIdleResetMs = CAPTURE_CADENCE_IDLE_RESET_MS,
-    encoderName: FfmpegEncoderName = "libx264",
-  ) {
+    encoderName = "libx264",
+  }: {
+    imageMode: GrpcImageMode;
+    windowCapacity?: number;
+    cadenceIdleResetMs?: number;
+    encoderName?: FfmpegEncoderName;
+  }) {
     if (!Number.isFinite(cadenceIdleResetMs) || cadenceIdleResetMs <= 0) {
       throw new RangeError("cadence idle reset must be a positive number");
     }
@@ -1374,6 +1380,7 @@ export type GrpcSessionEncoder = {
 
 export type GrpcSessionRuntime = {
   resolveEncoder(encoder: GrpcEncoder, signal: AbortSignal): Promise<FfmpegEncoderName>;
+  reportEncoderFailure(encoderName: FfmpegEncoderName, message: string): void;
   ensureEndpoint(serial: string, signal: AbortSignal): Promise<GrpcEndpoint>;
   createClient(endpoint: GrpcEndpoint): GrpcSessionClient;
   createEncoder(options: H264EncoderOpts): GrpcSessionEncoder;
@@ -1644,6 +1651,7 @@ const defaultReadDisplaySizeSignal: NonNullable<
 
 const DEFAULT_GRPC_SESSION_RUNTIME: GrpcSessionRuntime = {
   resolveEncoder: resolveFfmpegEncoder,
+  reportEncoderFailure: reportFfmpegEncoderFailure,
   ensureEndpoint: ensureEmulatorGrpcEndpoint,
   createClient: (endpoint) => new EmulatorGrpcClient(endpoint),
   createEncoder: (options) => new H264Encoder(options),
@@ -1761,9 +1769,10 @@ export async function startGrpcSession(
     options.signal?.removeEventListener("abort", abortFromParent);
     throw error;
   }
-  const captureDiagnostics = new GrpcCaptureDiagnosticsTracker(
-    imageMode, undefined, undefined, encoderName,
-  );
+  const captureDiagnostics = new GrpcCaptureDiagnosticsTracker({
+    imageMode,
+    encoderName,
+  });
   const client = runtime.createClient(endpoint);
   const listeners = new Set<(failure: StreamFailure) => void>();
   const packetQueue = new GrpcVideoPacketQueue();
@@ -1934,6 +1943,7 @@ export async function startGrpcSession(
       sessionMeta.width = size.width;
       sessionMeta.height = size.height;
     }
+    let stopping = false;
     const next = runtime.createEncoder({
       encoderName,
       width: latest.width,
@@ -1947,7 +1957,13 @@ export async function startGrpcSession(
         if (!frame.isConfig) encoderHasOutput = true;
         pushPacket(frame);
       },
-      onExit: (message) => emitFatal({ message, code: "encoder-exit" }),
+      onExit: (message) => {
+        if (stopping || closed || lifetime.signal.aborted || fatalFailure) return;
+        if (encoderName !== "libx264") {
+          runtime.reportEncoderFailure(encoderName, message);
+        }
+        emitFatal({ message, code: "encoder-exit" });
+      },
     });
     if (restart.announceSize) {
       pushPacket({
@@ -1957,7 +1973,17 @@ export async function startGrpcSession(
         clientResized: false,
       });
     }
-    return next;
+    return {
+      width: next.width,
+      height: next.height,
+      quarterTurn: next.quarterTurn,
+      write: (image, ptsUs) => next.write(image, ptsUs),
+      close: () => {
+        // A replaced encoder must not invalidate the new session's backend.
+        stopping = true;
+        return next.close();
+      },
+    };
   });
   const restartEncoder = (
     announceSize: boolean,

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -24,7 +24,8 @@ import {
 import { execText, type ExecResult } from "./exec.ts";
 import {
   H264Encoder,
-  assertFfmpegAvailable,
+  resolveFfmpegEncoder,
+  type FfmpegEncoderName,
   type H264EncoderInputFormat,
   type H264EncoderOpts,
   type QuarterTurn,
@@ -56,9 +57,11 @@ import type {
   StreamFailure,
   StreamMeta,
 } from "./stream-session.ts";
-import type {
-  GrpcImageMode,
-  InputSource,
+import {
+  DEFAULT_GRPC_ENCODER,
+  type GrpcEncoder,
+  type GrpcImageMode,
+  type InputSource,
 } from "./shared/api-contracts.ts";
 
 export { H264StartupGate } from "./h264-readiness.ts";
@@ -175,6 +178,7 @@ class RollingTimingWindow {
 /** Collects the capture counters exposed through an EmuSession diagnostics snapshot. */
 export class GrpcCaptureDiagnosticsTracker {
   readonly #imageMode: GrpcImageMode;
+  readonly #encoderName: FfmpegEncoderName;
   #rawGrpcMessagesReceived = 0;
   #rawGrpcMessagesEmitted = 0;
   #rawGrpcMessagesCoalesced = 0;
@@ -209,11 +213,13 @@ export class GrpcCaptureDiagnosticsTracker {
     imageMode: GrpcImageMode,
     windowCapacity = CAPTURE_DIAGNOSTIC_WINDOW,
     cadenceIdleResetMs = CAPTURE_CADENCE_IDLE_RESET_MS,
+    encoderName: FfmpegEncoderName = "libx264",
   ) {
     if (!Number.isFinite(cadenceIdleResetMs) || cadenceIdleResetMs <= 0) {
       throw new RangeError("cadence idle reset must be a positive number");
     }
     this.#imageMode = imageMode;
+    this.#encoderName = encoderName;
     this.#cadenceIdleResetMs = cadenceIdleResetMs;
     this.#sourceTimestampIntervals = new RollingTimingWindow(windowCapacity);
     this.#rawMessageReceiveIntervals = new RollingTimingWindow(windowCapacity);
@@ -357,6 +363,7 @@ export class GrpcCaptureDiagnosticsTracker {
   snapshot(): GrpcCaptureDiagnostics {
     return {
       imageMode: this.#imageMode,
+      encoderName: this.#encoderName,
       rawGrpcMessagesReceived: this.#rawGrpcMessagesReceived,
       rawGrpcMessagesEmitted: this.#rawGrpcMessagesEmitted,
       rawGrpcMessagesCoalesced: this.#rawGrpcMessagesCoalesced,
@@ -1366,7 +1373,7 @@ export type GrpcSessionEncoder = {
 };
 
 export type GrpcSessionRuntime = {
-  assertFfmpeg(signal: AbortSignal): Promise<void>;
+  resolveEncoder(encoder: GrpcEncoder, signal: AbortSignal): Promise<FfmpegEncoderName>;
   ensureEndpoint(serial: string, signal: AbortSignal): Promise<GrpcEndpoint>;
   createClient(endpoint: GrpcEndpoint): GrpcSessionClient;
   createEncoder(options: H264EncoderOpts): GrpcSessionEncoder;
@@ -1636,7 +1643,7 @@ const defaultReadDisplaySizeSignal: NonNullable<
 };
 
 const DEFAULT_GRPC_SESSION_RUNTIME: GrpcSessionRuntime = {
-  assertFfmpeg: assertFfmpegAvailable,
+  resolveEncoder: resolveFfmpegEncoder,
   ensureEndpoint: ensureEmulatorGrpcEndpoint,
   createClient: (endpoint) => new EmulatorGrpcClient(endpoint),
   createEncoder: (options) => new H264Encoder(options),
@@ -1728,7 +1735,6 @@ export async function startGrpcSession(
   const accessUnitBoundaryCadence = new GrpcAccessUnitBoundaryCadence(
     frameIntervalMs,
   );
-  const captureDiagnostics = new GrpcCaptureDiagnosticsTracker(imageMode);
 
   if (!isEmulatorSerial(serial)) {
     throw new Error(
@@ -1744,13 +1750,20 @@ export async function startGrpcSession(
   if (options.signal?.aborted) abortFromParent();
 
   let endpoint: Awaited<ReturnType<typeof ensureEmulatorGrpcEndpoint>>;
+  let encoderName: FfmpegEncoderName;
   try {
-    await runtime.assertFfmpeg(lifetime.signal);
+    encoderName = await runtime.resolveEncoder(
+      options.encoder ?? DEFAULT_GRPC_ENCODER,
+      lifetime.signal,
+    );
     endpoint = await runtime.ensureEndpoint(serial, lifetime.signal);
   } catch (error) {
     options.signal?.removeEventListener("abort", abortFromParent);
     throw error;
   }
+  const captureDiagnostics = new GrpcCaptureDiagnosticsTracker(
+    imageMode, undefined, undefined, encoderName,
+  );
   const client = runtime.createClient(endpoint);
   const listeners = new Set<(failure: StreamFailure) => void>();
   const packetQueue = new GrpcVideoPacketQueue();
@@ -1922,6 +1935,7 @@ export async function startGrpcSession(
       sessionMeta.height = size.height;
     }
     const next = runtime.createEncoder({
+      encoderName,
       width: latest.width,
       height: latest.height,
       quarterTurn: 0,

--- a/packages/serve-emu/packages/serve-emu/src/middleware.ts
+++ b/packages/serve-emu/packages/serve-emu/src/middleware.ts
@@ -40,6 +40,7 @@ import {
   isEmulatorSerial,
 } from "./device-capabilities.ts";
 import { loadDeviceGrid } from "./device-grid.ts";
+import { getHardwareEncoderError } from "./h264-encoder.ts";
 import { FrameStatWindow } from "./frame-stat-window.ts";
 import {
   listAvds,
@@ -106,6 +107,9 @@ import {
 import {
   DEFAULT_GRPC_INPUT_SOURCE,
   DEFAULT_GRPC_IMAGE_MODE,
+  DEFAULT_GRPC_ENCODER,
+  GRPC_ENCODERS,
+  isGrpcEncoder,
   GRPC_IMAGE_MODES,
   INPUT_SOURCES,
   isGrpcImageMode,
@@ -114,6 +118,7 @@ import {
   parseFontScale,
   parseStreamModeRequest,
   type GrpcImageMode,
+  type GrpcEncoder,
   type InputSource,
   type StreamMode,
   type StreamModeResponse,
@@ -137,12 +142,15 @@ export type {
 export {
   DEFAULT_GRPC_INPUT_SOURCE,
   DEFAULT_GRPC_IMAGE_MODE,
+  DEFAULT_GRPC_ENCODER,
+  GRPC_ENCODERS,
+  isGrpcEncoder,
   GRPC_IMAGE_MODES,
   INPUT_SOURCES,
   isGrpcImageMode,
   isInputSource,
 } from "./shared/api-contracts.ts";
-export type { GrpcImageMode, InputSource } from "./shared/api-contracts.ts";
+export type { GrpcEncoder, GrpcImageMode, InputSource } from "./shared/api-contracts.ts";
 export type {
   StreamEncoderSettings,
   StreamSettings,
@@ -180,6 +188,8 @@ export type AppOptions = {
   streamMode?: StreamMode;
   /** Emulator gRPC image delivery mode. Defaults to PNG. */
   grpcImageMode?: GrpcImageMode;
+  /** Host H.264 encoder for gRPC capture. Defaults to software. */
+  encoder?: GrpcEncoder;
   /** Input transport. gRPC streaming defaults to scrcpy input. */
   inputSource?: InputSource;
   /** @internal Shared by router-managed source generations for one device. */
@@ -334,6 +344,10 @@ async function createAppInternal(
     );
   }
   const grpcImageMode = requestedGrpcImageMode;
+  const encoder: unknown = opts.encoder ?? DEFAULT_GRPC_ENCODER;
+  if (!isGrpcEncoder(encoder)) {
+    throw new Error(`encoder must be one of: ${GRPC_ENCODERS.join(", ")}`);
+  }
   const streamMode = opts.streamMode ?? "scrcpy";
   const requestedInputSource: unknown =
     opts.inputSource ??
@@ -378,6 +392,7 @@ async function createAppInternal(
       keyFrameInterval: opts.keyFrameInterval,
       mode: streamMode,
       grpcImageMode,
+      encoder,
       inputSource,
     });
     throwIfAborted(opts.signal, "serve-emu app startup aborted");
@@ -461,6 +476,8 @@ async function createAppInternal(
     device: session.meta.deviceName,
     streamMode: session.mode,
     grpcImageMode,
+    encoder,
+    encoderName: session.diagnostics?.().grpcCapture?.encoderName ?? null,
     inputSource: session.inputSource,
     grpcCapture: session.diagnostics?.().grpcCapture ?? null,
     codec: session.meta.codecId,
@@ -1028,6 +1045,7 @@ async function createAppInternal(
       keyFrameInterval: opts.keyFrameInterval,
       mode,
       grpcImageMode,
+      encoder,
       inputSource: nextInputSource,
     });
 
@@ -1223,6 +1241,10 @@ async function createAppInternal(
           serial: opts.serial,
           device: session.meta.deviceName,
           streamMode: session.mode,
+          grpcImageMode,
+          encoder,
+          encoderName: session.diagnostics?.().grpcCapture?.encoderName ?? null,
+          inputSource: session.inputSource,
           codec: session.meta.codecId,
           size: { width: screen.width, height: screen.height },
           status,
@@ -1915,6 +1937,9 @@ async function createAppInternal(
     }),
     /** Exact gRPC image mode configured for this app generation. */
     getGrpcImageMode: (): GrpcImageMode => grpcImageMode,
+    getEncoder: (): GrpcEncoder => encoder,
+    getEncoderName: (): string | null =>
+      session.diagnostics?.().grpcCapture?.encoderName ?? null,
     /** Exact input source configured for this app generation. */
     getInputSource: (): InputSource => session.inputSource,
     health,
@@ -1989,6 +2014,14 @@ function grpcImageModeForApp(
   return readMode?.() ?? fallback;
 }
 
+function encoderForApp(app: EmuApp, fallback = DEFAULT_GRPC_ENCODER): GrpcEncoder {
+  return (app as EmuApp & { getEncoder?: () => GrpcEncoder }).getEncoder?.() ?? fallback;
+}
+
+function encoderNameForApp(app: EmuApp): string | null {
+  return (app as EmuApp & { getEncoderName?: () => string | null }).getEncoderName?.() ?? null;
+}
+
 function inputSourceForApp(app: EmuApp): InputSource {
   const readSource = (
     app as EmuApp & {
@@ -2025,6 +2058,7 @@ export type RouterDependencies = {
   stopEmulator?: typeof stopEmulator;
   readCameraWiring?: typeof readCameraWiring;
   createApp?: (opts: AppOptions) => Promise<EmuApp>;
+  getHardwareEncoderError?: typeof getHardwareEncoderError;
 };
 
 /**
@@ -2048,11 +2082,13 @@ export function createRouter(
   const killEmulator = dependencies.stopEmulator ?? stopEmulator;
   const readWiring = dependencies.readCameraWiring ?? readCameraWiring;
   const createDeviceApp = dependencies.createApp ?? createApp;
+  const hardwareEncoderError = dependencies.getHardwareEncoderError ?? getHardwareEncoderError;
   const apps = new Map<string, EmuApp>();
   const pending = new Map<string, Promise<EmuApp>>();
   const failureAt = new Map<string, number>();
   const streamModeOverrides = new Map<string, StreamMode>();
   const grpcImageModeOverrides = new Map<string, GrpcImageMode>();
+  const encoderOverrides = new Map<string, GrpcEncoder>();
   const inputSourceOverrides = new Map<string, InputSource>();
   const streamModeQueues = new Map<string, Promise<void>>();
   const sessionGenerations = new Map<string, number>();
@@ -2180,6 +2216,7 @@ export function createRouter(
           defaults.inputSource ??
           DEFAULT_GRPC_INPUT_SOURCE
         : "scrcpy",
+    encoder = encoderOverrides.get(serial) ?? defaults.encoder ?? DEFAULT_GRPC_ENCODER,
   ): Promise<EmuApp> => {
     const operation = beginOperation(serial, parentSignal);
     let created: EmuApp | null = null;
@@ -2197,6 +2234,7 @@ export function createRouter(
         serial,
         streamMode,
         grpcImageMode,
+        encoder,
         inputSource,
         deviceState,
         signal: combineAbortSignals(defaults.signal, operation.signal),
@@ -2325,6 +2363,7 @@ export function createRouter(
     streamMode: StreamMode,
     requestedGrpcImageMode: GrpcImageMode | undefined,
     requestedInputSource: InputSource | undefined,
+    requestedEncoder: GrpcEncoder | undefined,
     signal: AbortSignal,
   ): Promise<EmuApp> => {
     if (stopped) throw new Error("serve-emu router is stopped");
@@ -2339,6 +2378,9 @@ export function createRouter(
     }
 
     const current = apps.get(serial);
+    const configuredEncoder = encoderOverrides.get(serial) ?? defaults.encoder ?? DEFAULT_GRPC_ENCODER;
+    const currentEncoder = current ? encoderForApp(current, configuredEncoder) : configuredEncoder;
+    const encoder = requestedEncoder ?? currentEncoder;
     const configuredGrpcImageMode =
       grpcImageModeOverrides.get(serial) ??
       defaults.grpcImageMode ??
@@ -2371,10 +2413,12 @@ export function createRouter(
       current?.isStreaming() &&
       currentMode === streamMode &&
       currentGrpcImageMode === grpcImageMode &&
+      currentEncoder === encoder &&
       currentInputSource === inputSource
     ) {
       streamModeOverrides.set(serial, streamMode);
       grpcImageModeOverrides.set(serial, grpcImageMode);
+      encoderOverrides.set(serial, encoder);
       if (streamMode === "grpc-screenshot") {
         inputSourceOverrides.set(serial, inputSource);
       }
@@ -2408,6 +2452,7 @@ export function createRouter(
         current ? streamEncoderSettingsForApp(current) : undefined,
         grpcImageMode,
         inputSource,
+        encoder,
       );
     } finally {
       await retainedDeviceState?.release(
@@ -2438,6 +2483,7 @@ export function createRouter(
     }
     streamModeOverrides.set(serial, streamMode);
     grpcImageModeOverrides.set(serial, grpcImageMode);
+    encoderOverrides.set(serial, encoder);
     if (streamMode === "grpc-screenshot") {
       inputSourceOverrides.set(serial, inputSource);
     }
@@ -2462,6 +2508,7 @@ export function createRouter(
     streamMode: StreamMode,
     grpcImageMode?: GrpcImageMode,
     inputSource?: InputSource,
+    encoder?: GrpcEncoder,
   ): Promise<EmuApp> =>
     enqueueStreamModeOperation(serial, (signal) =>
       performStreamModeSwitch(
@@ -2469,6 +2516,7 @@ export function createRouter(
         streamMode,
         grpcImageMode,
         inputSource,
+        encoder,
         signal,
       ),
     );
@@ -2509,6 +2557,10 @@ export function createRouter(
         defaults.grpcImageMode ??
         DEFAULT_GRPC_IMAGE_MODE,
     ),
+    encoder: encoderForApp(app, encoderOverrides.get(serial) ?? defaults.encoder ?? DEFAULT_GRPC_ENCODER),
+    encoderName: encoderNameForApp(app),
+    availableEncoders: hardwareEncoderError() ? ["software"] : [...GRPC_ENCODERS],
+    ...(hardwareEncoderError() ? { hardwareEncoderError: hardwareEncoderError() } : {}),
     inputSource: inputSourceForApp(app),
     availableInputSources:
       streamSessionForApp(app).mode === "grpc-screenshot"
@@ -2570,6 +2622,7 @@ export function createRouter(
     failureAt.delete(serial);
     streamModeOverrides.delete(serial);
     grpcImageModeOverrides.delete(serial);
+    encoderOverrides.delete(serial);
     inputSourceOverrides.delete(serial);
     streamModeQueues.delete(serial);
     sessionGenerations.delete(serial);
@@ -2660,6 +2713,7 @@ export function createRouter(
       let streamMode: StreamMode;
       let grpcImageMode: GrpcImageMode | undefined;
       let inputSource: InputSource | undefined;
+      let encoder: GrpcEncoder | undefined;
       try {
         const payload = await readRouterPayload(req);
         const streamModeRequest = parseStreamModeRequest(payload);
@@ -2670,6 +2724,7 @@ export function createRouter(
           );
         }
         streamMode = mode;
+        encoder = streamModeRequest.mode === "grpc-screenshot" ? streamModeRequest.encoder : undefined;
         grpcImageMode =
           streamModeRequest.mode === "grpc-screenshot"
             ? streamModeRequest.grpcImageMode
@@ -2688,6 +2743,7 @@ export function createRouter(
           streamMode,
           grpcImageMode,
           inputSource,
+          encoder,
         );
         return Response.json(streamModeResponse(serial, app));
       } catch (err) {
@@ -2931,6 +2987,7 @@ export function createRouter(
       failureAt.clear();
       streamModeOverrides.clear();
       grpcImageModeOverrides.clear();
+      encoderOverrides.clear();
       inputSourceOverrides.clear();
       streamModeQueues.clear();
       sessionGenerations.clear();

--- a/packages/serve-emu/packages/serve-emu/src/middleware.ts
+++ b/packages/serve-emu/packages/serve-emu/src/middleware.ts
@@ -2559,7 +2559,7 @@ export function createRouter(
     ),
     encoder: encoderForApp(app, encoderOverrides.get(serial) ?? defaults.encoder ?? DEFAULT_GRPC_ENCODER),
     encoderName: encoderNameForApp(app),
-    availableEncoders: hardwareEncoderError() ? ["software"] : [...GRPC_ENCODERS],
+    availableEncoders: [...GRPC_ENCODERS],
     ...(hardwareEncoderError() ? { hardwareEncoderError: hardwareEncoderError() } : {}),
     inputSource: inputSourceForApp(app),
     availableInputSources:

--- a/packages/serve-emu/packages/serve-emu/src/server.ts
+++ b/packages/serve-emu/packages/serve-emu/src/server.ts
@@ -1,3 +1,4 @@
+import { getHardwareEncoderError } from "./h264-encoder.ts";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { timingSafeEqual } from "node:crypto";
@@ -163,6 +164,9 @@ import {
 import {
   DEFAULT_GRPC_INPUT_SOURCE,
   DEFAULT_GRPC_IMAGE_MODE,
+  DEFAULT_GRPC_ENCODER,
+  GRPC_ENCODERS,
+  isGrpcEncoder,
   GRPC_IMAGE_MODES,
   INPUT_SOURCES,
   isGrpcImageMode,
@@ -173,6 +177,7 @@ import {
   parseStreamModeRequest,
   STREAM_MODES,
   type GrpcImageMode,
+  type GrpcEncoder,
   type InputSource,
   type StreamMode,
 } from "./shared/api-contracts.ts";
@@ -205,6 +210,8 @@ export type ServerOpts = {
   streamMode?: StreamMode;
   /** Emulator gRPC image delivery mode. Defaults to PNG. */
   grpcImageMode?: GrpcImageMode;
+  /** Host H.264 encoder for gRPC capture. Defaults to software. */
+  encoder?: GrpcEncoder;
   /** Input transport. gRPC streaming defaults to scrcpy input. */
   inputSource?: InputSource;
   maxApkUploadBytes?: number;
@@ -396,6 +403,11 @@ export async function startServer(
     );
   }
   const defaultGrpcImageMode = requestedDefaultGrpcImageMode;
+  const requestedDefaultEncoder: unknown = opts.encoder ?? DEFAULT_GRPC_ENCODER;
+  if (!isGrpcEncoder(requestedDefaultEncoder)) {
+    throw new Error(`encoder must be one of: ${GRPC_ENCODERS.join(", ")}`);
+  }
+  const defaultEncoder = requestedDefaultEncoder;
   const requestedDefaultInputSource: unknown =
     opts.inputSource ?? DEFAULT_GRPC_INPUT_SOURCE;
   if (!isInputSource(requestedDefaultInputSource)) {
@@ -517,6 +529,8 @@ export async function startServer(
       : DEFAULT_WEBRTC_STREAM_SETTINGS;
   const streamModes = new Map<string, StreamMode>();
   const grpcImageModes = new Map<string, GrpcImageMode>();
+  const encoders = new Map<string, GrpcEncoder>();
+  const contextEncoders = new WeakMap<DeviceContext, GrpcEncoder>();
   const inputSources = new Map<string, InputSource>();
   const contextGrpcImageModes = new WeakMap<DeviceContext, GrpcImageMode>();
   const defaultStreamEncoderSettings: StreamEncoderSettings = {
@@ -534,6 +548,8 @@ export async function startServer(
     (isEmulatorSerial(serial) ? defaultStreamMode : "scrcpy");
   const grpcImageModeForSerial = (serial: string): GrpcImageMode =>
     grpcImageModes.get(serial) ?? defaultGrpcImageMode;
+  const encoderForSerial = (serial: string): GrpcEncoder =>
+    encoders.get(serial) ?? defaultEncoder;
   const inputSourceForSerial = (
     serial: string,
     mode: StreamMode,
@@ -549,11 +565,13 @@ export async function startServer(
     encoderSettings = encoderSettingsForSerial(serial),
     grpcImageMode = grpcImageModeForSerial(serial),
     inputSource = inputSourceForSerial(serial, mode),
+    encoder = encoderForSerial(serial),
   ) =>
     openSession({
       serial,
       mode,
       grpcImageMode,
+      encoder,
       inputSource,
       signal,
       maxFps: encoderSettings.h264Fps,
@@ -603,6 +621,7 @@ export async function startServer(
     stream: EmuSession,
     deviceState?: DeviceSessionState,
     grpcImageMode = grpcImageModeForSerial(serial),
+    encoder = encoderForSerial(serial),
   ): DeviceContext => {
     const context = new ActiveDeviceSession<Client>({
       serial,
@@ -622,6 +641,7 @@ export async function startServer(
       ),
     );
     contextGrpcImageModes.set(context, grpcImageMode);
+    contextEncoders.set(context, encoder);
     return context;
   };
 
@@ -636,6 +656,7 @@ export async function startServer(
   }
   streamModes.set(opts.serial, initialMode);
   grpcImageModes.set(opts.serial, defaultGrpcImageMode);
+  encoders.set(opts.serial, defaultEncoder);
   inputSources.set(opts.serial, defaultInputSource);
   const sessions = new DeviceSessionManager(initialContext);
   const recoveries = new WeakMap<
@@ -691,6 +712,9 @@ export async function startServer(
     codec: context.stream.meta.codecId,
     streamMode: context.stream.mode,
     grpcImageMode: grpcImageModeForContext(context),
+    encoder: encoderForContext(context),
+    encoderName: context.stream.diagnostics?.().grpcCapture?.encoderName ?? null,
+    inputSource: context.stream.inputSource,
     grpcCapture: context.stream.diagnostics?.().grpcCapture ?? null,
     size: { width: context.screen.width, height: context.screen.height },
     clients: context.clients.size,
@@ -1627,6 +1651,7 @@ export async function startServer(
     encoderSettings = encoderSettingsForSerial(serial),
     grpcImageMode = grpcImageModeForSerial(serial),
     inputSource = inputSourceForSerial(serial, mode),
+    encoder = encoderForSerial(serial),
   ): Promise<DeviceContext> => {
     const stagingOwner = {};
     let retainedDeviceState =
@@ -1648,6 +1673,7 @@ export async function startServer(
         encoderSettings,
         grpcImageMode,
         inputSource,
+        encoder,
       );
       try {
         return createContext(
@@ -1656,6 +1682,7 @@ export async function startServer(
           stream,
           retainedDeviceState,
           grpcImageMode,
+          encoder,
         );
       } catch (error) {
         await stream.close().catch(() => {});
@@ -1673,11 +1700,18 @@ export async function startServer(
     contextGrpcImageModes.get(context) ??
     grpcImageModeForSerial(context.serial);
 
+  const encoderForContext = (context: DeviceContext): GrpcEncoder =>
+    contextEncoders.get(context) ?? encoderForSerial(context.serial);
+
   const streamModeResponse = (context: DeviceContext) => ({
     ok: true as const,
     serial: context.serial,
     mode: context.stream.mode,
     grpcImageMode: grpcImageModeForContext(context),
+    encoder: encoderForContext(context),
+    encoderName: context.stream.diagnostics?.().grpcCapture?.encoderName ?? null,
+    availableEncoders: getHardwareEncoderError() ? ["software"] : [...GRPC_ENCODERS],
+    ...(getHardwareEncoderError() ? { hardwareEncoderError: getHardwareEncoderError() } : {}),
     inputSource: context.stream.inputSource,
     availableInputSources:
       context.stream.mode === "grpc-screenshot"
@@ -1728,6 +1762,7 @@ export async function startServer(
     );
     streamModes.set(context.serial, context.stream.mode);
     grpcImageModes.set(context.serial, grpcImageModeForContext(context));
+    encoders.set(context.serial, encoderForContext(context));
     return {
       ok: true,
       serial: context.serial,
@@ -1739,6 +1774,7 @@ export async function startServer(
     mode: StreamMode,
     requestedGrpcImageMode: GrpcImageMode | undefined,
     requestedInputSource: InputSource | undefined,
+    requestedEncoder: GrpcEncoder | undefined,
     expected?: DeviceContext,
   ) => {
     const active = sessions.current;
@@ -1753,6 +1789,7 @@ export async function startServer(
     }
     let grpcImageMode: GrpcImageMode | undefined;
     let inputSource: InputSource | undefined;
+    let encoder: GrpcEncoder | undefined;
     const context = await sessions.replace(
       (current, generation, signal) => {
         const selectedGrpcImageMode =
@@ -1760,6 +1797,7 @@ export async function startServer(
           requestedGrpcImageMode ??
           grpcImageModeForContext(current);
         grpcImageMode = selectedGrpcImageMode;
+        encoder = encoder ?? requestedEncoder ?? encoderForContext(current);
         const selectedInputSource =
           mode === "grpc-screenshot"
             ? inputSource ??
@@ -1778,6 +1816,7 @@ export async function startServer(
           encoderSettingsForSerial(current.serial),
           selectedGrpcImageMode,
           selectedInputSource,
+          encoder,
         );
       },
       activateContext,
@@ -1789,6 +1828,7 @@ export async function startServer(
             current.generation,
           );
         }
+        encoder = requestedEncoder ?? encoderForContext(current);
         grpcImageMode =
           requestedGrpcImageMode ?? grpcImageModeForContext(current);
         inputSource =
@@ -1801,6 +1841,7 @@ export async function startServer(
         return (
           current.stream.mode !== mode ||
           grpcImageModeForContext(current) !== grpcImageMode ||
+          encoderForContext(current) !== encoder ||
           current.stream.inputSource !== inputSource
         );
       },
@@ -1809,6 +1850,7 @@ export async function startServer(
       grpcImageMode ?? grpcImageModeForContext(context);
     streamModes.set(context.serial, mode);
     grpcImageModes.set(context.serial, appliedGrpcImageMode);
+    encoders.set(context.serial, encoder ?? encoderForContext(context));
     if (mode === "grpc-screenshot") {
       inputSources.set(
         context.serial,
@@ -1992,6 +2034,10 @@ export async function startServer(
             device: requestContext.stream.meta.deviceName,
             codec: requestContext.stream.meta.codecId,
             streamMode: requestContext.stream.mode,
+            grpcImageMode: grpcImageModeForContext(requestContext),
+            encoder: encoderForContext(requestContext),
+            encoderName: requestContext.stream.diagnostics?.().grpcCapture?.encoderName ?? null,
+            inputSource: requestContext.stream.inputSource,
             size: {
               width: requestContext.screen.width,
               height: requestContext.screen.height,
@@ -2020,6 +2066,7 @@ export async function startServer(
         let mode: StreamMode;
         let grpcImageMode: GrpcImageMode | undefined;
         let inputSource: InputSource | undefined;
+        let encoder: GrpcEncoder | undefined;
         try {
           const payload = await readJsonBody(req, MAX_JSON_BODY_BYTES);
           const streamModeRequest = parseStreamModeRequest(payload);
@@ -2033,6 +2080,7 @@ export async function startServer(
             );
           }
           mode = requestedMode;
+          encoder = streamModeRequest.mode === "grpc-screenshot" ? streamModeRequest.encoder : undefined;
           grpcImageMode =
             streamModeRequest.mode === "grpc-screenshot"
               ? streamModeRequest.grpcImageMode
@@ -2050,6 +2098,7 @@ export async function startServer(
               mode,
               grpcImageMode,
               inputSource,
+              encoder,
               requestContext,
             ),
           );

--- a/packages/serve-emu/packages/serve-emu/src/server.ts
+++ b/packages/serve-emu/packages/serve-emu/src/server.ts
@@ -1,4 +1,3 @@
-import { getHardwareEncoderError } from "./h264-encoder.ts";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { timingSafeEqual } from "node:crypto";
@@ -10,6 +9,7 @@ import {
   readCameraWiring,
 } from "./camera.ts";
 import { getExecSnapshot } from "./exec.ts";
+import { getHardwareEncoderError } from "./h264-encoder.ts";
 import {
   getFontWeight,
   getDisplayDensity,
@@ -324,6 +324,7 @@ const MAX_LOGCAT_QUERY_BYTES = 200;
 const MAX_WEBRTC_CLOSE_BODY_BYTES = 4 * 1024;
 
 export type ServerDependencies = {
+  getHardwareEncoderError?: typeof getHardwareEncoderError;
   openSession?: (options: StartEmuSessionOptions) => Promise<EmuSession>;
   openScrcpy?: (
     serial: string,
@@ -415,6 +416,7 @@ export async function startServer(
   }
   const defaultInputSource = requestedDefaultInputSource;
   const serve = dependencies.serve ?? Bun.serve;
+  const hardwareEncoderError = dependencies.getHardwareEncoderError ?? getHardwareEncoderError;
   const listDevices =
     dependencies.listDevices ?? dependencies.listAllDevices ?? listAllDevices;
   const launchEmulator = dependencies.startEmulator ?? startEmulator;
@@ -1710,8 +1712,8 @@ export async function startServer(
     grpcImageMode: grpcImageModeForContext(context),
     encoder: encoderForContext(context),
     encoderName: context.stream.diagnostics?.().grpcCapture?.encoderName ?? null,
-    availableEncoders: getHardwareEncoderError() ? ["software"] : [...GRPC_ENCODERS],
-    ...(getHardwareEncoderError() ? { hardwareEncoderError: getHardwareEncoderError() } : {}),
+    availableEncoders: [...GRPC_ENCODERS],
+    ...(hardwareEncoderError() ? { hardwareEncoderError: hardwareEncoderError() } : {}),
     inputSource: context.stream.inputSource,
     availableInputSources:
       context.stream.mode === "grpc-screenshot"

--- a/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
+++ b/packages/serve-emu/packages/serve-emu/src/shared/api-contracts.ts
@@ -109,6 +109,17 @@ export function isGrpcImageMode(value: unknown): value is GrpcImageMode {
   );
 }
 
+/** Host H.264 implementation used by the emulator gRPC screenshot source. */
+export const GRPC_ENCODERS = ["software", "hardware"] as const;
+export type GrpcEncoder = (typeof GRPC_ENCODERS)[number];
+export const DEFAULT_GRPC_ENCODER: GrpcEncoder = "software";
+export function isGrpcEncoder(value: unknown): value is GrpcEncoder {
+  return (
+    typeof value === "string" &&
+    GRPC_ENCODERS.some((encoder) => encoder === value)
+  );
+}
+
 export type RollingTimingSummary = {
   /** Number of samples retained in the rolling window. */
   windowSamples: number;
@@ -122,6 +133,8 @@ export type RollingTimingSummary = {
 export type GrpcCaptureDiagnostics = {
   /** Exact screenshot image/delivery strategy selected by the caller. */
   imageMode: GrpcImageMode;
+  /** Resolved ffmpeg backend; null when an older server omits it. */
+  encoderName: string | null;
   /** Raw framed protobuf messages received before either pacing stage. */
   rawGrpcMessagesReceived: number;
   /**
@@ -183,6 +196,8 @@ export type StreamModeRequest =
       mode: "grpc-screenshot";
       /** Optional for backwards compatibility; omitted means keep the configured mode. */
       grpcImageMode?: GrpcImageMode;
+      /** Omitted means keep the configured encoder. Hardware selection is strict. */
+      encoder?: GrpcEncoder;
       /** Optional for backwards compatibility; omitted means keep the configured source. */
       inputSource?: InputSource;
     };
@@ -190,6 +205,10 @@ export type StreamModeResponse = ApiSuccess<{
   serial: string;
   mode: StreamMode;
   grpcImageMode: GrpcImageMode;
+  encoder: GrpcEncoder;
+  encoderName: string | null;
+  availableEncoders: GrpcEncoder[];
+  hardwareEncoderError?: string;
   inputSource: InputSource;
   availableInputSources: InputSource[];
   availableModes: StreamMode[];
@@ -470,6 +489,7 @@ export type HealthResponse = {
   serial: string;
   device: string;
   streamMode?: StreamMode;
+  encoderName?: string | null;
   grpcImageMode?: GrpcImageMode;
   inputSource?: InputSource;
   grpcCapture?: GrpcCaptureDiagnostics | null;
@@ -505,6 +525,7 @@ export type ApiInfoResponse = {
   serial: string;
   device: string;
   streamMode?: StreamMode;
+  encoderName?: string | null;
   codec: string;
   size: DeviceSize;
   status: SessionStatus;
@@ -894,6 +915,13 @@ export function parseApiInfoResponse(value: unknown): ApiInfoResponse {
             "API info response.streamMode",
           ),
         }),
+    ...(root.encoderName === undefined
+      ? {}
+      : {
+          encoderName: root.encoderName === null
+            ? null
+            : string(root.encoderName, "API info response.encoderName"),
+        }),
     codec: string(root.codec, "API info response.codec"),
     size: parseDeviceSize(root.size, "API info response.size"),
     status: oneOf(
@@ -961,10 +989,18 @@ export function parseStreamModeRequest(value: unknown): StreamModeRequest {
         "stream mode request.inputSource is available only with mode grpc-screenshot",
       );
     }
+    if (root.encoder !== undefined) {
+      fail("stream mode request.encoder is available only with mode grpc-screenshot");
+    }
     return { mode };
   }
   return {
     mode,
+    ...(root.encoder === undefined
+      ? {}
+      : {
+          encoder: oneOf(root.encoder, GRPC_ENCODERS, "stream mode request.encoder"),
+        }),
     ...(root.grpcImageMode === undefined
       ? {}
       : {
@@ -997,6 +1033,27 @@ export function parseStreamModeResponse(value: unknown): StreamModeResponse {
     GRPC_IMAGE_MODES,
     "stream mode response.grpcImageMode",
   );
+  const encoder = root.encoder === undefined
+    ? DEFAULT_GRPC_ENCODER
+    : oneOf(root.encoder, GRPC_ENCODERS, "stream mode response.encoder");
+  const encoderName = root.encoderName === undefined || root.encoderName === null
+    ? null
+    : string(root.encoderName, "stream mode response.encoderName");
+  const rawEncoders = root.availableEncoders === undefined
+    ? [DEFAULT_GRPC_ENCODER]
+    : root.availableEncoders;
+  if (!Array.isArray(rawEncoders)) {
+    fail("stream mode response.availableEncoders must be an array");
+  }
+  const availableEncoders = rawEncoders.map((value, index) =>
+    oneOf(value, GRPC_ENCODERS, `stream mode response.availableEncoders[${index}]`),
+  );
+  if (!availableEncoders.includes("software")) {
+    fail("stream mode response.availableEncoders must include software");
+  }
+  if (new Set(availableEncoders).size !== availableEncoders.length) {
+    fail("stream mode response.availableEncoders must not contain duplicates");
+  }
   const inputSource = oneOf(
     root.inputSource,
     INPUT_SOURCES,
@@ -1054,6 +1111,17 @@ export function parseStreamModeResponse(value: unknown): StreamModeResponse {
     serial,
     mode,
     grpcImageMode,
+    encoder,
+    encoderName,
+    availableEncoders,
+    ...(root.hardwareEncoderError === undefined
+      ? {}
+      : {
+          hardwareEncoderError: string(
+            root.hardwareEncoderError,
+            "stream mode response.hardwareEncoderError",
+          ),
+        }),
     inputSource,
     availableInputSources,
     availableModes,
@@ -1634,6 +1702,9 @@ function parseGrpcCaptureDiagnostics(value: unknown): GrpcCaptureDiagnostics {
       GRPC_IMAGE_MODES,
       "health response.grpcCapture.imageMode",
     ),
+    encoderName: item.encoderName === undefined || item.encoderName === null
+      ? null
+      : string(item.encoderName, "health response.grpcCapture.encoderName"),
     rawGrpcMessagesReceived: numeric("rawGrpcMessagesReceived"),
     rawGrpcMessagesEmitted: numeric("rawGrpcMessagesEmitted"),
     rawGrpcMessagesCoalesced: numeric("rawGrpcMessagesCoalesced"),
@@ -1738,6 +1809,13 @@ export function parseHealthResponse(value: unknown): HealthResponse {
             INPUT_SOURCES,
             "health response.inputSource",
           ),
+        }),
+    ...(root.encoderName === undefined
+      ? {}
+      : {
+          encoderName: root.encoderName === null
+            ? null
+            : string(root.encoderName, "health response.encoderName"),
         }),
     ...(root.grpcCapture === undefined
       ? {}

--- a/packages/serve-emu/packages/serve-emu/src/stream-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/stream-session.ts
@@ -10,6 +10,7 @@ import {
 } from "./scrcpy.ts";
 import type {
   GrpcCaptureDiagnostics,
+  GrpcEncoder,
   GrpcImageMode,
   InputSource,
   StreamMode,
@@ -65,6 +66,8 @@ export type StartEmuSessionOptions = StartOpts & {
   mode: StreamMode;
   /** Exact emulator screenshot image mode. Capture never silently falls back. */
   grpcImageMode: GrpcImageMode;
+  /** Host H.264 encoder used only for gRPC capture; defaults to software. */
+  encoder?: GrpcEncoder;
   /** Exact input source. scrcpy capture always requires scrcpy input. */
   inputSource: InputSource;
 };
@@ -87,8 +90,9 @@ export async function startEmuSession(
   if (options.inputSource !== "scrcpy") {
     throw new Error("scrcpy streaming requires scrcpy input");
   }
+  const { encoder: _encoder, ...scrcpyOptions } = options;
   return prepareDecodableScrcpySession(
-    await startScrcpy(options),
+    await startScrcpy(scrcpyOptions),
     options.signal,
   );
 }

--- a/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
+++ b/packages/serve-emu/packages/serve-emu/src/ui/components/stream-mode-panel.tsx
@@ -4,8 +4,11 @@ import {
   type StreamTransport,
 } from "../../stream-settings";
 import {
+  GRPC_ENCODERS,
+  isGrpcEncoder,
   GRPC_IMAGE_MODES,
   STREAM_MODES,
+  type GrpcEncoder,
   type GrpcImageMode,
   type StreamMode,
   type StreamModeResponse,
@@ -234,6 +237,57 @@ export function GrpcImageModeSelector({
   );
 }
 
+type GrpcEncoderSelectorProps = {
+  value: GrpcEncoder;
+  available: readonly GrpcEncoder[];
+  disabled: boolean;
+  encoderName: string | null;
+  hardwareEncoderError?: string;
+  onChange: (encoder: GrpcEncoder) => void;
+};
+
+export function GrpcEncoderSelector({
+  value,
+  available,
+  disabled,
+  encoderName,
+  hardwareEncoderError,
+  onChange,
+}: GrpcEncoderSelectorProps) {
+  return (
+    <fieldset className="stream-mode-fieldset" disabled={disabled}>
+      <legend>Encoder</legend>
+      <select
+        aria-label="Encoder"
+        aria-describedby="grpc-encoder-status"
+        value={value}
+        onChange={(event) => {
+          const encoder = event.currentTarget.value;
+          if (isGrpcEncoder(encoder)) onChange(encoder);
+        }}
+      >
+        {GRPC_ENCODERS.map((encoder) => (
+          <option
+            key={encoder}
+            value={encoder}
+            disabled={!available.includes(encoder)}
+          >
+            {encoder === "software" ? "Software" : "Hardware"}
+          </option>
+        ))}
+      </select>
+      <div id="grpc-encoder-status" aria-live="polite">
+        {encoderName ? (
+          <p className="stream-mode-help">Active encoder: {encoderName}</p>
+        ) : null}
+        {hardwareEncoderError ? (
+          <p className="stream-mode-help" role="alert">{hardwareEncoderError}</p>
+        ) : null}
+      </div>
+    </fieldset>
+  );
+}
+
 export function StreamModePanel() {
   const viewerTransport = useViewerTransportControls();
   const deviceSession = useDeviceSessionSnapshot();
@@ -295,6 +349,7 @@ export function StreamModePanel() {
     async (
       nextMode: StreamMode,
       nextGrpcImageMode: GrpcImageMode,
+      nextEncoder: GrpcEncoder,
     ) => {
       if (
         busy ||
@@ -302,7 +357,8 @@ export function StreamModePanel() {
         !loaded ||
         (
           nextMode === loaded.mode &&
-          nextGrpcImageMode === loaded.grpcImageMode
+          nextGrpcImageMode === loaded.grpcImageMode &&
+          nextEncoder === loaded.encoder
         ) ||
         !loaded.availableModes.includes(nextMode)
       ) {
@@ -320,7 +376,11 @@ export function StreamModePanel() {
         response = await apiRequest("/api/stream-mode", {
           method: "PUT",
           body: nextMode === "grpc-screenshot"
-            ? { mode: nextMode, grpcImageMode: nextGrpcImageMode }
+            ? {
+                mode: nextMode,
+                grpcImageMode: nextGrpcImageMode,
+                encoder: nextEncoder,
+              }
             : { mode: nextMode },
         });
       } catch (error) {
@@ -420,7 +480,7 @@ export function StreamModePanel() {
                   checked={displayedMode === option.mode}
                   disabled={disabled}
                   onChange={() => {
-                    if (loaded) void apply(option.mode, loaded.grpcImageMode);
+                    if (loaded) void apply(option.mode, loaded.grpcImageMode, loaded.encoder);
                   }}
                 />
                 <span>
@@ -433,11 +493,21 @@ export function StreamModePanel() {
         </div>
       </fieldset>
       {grpcSelected && loaded ? (
-        <GrpcImageModeSelector
-          value={loaded.grpcImageMode}
-          disabled={grpcImageModeDisabled}
-          onChange={(mode) => void apply("grpc-screenshot", mode)}
-        />
+        <>
+          <GrpcImageModeSelector
+            value={loaded.grpcImageMode}
+            disabled={grpcImageModeDisabled}
+            onChange={(mode) => void apply("grpc-screenshot", mode, loaded.encoder)}
+          />
+          <GrpcEncoderSelector
+            value={loaded.encoder}
+            available={loaded.availableEncoders}
+            disabled={grpcImageModeDisabled}
+            encoderName={loaded.encoderName}
+            hardwareEncoderError={loaded.hardwareEncoderError}
+            onChange={(encoder) => void apply("grpc-screenshot", loaded.grpcImageMode, encoder)}
+          />
+        </>
       ) : null}
       <p className="stream-mode-help" id="stream-mode-help">
         {help}

--- a/packages/serve-emu/packages/serve-emu/tests/api-contracts-complete.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/api-contracts-complete.test.ts
@@ -35,6 +35,7 @@ import {
 const timestamp = "2026-07-12T10:00:00.000Z";
 
 const grpcCaptureDiagnostics = {
+  encoderName: "h264_videotoolbox",
   imageMode: "mmap" as const,
   rawGrpcMessagesReceived: 120,
   rawGrpcMessagesEmitted: 100,
@@ -152,6 +153,7 @@ describe("complete API success contracts", () => {
         generation: 3,
         serial: "emulator-5554",
         device: "Pixel 8",
+        encoderName: "h264_videotoolbox",
         codec: "h264",
         size: { width: 1080, height: 1920 },
         status: "streaming",
@@ -174,6 +176,7 @@ describe("complete API success contracts", () => {
       generation: 3,
       serial: "emulator-5554",
       device: "Pixel 8",
+      encoderName: "h264_videotoolbox",
       codec: "h264",
       size: { width: 1080, height: 1920 },
       status: "streaming",
@@ -454,6 +457,7 @@ describe("generic and detailed API contracts", () => {
       device: "Pixel 8",
       streamMode: "grpc-screenshot",
       grpcImageMode: "mmap",
+      encoderName: "h264_videotoolbox",
       grpcCapture: grpcCaptureDiagnostics,
       codec: "h264",
       size: { width: 1080, height: 1920 },
@@ -503,6 +507,7 @@ describe("generic and detailed API contracts", () => {
 
     expect(health.frameStats?.intervalMs?.p95).toBe(20.1);
     expect(health.grpcImageMode).toBe("mmap");
+    expect(health.encoderName).toBe("h264_videotoolbox");
     expect(health.grpcCapture).toEqual(grpcCaptureDiagnostics);
     expect(health.frameStats?.avgKeyFrameBytes).toBe(50_000);
     expect(health.clientsDetail[0]).toMatchObject({ id: 7, frameMeta: true });

--- a/packages/serve-emu/packages/serve-emu/tests/api-contracts.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/api-contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   API_ERROR_CODES,
   API_SUCCESS_PARSERS,
+  isGrpcEncoder,
   isGrpcImageMode,
   isInputSource,
   isApiFailure,
@@ -75,6 +76,49 @@ describe("API contracts", () => {
     ).toThrow("available only with mode grpc-screenshot");
   });
 
+  test("validates strict gRPC encoder selection without changing omitted requests", () => {
+    expect(isGrpcEncoder("software")).toBe(true);
+    expect(isGrpcEncoder("hardware")).toBe(true);
+    expect(isGrpcEncoder("auto")).toBe(false);
+    expect(isGrpcEncoder(null)).toBe(false);
+    expect(parseStreamModeRequest({ mode: "grpc-screenshot", encoder: "hardware" })).toEqual({
+      mode: "grpc-screenshot", encoder: "hardware",
+    });
+    expect(() => parseStreamModeRequest({ mode: "grpc-screenshot", encoder: "auto" })).toThrow("encoder is invalid");
+    expect(() => parseStreamModeRequest({ mode: "scrcpy", encoder: "software" })).toThrow("available only with mode grpc-screenshot");
+  });
+
+  test("parses hardware status and validates encoder availability and errors", () => {
+    const status = {
+      ok: true,
+      serial: "emulator-5554",
+      mode: "grpc-screenshot",
+      grpcImageMode: "rgb888",
+      inputSource: "grpc",
+      availableInputSources: ["grpc", "scrcpy"],
+      availableModes: ["grpc-screenshot", "scrcpy"],
+      sessionGeneration: 1,
+      encoder: "hardware",
+      encoderName: "h264_videotoolbox",
+      availableEncoders: ["software", "hardware"],
+    };
+    expect(parseStreamModeResponse(status)).toEqual(status);
+    const failed = { ...status, encoderName: null, availableEncoders: ["software"], hardwareEncoderError: "GPU unavailable" };
+    expect(parseStreamModeResponse(failed)).toEqual(failed);
+    for (const patch of [
+      { encoder: "auto" },
+      { encoderName: 42 },
+      { availableEncoders: "hardware" },
+      { availableEncoders: [] },
+      { availableEncoders: ["hardware"] },
+      { availableEncoders: ["software", "software"] },
+      { availableEncoders: ["software", "auto"] },
+      { hardwareEncoderError: null },
+    ]) {
+      expect(() => parseStreamModeResponse({ ...status, ...patch })).toThrow();
+    }
+  });
+
   test("recognizes only explicit gRPC image modes", () => {
     expect(isGrpcImageMode("png")).toBe(true);
     expect(isGrpcImageMode("mmap")).toBe(true);
@@ -143,6 +187,9 @@ describe("API contracts", () => {
       ok: true,
       serial: "emulator-5554",
       mode: "grpc-screenshot",
+      encoder: "software",
+      encoderName: null,
+      availableEncoders: ["software"],
       grpcImageMode: "mmap",
       inputSource: "scrcpy",
       availableInputSources: ["scrcpy", "grpc"],

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -706,6 +706,7 @@ describe("gRPC screenshot session helpers", () => {
 
     expect(diagnostics.snapshot()).toEqual({
       imageMode: "mmap",
+      encoderName: "libx264",
       rawGrpcMessagesReceived: 5,
       rawGrpcMessagesEmitted: 3,
       rawGrpcMessagesCoalesced: 2,
@@ -1158,7 +1159,7 @@ function integrationRuntime(
   } = {},
 ): GrpcSessionRuntime {
   return {
-    async assertFfmpeg() {},
+    async resolveEncoder() { return "libx264"; },
     async ensureEndpoint() {
       return { port: 8554, token: "token", avdName: "Pixel_9" };
     },
@@ -1185,6 +1186,60 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("startGrpcSession integration", () => {
+  test.each(["software", "hardware"] as const)("resolves %s once and keeps the backend across size changes", async (encoder) => {
+    const client = new FakeGrpcClient(integrationImage());
+    const encoders: FakeGrpcEncoder[] = [];
+    const resolved = encoder === "hardware" ? "h264_videotoolbox" : "libx264";
+    const requests: string[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "png", inputSource: "grpc", encoder },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: {
+          ...integrationRuntime(client, encoders),
+          async resolveEncoder(requested, signal) {
+            expect(signal.aborted).toBe(false);
+            requests.push(requested);
+            return resolved;
+          },
+        },
+      },
+    );
+    try {
+      expect(requests).toEqual([encoder]);
+      expect(encoders[0]!.options.encoderName).toBe(resolved);
+      expect(session.diagnostics?.().grpcCapture?.encoderName).toBe(resolved);
+      client.streamImage!(integrationImage(0, 6, 4), "stream", Date.now());
+      await waitFor(() => encoders.length === 2);
+      expect(encoders[1]!.options.encoderName).toBe(resolved);
+      expect(requests).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("returns hardware probe failure before opening capture without trying software", async () => {
+    const requested: string[] = [];
+    let endpointCalls = 0;
+    await expect(startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "png", inputSource: "grpc", encoder: "hardware" },
+      {
+        runtime: {
+          async resolveEncoder(encoder) {
+            requested.push(encoder);
+            throw new Error("VideoToolbox hardware unavailable");
+          },
+          async ensureEndpoint() {
+            endpointCalls++;
+            throw new Error("must not open capture");
+          },
+        },
+      },
+    )).rejects.toThrow("VideoToolbox hardware unavailable");
+    expect(requested).toEqual(["hardware"]);
+    expect(endpointCalls).toBe(0);
+  });
+
   test("RGB888 drains incoming frames independently of the encoder FPS limit", async () => {
     const width = 192;
     const height = 192;
@@ -1552,6 +1607,7 @@ describe("startGrpcSession integration", () => {
       { key: "Power" },
     ]);
     expect(encoders).toHaveLength(1);
+    expect(encoders[0]!.options.encoderName).toBe("libx264");
     await waitFor(() => encoders[0]!.writes >= 2);
     await session.readFrame();
     await session.readFrame();

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -301,7 +301,10 @@ describe("gRPC screenshot session helpers", () => {
 
   test("drops MMAP notifications during cooldown without a trailing snapshot", () => {
     const clock = new FakeMmapSchedulerClock();
-    const diagnostics = new GrpcCaptureDiagnosticsTracker("mmap", 8);
+    const diagnostics = new GrpcCaptureDiagnosticsTracker({
+      imageMode: "mmap",
+      windowCapacity: 8,
+    });
     const consumed: Array<{ seq: number; receivedAtMs: number }> = [];
     const scheduler = new GrpcMmapNotificationScheduler({
       maxFps: 20,
@@ -649,7 +652,10 @@ describe("gRPC screenshot session helpers", () => {
   });
 
   test("reports cumulative gRPC capture loss, source timing, and encoder writes", () => {
-    const diagnostics = new GrpcCaptureDiagnosticsTracker("mmap", 4);
+    const diagnostics = new GrpcCaptureDiagnosticsTracker({
+      imageMode: "mmap",
+      windowCapacity: 4,
+    });
     const pacingEvents = [
       "received",
       "emitted",
@@ -772,7 +778,10 @@ describe("gRPC screenshot session helpers", () => {
   });
 
   test("resets active cadence after a long idle without clearing latency history", () => {
-    const diagnostics = new GrpcCaptureDiagnosticsTracker("mmap", 8);
+    const diagnostics = new GrpcCaptureDiagnosticsTracker({
+      imageMode: "mmap",
+      windowCapacity: 8,
+    });
     const image = Buffer.alloc(1);
     const record = (seq: number, timestampUs: bigint, atMs: number) => {
       diagnostics.recordGrpcMessage("received", undefined, atMs);
@@ -1160,6 +1169,7 @@ function integrationRuntime(
 ): GrpcSessionRuntime {
   return {
     async resolveEncoder() { return "libx264"; },
+    reportEncoderFailure() {},
     async ensureEndpoint() {
       return { port: 8554, token: "token", avdName: "Pixel_9" };
     },
@@ -1213,6 +1223,128 @@ describe("startGrpcSession integration", () => {
       await waitFor(() => encoders.length === 2);
       expect(encoders[1]!.options.encoderName).toBe(resolved);
       expect(requests).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("reports unexpected hardware encoder exits to invalidate availability", async () => {
+    const client = new FakeGrpcClient(integrationImage());
+    const encoders: FakeGrpcEncoder[] = [];
+    const failures: Array<{ encoderName: string; message: string }> = [];
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554",
+        mode: "grpc-screenshot",
+        grpcImageMode: "png",
+        inputSource: "grpc",
+        encoder: "hardware",
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: {
+          ...integrationRuntime(client, encoders),
+          async resolveEncoder() {
+            return "h264_videotoolbox";
+          },
+          reportEncoderFailure(encoderName, message) {
+            failures.push({ encoderName, message });
+          },
+        },
+      },
+    );
+    try {
+      const fatal: string[] = [];
+      session.onFatal((failure) => fatal.push(failure.message));
+      encoders[0]!.options.onExit("ffmpeg hardware session exhausted");
+      encoders[0]!.options.onExit("duplicate exit");
+      expect(failures).toEqual([{
+        encoderName: "h264_videotoolbox",
+        message: "ffmpeg hardware session exhausted",
+      }]);
+      expect(fatal).toEqual(["ffmpeg hardware session exhausted"]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("does not report encoder failures during replacement, close, or abort", async () => {
+    const client = new FakeGrpcClient(integrationImage());
+    const encoders: FakeGrpcEncoder[] = [];
+    const failures: string[] = [];
+    const controller = new AbortController();
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554",
+        mode: "grpc-screenshot",
+        grpcImageMode: "png",
+        inputSource: "grpc",
+        encoder: "hardware",
+        signal: controller.signal,
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: {
+          ...integrationRuntime(client, encoders),
+          async resolveEncoder() {
+            return "h264_videotoolbox";
+          },
+          reportEncoderFailure(_encoderName, message) {
+            failures.push(message);
+          },
+          createEncoder(options) {
+            const encoder = new FakeGrpcEncoder(options);
+            encoder.close = async () => {
+              encoder.closed = true;
+              options.onExit("encoder intentionally stopped");
+            };
+            encoders.push(encoder);
+            return encoder;
+          },
+        },
+      },
+    );
+    const fatal: string[] = [];
+    session.onFatal((failure) => fatal.push(failure.message));
+    try {
+      client.streamImage!(integrationImage(0, 6, 4), "stream", Date.now());
+      await waitFor(() => encoders.length === 2);
+      expect(encoders[0]!.closed).toBe(true);
+      encoders[0]!.options.onExit("late exit from replaced encoder");
+      controller.abort();
+      encoders[1]!.options.onExit("exit after abort");
+      await session.close();
+      expect(failures).toEqual([]);
+      expect(fatal).toEqual([]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("does not invalidate hardware availability after a software encoder failure", async () => {
+    const client = new FakeGrpcClient(integrationImage());
+    const encoders: FakeGrpcEncoder[] = [];
+    const failures: string[] = [];
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554",
+        mode: "grpc-screenshot",
+        grpcImageMode: "png",
+        inputSource: "grpc",
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: {
+          ...integrationRuntime(client, encoders),
+          reportEncoderFailure(_encoderName, message) {
+            failures.push(message);
+          },
+        },
+      },
+    );
+    try {
+      encoders[0]!.options.onExit("libx264 failed");
+      expect(failures).toEqual([]);
     } finally {
       await session.close();
     }

--- a/packages/serve-emu/packages/serve-emu/tests/middleware-create-app.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/middleware-create-app.test.ts
@@ -21,6 +21,7 @@ import type {
 const SESSION_ID = "00000000-0000-4000-8000-000000000000";
 
 const GRPC_CAPTURE_DIAGNOSTICS: GrpcCaptureDiagnostics = {
+  encoderName: "libx264",
   imageMode: "mmap",
   rawGrpcMessagesReceived: 120,
   rawGrpcMessagesEmitted: 100,

--- a/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
@@ -1637,9 +1637,10 @@ test("router preserves a working encoder on failed switches and retains per-devi
           hardwareError = "No hardware H.264 encoder: unavailable driver";
           throw new Error(hardwareError);
         }
+        if (options.encoder === "hardware") hardwareError = undefined;
         opened.push(opts);
         const stream = liveStreamSession(options.mode);
-        const diagnostics = new GrpcCaptureDiagnosticsTracker(options.grpcImageMode).snapshot();
+        const diagnostics = new GrpcCaptureDiagnosticsTracker({ imageMode: options.grpcImageMode }).snapshot();
         return { ...stream, diagnostics: () => ({ grpcCapture: {
           ...diagnostics,
           encoderName: options.encoder === "hardware" ? "h264_videotoolbox" : "libx264",
@@ -1655,12 +1656,12 @@ test("router preserves a working encoder on failed switches and retains per-devi
     const failed = await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "hardware" }));
     expect(failed.status).toBe(503);
     expect(await failed.json()).toMatchObject({ error: { message: hardwareError } });
-    expect(await read()).toMatchObject({ encoder: "software", encoderName: "libx264", availableEncoders: ["software"], hardwareEncoderError: hardwareError, sessionGeneration: 0 });
+    expect(await read()).toMatchObject({ encoder: "software", encoderName: "libx264", availableEncoders: ["software", "hardware"], hardwareEncoderError: hardwareError, sessionGeneration: 0 });
     expect(opened).toHaveLength(1);
     failHardware = false;
-    hardwareError = undefined;
     expect((await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "hardware" }))).status).toBe(200);
     expect(await read()).toMatchObject({ encoder: "hardware", encoderName: "h264_videotoolbox", sessionGeneration: 1 });
+    expect(await read()).not.toHaveProperty("hardwareEncoderError");
     for (const path of ["/health", "/api"]) {
       expect(await read(path)).toMatchObject({ encoder: "hardware", encoderName: "h264_videotoolbox" });
     }

--- a/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/middleware-router.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, test } from "bun:test";
 import type { Device } from "../src/adb.ts";
+import { GrpcCaptureDiagnosticsTracker } from "../src/grpc-session.ts";
 import { ControlInputQueue } from "../src/control-input-queue.ts";
 import {
   createApp,
@@ -760,6 +761,9 @@ describe("createRouter stream mode", () => {
       grpcImageMode: "png",
       inputSource: "scrcpy",
       availableInputSources: ["scrcpy"],
+      encoder: "software",
+      encoderName: null,
+      availableEncoders: ["software", "hardware"],
       availableModes: ["scrcpy", "grpc-screenshot"],
       sessionGeneration: 0,
     });
@@ -787,6 +791,9 @@ describe("createRouter stream mode", () => {
       grpcImageMode: "png",
       inputSource: "scrcpy",
       availableInputSources: ["scrcpy", "grpc"],
+      encoder: "software",
+      encoderName: null,
+      availableEncoders: ["software", "hardware"],
       availableModes: ["scrcpy", "grpc-screenshot"],
       sessionGeneration: 1,
     });
@@ -1611,4 +1618,61 @@ describe("createRouter stream mode", () => {
     expect((await stopping).status).toBe(200);
     expect(events.at(-1)).toBe("stop-emulator");
   });
+});
+
+
+test("router preserves a working encoder on failed switches and retains per-device selections", async () => {
+  let hardwareError: string | undefined;
+  let failHardware = false;
+  const opened: AppOptions[] = [];
+  const router = createRouter({ streamMode: "grpc-screenshot" }, {
+    listDevices: async () => [
+      { serial: "emulator-5554", state: "device" },
+      { serial: "emulator-5556", state: "device" },
+    ],
+    getHardwareEncoderError: () => hardwareError,
+    createApp: (opts) => createApp(opts, {
+      startSession: async (options) => {
+        if (options.encoder === "hardware" && failHardware) {
+          hardwareError = "No hardware H.264 encoder: unavailable driver";
+          throw new Error(hardwareError);
+        }
+        opened.push(opts);
+        const stream = liveStreamSession(options.mode);
+        const diagnostics = new GrpcCaptureDiagnosticsTracker(options.grpcImageMode).snapshot();
+        return { ...stream, diagnostics: () => ({ grpcCapture: {
+          ...diagnostics,
+          encoderName: options.encoder === "hardware" ? "h264_videotoolbox" : "libx264",
+        } }) };
+      },
+    }),
+  });
+  const read = async (path = "/api/stream-mode") =>
+    (await router.handleRequest(new Request(`http://router.test${path}`))).json();
+  try {
+    expect(await read()).toMatchObject({ encoder: "software", encoderName: "libx264", availableEncoders: ["software", "hardware"] });
+    failHardware = true;
+    const failed = await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "hardware" }));
+    expect(failed.status).toBe(503);
+    expect(await failed.json()).toMatchObject({ error: { message: hardwareError } });
+    expect(await read()).toMatchObject({ encoder: "software", encoderName: "libx264", availableEncoders: ["software"], hardwareEncoderError: hardwareError, sessionGeneration: 0 });
+    expect(opened).toHaveLength(1);
+    failHardware = false;
+    hardwareError = undefined;
+    expect((await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "hardware" }))).status).toBe(200);
+    expect(await read()).toMatchObject({ encoder: "hardware", encoderName: "h264_videotoolbox", sessionGeneration: 1 });
+    for (const path of ["/health", "/api"]) {
+      expect(await read(path)).toMatchObject({ encoder: "hardware", encoderName: "h264_videotoolbox" });
+    }
+    await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", grpcImageMode: "rgb888" }));
+    expect(await read()).toMatchObject({ encoder: "hardware", grpcImageMode: "rgb888", sessionGeneration: 2 });
+    await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "hardware" }));
+    expect(opened).toHaveLength(3);
+    expect(await read("/api/stream-mode?device=emulator-5556")).toMatchObject({ encoder: "software" });
+    const invalid = await router.handleRequest(put("/api/stream-mode", { mode: "grpc-screenshot", encoder: "auto" }));
+    expect(invalid.status).toBe(400);
+    expect(opened).toHaveLength(4);
+  } finally {
+    await router.stopAll();
+  }
 });

--- a/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
@@ -55,9 +55,7 @@ function fakeSession(
       ? {}
       : {
           diagnostics: () => ({
-            grpcCapture: new GrpcCaptureDiagnosticsTracker(
-              grpcImageMode,
-            ).snapshot(),
+            grpcCapture: new GrpcCaptureDiagnosticsTracker({ imageMode: grpcImageMode }).snapshot(),
           }),
         }),
     readFrame: () => end.promise,
@@ -902,14 +900,20 @@ test("standalone encoder switches preserve selection and current capture after f
   const opened: StartEmuSessionOptions[] = [];
   const streams: ReturnType<typeof fakeSession>[] = [];
   let failHardware = false;
+  let hardwareError: string | undefined;
   const started = await startServer({ port: 3300, serial: "emulator-5554", streamMode: "grpc-screenshot", encoder: "hardware" }, {
     serve: capturingServe(captured),
+    getHardwareEncoderError: () => hardwareError,
     openSession: async (options) => {
-      if (options.encoder === "hardware" && failHardware) throw new Error("Hardware encoder unavailable");
+      if (options.encoder === "hardware" && failHardware) {
+        hardwareError = "Hardware encoder unavailable";
+        throw new Error(hardwareError);
+      }
+      if (options.encoder === "hardware") hardwareError = undefined;
       opened.push(options);
       const stream = fakeSession(options.serial, options.mode, options.grpcImageMode, options.inputSource);
       streams.push(stream);
-      const diagnostics = new GrpcCaptureDiagnosticsTracker(options.grpcImageMode).snapshot();
+      const diagnostics = new GrpcCaptureDiagnosticsTracker({ imageMode: options.grpcImageMode }).snapshot();
       return { ...stream.session, diagnostics: () => ({ grpcCapture: { ...diagnostics, encoderName: options.encoder === "hardware" ? "h264_videotoolbox" : "libx264" } }) };
     },
   });
@@ -926,13 +930,14 @@ test("standalone encoder switches preserve selection and current capture after f
     failHardware = true;
     expect((await setEncoder("hardware")).status).toBe(503);
     expect(streams[1]!.closeCalls()).toBe(0);
-    expect(await (await request(captured, "/api/stream-mode")).json()).toMatchObject({ encoder: "software", encoderName: "libx264", sessionGeneration: 1 });
+    expect(await (await request(captured, "/api/stream-mode")).json()).toMatchObject({ encoder: "software", encoderName: "libx264", availableEncoders: ["software", "hardware"], hardwareEncoderError: hardwareError, sessionGeneration: 1 });
     await putMode(captured, "grpc-screenshot", "rgb888");
     expect(opened.at(-1)).toMatchObject({ encoder: "software", grpcImageMode: "rgb888" });
     await patchStreamSettings(captured, { h264Fps: 24 });
     expect(opened.at(-1)).toMatchObject({ encoder: "software", maxFps: 24 });
     failHardware = false;
     expect((await setEncoder("hardware")).status).toBe(200);
+    expect(await (await request(captured, "/api/stream-mode")).json()).not.toHaveProperty("hardwareEncoderError");
     const count = opened.length;
     expect((await setEncoder("hardware")).status).toBe(200);
     expect(opened).toHaveLength(count);

--- a/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/server-stream-mode.test.ts
@@ -514,6 +514,9 @@ describe("server stream source switching", () => {
       grpcImageMode: "png",
       inputSource: "scrcpy",
       availableInputSources: ["scrcpy"],
+      encoder: "software",
+      encoderName: null,
+      availableEncoders: ["software", "hardware"],
       availableModes: ["scrcpy", "grpc-screenshot"],
       sessionGeneration: 0,
     });
@@ -891,4 +894,50 @@ describe("server stream source switching", () => {
     });
     await started.stop();
   });
+});
+
+
+test("standalone encoder switches preserve selection and current capture after failure", async () => {
+  const captured: CapturedServer = { options: null };
+  const opened: StartEmuSessionOptions[] = [];
+  const streams: ReturnType<typeof fakeSession>[] = [];
+  let failHardware = false;
+  const started = await startServer({ port: 3300, serial: "emulator-5554", streamMode: "grpc-screenshot", encoder: "hardware" }, {
+    serve: capturingServe(captured),
+    openSession: async (options) => {
+      if (options.encoder === "hardware" && failHardware) throw new Error("Hardware encoder unavailable");
+      opened.push(options);
+      const stream = fakeSession(options.serial, options.mode, options.grpcImageMode, options.inputSource);
+      streams.push(stream);
+      const diagnostics = new GrpcCaptureDiagnosticsTracker(options.grpcImageMode).snapshot();
+      return { ...stream.session, diagnostics: () => ({ grpcCapture: { ...diagnostics, encoderName: options.encoder === "hardware" ? "h264_videotoolbox" : "libx264" } }) };
+    },
+  });
+  const setEncoder = (encoder: string) => request(captured, "/api/stream-mode", {
+    method: "PUT", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode: "grpc-screenshot", encoder }),
+  });
+  try {
+    for (const path of ["/api/stream-mode", "/health", "/api"]) {
+      expect(await (await request(captured, path)).json()).toMatchObject({ encoder: "hardware", encoderName: "h264_videotoolbox" });
+    }
+    expect((await setEncoder("software")).status).toBe(200);
+    expect(streams[0]!.closeCalls()).toBe(1);
+    failHardware = true;
+    expect((await setEncoder("hardware")).status).toBe(503);
+    expect(streams[1]!.closeCalls()).toBe(0);
+    expect(await (await request(captured, "/api/stream-mode")).json()).toMatchObject({ encoder: "software", encoderName: "libx264", sessionGeneration: 1 });
+    await putMode(captured, "grpc-screenshot", "rgb888");
+    expect(opened.at(-1)).toMatchObject({ encoder: "software", grpcImageMode: "rgb888" });
+    await patchStreamSettings(captured, { h264Fps: 24 });
+    expect(opened.at(-1)).toMatchObject({ encoder: "software", maxFps: 24 });
+    failHardware = false;
+    expect((await setEncoder("hardware")).status).toBe(200);
+    const count = opened.length;
+    expect((await setEncoder("hardware")).status).toBe(200);
+    expect(opened).toHaveLength(count);
+    expect((await setEncoder("auto")).status).toBe(400);
+  } finally {
+    await started.stop();
+  }
 });

--- a/packages/serve-emu/packages/serve-emu/tests/stream-mode-panel.test.tsx
+++ b/packages/serve-emu/packages/serve-emu/tests/stream-mode-panel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
+  GrpcEncoderSelector,
   GrpcImageModeSelector,
   StreamStatsDownloadControl,
   StreamModePanel,
@@ -178,4 +179,21 @@ test("renders RGB888 applied and disabled during a pending change", () => {
     .find((option: { key: string }) => option.key === "rgb888")
     .props.children[0].props.onChange();
   expect(selected).toBe("rgb888");
+});
+
+test("renders the active hardware encoder and disables an unavailable hardware option", () => {
+  const hardware = renderToStaticMarkup(
+    <GrpcEncoderSelector value="hardware" available={["software", "hardware"]} disabled={false} encoderName="h264_videotoolbox" onChange={() => {}} />,
+  );
+  expect(hardware).toContain('aria-label="Encoder"');
+  expect(hardware).toContain('aria-describedby="grpc-encoder-status"');
+  expect(hardware).toContain('<option value="hardware" selected="">Hardware</option>');
+  expect(hardware).toContain('Active encoder: h264_videotoolbox');
+  const unavailable = renderToStaticMarkup(
+    <GrpcEncoderSelector value="software" available={["software"]} disabled encoderName="libx264" hardwareEncoderError="Hardware encoder unavailable" onChange={() => {}} />,
+  );
+  expect(unavailable).toContain('<fieldset class="stream-mode-fieldset" disabled="">');
+  expect(unavailable).toContain('<option value="hardware" disabled="">Hardware</option>');
+  expect(unavailable).toContain('role="alert"');
+  expect(unavailable).toContain('Hardware encoder unavailable');
 });

--- a/packages/serve-emu/packages/serve-emu/tests/stream-settings-http.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/stream-settings-http.test.ts
@@ -11,6 +11,7 @@ import type { StreamSocket } from "../src/stream-socket.ts";
 type CapturedStartOpts = StartOpts & {
   mode?: "scrcpy";
   grpcImageMode?: "png" | "mmap";
+  encoder?: "software" | "hardware";
   inputSource?: "scrcpy" | "grpc";
 };
 
@@ -172,6 +173,7 @@ describe("stream settings HTTP API", () => {
         keyFrameInterval: undefined,
         mode: "scrcpy",
         grpcImageMode: "png",
+        encoder: "software",
         inputSource: "scrcpy",
       });
       expect(app.health().encoderSettings).toEqual({
@@ -236,6 +238,7 @@ describe("stream settings HTTP API", () => {
         keyFrameInterval: undefined,
         mode: "scrcpy",
         grpcImageMode: "png",
+        encoder: "software",
         inputSource: "scrcpy",
       });
     } finally {


### PR DESCRIPTION
Threads `encoder: software|hardware` through Android gRPC sessions, CLI, router, standalone server, API contracts and the standalone selector. Software remains the default; scrcpy ignores the setting. Diagnostics and stream-mode responses report the resolved FFmpeg encoder name.

Source changes use staged replacement: a failed hardware attempt leaves the current capture and session generation intact. Hardware stays selectable after failure, with the last error retained as an advisory diagnostic and cleared after a successful probe. Unexpected runtime hardware encoder exits invalidate cached probe success; intentional close, replacement and abort do not. The diagnostics constructor now accepts named options.

Validation: 91 focused session/router/standalone tests, including fail-once/retry-success on both API implementations, runtime failure reporting, expected encoder lifecycle callbacks, and software isolation. The combined stack passes 973 serve-emu tests, critical coverage, typechecks, builds, documentation checks and package smoke. The latest Ubuntu CI check passes.

The built Hub was also tested in the Codex browser with WebRTC and a 60 FPS cap: one simulated hardware smoke failure preserved live Software at generation 0 and left Hardware enabled; retrying without a server restart produced live VideoToolbox video at generation 1 and cleared the error.

PR 2 of 3; depends on the encoder/probe layer in #94.

— Codex (GPT-6)
