### PR TITLE
Preserve right sidebar sections and scroll position

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
         "@types/react-dom": "~19.2.0",
         "@types/ws": "^8.18.1",
         "expo": "catalog:",
+        "playwright": "^1.63.0",
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-native": "catalog:",
@@ -1852,6 +1853,10 @@
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
     "piscina": ["piscina@4.9.3", "", { "optionalDependencies": { "@napi-rs/nice": "^1.0.1" } }, "sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA=="],
+
+    "playwright": ["playwright@1.63.0", "", { "dependencies": { "playwright-core": "1.63.0" }, "bin": { "playwright": "cli.js" } }, "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg=="],
+
+    "playwright-core": ["playwright-core@1.63.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg=="],
 
     "plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 

--- a/packages/@expo/hub-components/src/dashboard/LogList.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogList.tsx
@@ -50,11 +50,16 @@ export function LogList({
   emptyMessage?: string;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const previousLogs = useRef<ReadonlyArray<DeviceLog> | null>(null);
 
   // New lines arrive at the bottom; while attached we follow the tail so the
   // newest line stays in view. The stream stops on Detach (lines are kept), so
   // detaching is how you pause to scroll back through history.
   useEffect(() => {
+    // Activity reactivates effects when the inspector reopens. Only new data
+    // should scroll to the tail; unchanged rows must retain the user's position.
+    if (previousLogs.current === logs) return;
+    previousLogs.current = logs;
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [logs]);

--- a/packages/@expo/hub-components/src/dashboard/LogList.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogList.tsx
@@ -50,18 +50,14 @@ export function LogList({
   emptyMessage?: string;
 }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const previousLogs = useRef<ReadonlyArray<DeviceLog> | null>(null);
+  const followTail = useRef(true);
 
-  // New lines arrive at the bottom; while attached we follow the tail so the
-  // newest line stays in view. The stream stops on Detach (lines are kept), so
-  // detaching is how you pause to scroll back through history.
+  // Keep following new lines only while the user is at the bottom. Reconnecting
+  // can replay the same rows in a new array, so array identity cannot tell us
+  // whether to preserve a position in the history when Activity resumes.
   useEffect(() => {
-    // Activity reactivates effects when the inspector reopens. Only new data
-    // should scroll to the tail; unchanged rows must retain the user's position.
-    if (previousLogs.current === logs) return;
-    previousLogs.current = logs;
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el && followTail.current) el.scrollTop = el.scrollHeight;
   }, [logs]);
 
   const emptyMessage =
@@ -71,7 +67,17 @@ export function LogList({
       : 'Logs are paused. Press Start to stream device logs.');
 
   return (
-    <div ref={scrollRef} className="hub-log-scroll" style={scrollStyle}>
+    <div
+      ref={scrollRef}
+      className="hub-log-scroll"
+      style={scrollStyle}
+      onScroll={({ currentTarget }) => {
+        // Hiding an Activity removes layout; its zero dimensions are not a
+        // user scroll back to the tail.
+        if (currentTarget.clientHeight === 0) return;
+        followTail.current =
+          currentTarget.scrollHeight - currentTarget.clientHeight - currentTarget.scrollTop <= 1;
+      }}>
       <style>{SCROLLBAR_CSS}</style>
       {logs.length === 0 ? (
         <div

--- a/packages/expo-device-hub/package.json
+++ b/packages/expo-device-hub/package.json
@@ -63,6 +63,7 @@
     "@types/react-dom": "~19.2.0",
     "@types/ws": "^8.18.1",
     "expo": "catalog:",
+    "playwright": "^1.63.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
@@ -94,6 +95,7 @@
     "build": "bun run build:web && bun run build:vendor && bun run build:server",
     "build:web": "expo export --platform web --output-dir dist/client",
     "build:vendor": "bun run scripts/vendor.ts",
-    "build:server": "bun run scripts/build-plugin-server.ts"
+    "build:server": "bun run scripts/build-plugin-server.ts",
+    "test:sidebar": "bun scripts/check-sidebar-persistence.ts"
   }
 }

--- a/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
+++ b/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
@@ -1,18 +1,31 @@
 /**
- * Browser regression against the exported dashboard, with an empty device host.
+ * Browser regressions for the exported dashboard and populated inspector panes.
  * Run build:web first, then `bun run test:sidebar` (install Chromium once with
  * `bunx playwright install chromium`). Set SIDEBAR_VIDEO_DIR to record the run.
  */
 import assert from 'node:assert/strict';
 import { resolve, sep } from 'node:path';
-import { chromium, type Browser } from 'playwright';
+import { chromium, type Browser, type BrowserContext } from 'playwright';
 
 const root = resolve(import.meta.dir, '../dist/client');
 assert(await Bun.file(resolve(root, 'index.html')).exists(), 'Run build:web first');
+const fixture = await Bun.build({
+  entrypoints: [resolve(import.meta.dir, 'fixtures/sidebar-logs.tsx')],
+  target: 'browser',
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+});
+assert(fixture.success, String(fixture.logs));
 const server = Bun.serve({
+  hostname: '127.0.0.1',
   port: 0,
   async fetch(request) {
     const pathname = decodeURIComponent(new URL(request.url).pathname);
+    if (pathname === '/sidebar-logs.js') return new Response(fixture.outputs[0]);
+    if (pathname === '/sidebar-logs') {
+      return new Response('<html><body style="margin:0"><div id="root"></div><script type="module" src="/sidebar-logs.js"></script></body></html>', {
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
     const path = resolve(root, `.${pathname === '/' ? '/index.html' : pathname}`);
     if (!path.startsWith(root + sep)) return new Response(null, { status: 403 });
     const file = Bun.file(path);
@@ -29,7 +42,7 @@ let browser: Browser | undefined;
 try {
   browser = await chromium.launch();
   for (const reducedMotion of ['no-preference', 'reduce'] as const) {
-    const context = await browser.newContext({
+    const context: BrowserContext = await browser.newContext({
       viewport: { width: 1280, height: 440 },
       reducedMotion,
       recordVideo: process.env.SIDEBAR_VIDEO_DIR
@@ -111,6 +124,30 @@ try {
     await context.close();
     if (video) console.log(`Video: ${await video.path()}`);
     console.log(`PASS: sidebar persistence (${reducedMotion})`);
+
+    // Actual inspector sections with static populated buffers: Activity must not
+    // mistake effect reactivation for new data and jump their panes to the tail.
+    const populated = await browser.newPage({ reducedMotion, viewport: { width: 1200, height: 800 } });
+    await populated.goto(new URL('/sidebar-logs', server.url).toString());
+    await populated.getByRole('button', { name: 'Events', exact: true }).click();
+    await populated.getByRole('button', { name: 'Logs', exact: true }).click();
+    await populated.waitForTimeout(300);
+    const panes = populated.locator('.hub-log-scroll');
+    assert.equal(await panes.count(), 2);
+    await panes.evaluateAll((elements) => elements.forEach((el) => { el.scrollTop = 100; }));
+    assert.deepEqual(await panes.evaluateAll((elements) => elements.map((el) => el.scrollTop)), [100, 100]);
+    await populated.getByRole('button', { name: 'Toggle inspector' }).click();
+    await populated.waitForTimeout(300);
+    await populated.getByRole('button', { name: 'Toggle inspector' }).click();
+    await populated.waitForTimeout(300);
+    assert.deepEqual(await panes.evaluateAll((elements) => elements.map((el) => el.scrollTop)), [100, 100],
+      'Populated Events and Logs must preserve their own scroll positions');
+    await populated.getByRole('button', { name: 'Append log' }).click();
+    await populated.waitForTimeout(100);
+    assert(await panes.last().evaluate((el) => el.scrollTop === el.scrollHeight - el.clientHeight),
+      'New log entries should still scroll to the tail');
+    await populated.close();
+    console.log(`PASS: populated inspector persistence (${reducedMotion})`);
   }
 } finally {
   for (const heartbeat of heartbeats) clearInterval(heartbeat);

--- a/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
+++ b/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
@@ -1,0 +1,119 @@
+/**
+ * Browser regression against the exported dashboard, with an empty device host.
+ * Run build:web first, then `bun run test:sidebar` (install Chromium once with
+ * `bunx playwright install chromium`). Set SIDEBAR_VIDEO_DIR to record the run.
+ */
+import assert from 'node:assert/strict';
+import { resolve, sep } from 'node:path';
+import { chromium, type Browser } from 'playwright';
+
+const root = resolve(import.meta.dir, '../dist/client');
+assert(await Bun.file(resolve(root, 'index.html')).exists(), 'Run build:web first');
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    const pathname = decodeURIComponent(new URL(request.url).pathname);
+    const path = resolve(root, `.${pathname === '/' ? '/index.html' : pathname}`);
+    if (!path.startsWith(root + sep)) return new Response(null, { status: 403 });
+    const file = Bun.file(path);
+    if (path.endsWith('/index.html')) {
+      return new Response((await file.text()).replaceAll('{{mount}}', ''), {
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+    return (await file.exists()) ? new Response(file) : new Response(null, { status: 404 });
+  },
+});
+const heartbeats: ReturnType<typeof setInterval>[] = [];
+let browser: Browser | undefined;
+try {
+  browser = await chromium.launch();
+  for (const reducedMotion of ['no-preference', 'reduce'] as const) {
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 440 },
+      reducedMotion,
+      recordVideo: process.env.SIDEBAR_VIDEO_DIR
+        ? { dir: process.env.SIDEBAR_VIDEO_DIR, size: { width: 1280, height: 440 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(10_000);
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.addInitScript(() => { window.__EXPO_DEVICE_HUB_BASE_PATH__ = ''; });
+    await page.route('**/api/new-device-options', (route) => route.fulfill({
+      json: { ios: { runtimes: [] }, android: { runtimes: [] } },
+    }));
+    await page.routeWebSocket('**/api/argent-interactions/ws', () => {});
+    await page.routeWebSocket('**/api/devices/ws', (socket) => {
+      socket.send(JSON.stringify({ type: 'device-list', devices: { simulators: [], emulators: [] } }));
+      const heartbeat = setInterval(() => socket.send('{"type":"heartbeat"}'), 1000);
+      heartbeats.push(heartbeat);
+      socket.onClose(() => clearInterval(heartbeat));
+    });
+    await page.goto(server.url.toString());
+    const panel = page.locator('[data-sidebar-docked="right"], [data-sidebar-overlay="right"]');
+    const toggle = panel.getByRole('button', { name: 'Toggle sidebar' });
+    const logs = panel.getByRole('button', { name: 'Logs', exact: true });
+    const currentApp = panel.getByRole('button', { name: 'Current app', exact: true });
+    const scroller = panel.locator('aside > div').last();
+    const settle = () => page.waitForTimeout(process.env.SIDEBAR_VIDEO_DIR ? 1200 : 300);
+    const state = () => panel.locator('button[aria-expanded]').evaluateAll((buttons) =>
+      buttons.map((button) => [button.textContent, button.getAttribute('aria-expanded')]));
+    const scrollTop = () => scroller.evaluate((el) => el.scrollTop);
+    const cycle = async () => {
+      const before = await state();
+      const offset = await scrollTop();
+      await toggle.click();
+      await settle(); // Wait past the exit animation, where the original reset occurs.
+      assert.equal(await page.getByRole('button', { name: 'Logs', exact: true }).count(), 0,
+        'Closed sidebar must be inaccessible');
+      await page.locator('[data-floating-sidebar-toggle="right"] button').click();
+      await settle();
+      assert.deepEqual(await state(), before, 'Expanded sections must survive closing and reopening');
+      assert.equal(await scrollTop(), offset, 'Sidebar scroll position must survive closing and reopening');
+    };
+    await logs.click();
+    await currentApp.click();
+    await settle();
+    await cycle(); // Both opened and collapsed choices must persist.
+    await currentApp.click();
+    await settle();
+    await scroller.evaluate((el) => { el.scrollTop = 100; });
+    assert((await scrollTop()) > 0, 'Fixture must have scrollable content');
+    await settle();
+    await cycle();
+    const expanded = await state();
+    const offset = await scrollTop();
+    await page.setViewportSize({ width: 640, height: 440 });
+    await settle();
+    // Auto-docked sidebars close when they no longer fit. Reopen as an overlay.
+    await page.locator('[data-floating-sidebar-toggle="right"] button').click();
+    await settle();
+    assert.deepEqual(await state(), expanded, 'Docked → overlay must preserve expansion');
+    assert.equal(await scrollTop(), offset, 'Docked → overlay must preserve scroll');
+    await cycle();
+    await page.setViewportSize({ width: 1280, height: 440 });
+    await settle();
+    assert.deepEqual(await state(), expanded, 'Overlay → docked must preserve expansion');
+    assert.equal(await scrollTop(), offset, 'Overlay → docked must preserve scroll');
+    await page.setViewportSize({ width: 640, height: 440 });
+    await settle();
+    await page.locator('[data-sidebar-backdrop="right"]').click({ position: { x: 10, y: 200 } });
+    await settle();
+    await page.setViewportSize({ width: 1280, height: 440 });
+    await page.locator('[data-floating-sidebar-toggle="right"] button').click();
+    await settle();
+    assert.deepEqual(await state(), expanded, 'Resize while closed must preserve expansion');
+    assert.equal(await scrollTop(), offset, 'Resize while closed must preserve scroll');
+    assert.deepEqual(errors, [], 'Dashboard must not throw browser errors');
+    const video = page.video();
+    await context.close();
+    if (video) console.log(`Video: ${await video.path()}`);
+    console.log(`PASS: sidebar persistence (${reducedMotion})`);
+  }
+} finally {
+  for (const heartbeat of heartbeats) clearInterval(heartbeat);
+  await browser?.close();
+  server.stop(true);
+}

--- a/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
+++ b/packages/expo-device-hub/scripts/check-sidebar-persistence.ts
@@ -142,6 +142,16 @@ try {
     await populated.waitForTimeout(300);
     assert.deepEqual(await panes.evaluateAll((elements) => elements.map((el) => el.scrollTop)), [100, 100],
       'Populated Events and Logs must preserve their own scroll positions');
+    await populated.getByRole('button', { name: 'Refresh buffers' }).click();
+    await populated.waitForTimeout(100);
+    assert.deepEqual(await panes.evaluateAll((elements) => elements.map((el) => el.scrollTop)), [100, 100],
+      'Replayed snapshots must preserve scroll even when the arrays are replaced');
+    await populated.getByRole('button', { name: 'Append log' }).click();
+    await populated.waitForTimeout(100);
+    assert.equal(await panes.last().evaluate((el) => el.scrollTop), 100,
+      'New entries must not interrupt reading earlier logs');
+    await panes.last().evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await populated.waitForTimeout(100);
     await populated.getByRole('button', { name: 'Append log' }).click();
     await populated.waitForTimeout(100);
     assert(await panes.last().evaluate((el) => el.scrollTop === el.scrollHeight - el.clientHeight),

--- a/packages/expo-device-hub/scripts/fixtures/sidebar-logs.tsx
+++ b/packages/expo-device-hub/scripts/fixtures/sidebar-logs.tsx
@@ -20,16 +20,23 @@ const client = {
 function Fixture() {
   const [open, setOpen] = useState(true);
   const [rows, setRows] = useState(entries);
+  const [events, setEvents] = useState(client.events);
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <div>
         <button onClick={() => setOpen(!open)}>Toggle inspector</button>
+        <button onClick={() => {
+          setRows(rows.map((entry) => ({ ...entry })));
+          setEvents(events.map((entry) => ({ ...entry })));
+        }}>
+          Refresh buffers
+        </button>
         <button onClick={() => setRows([...rows, { id: String(rows.length), source: 'test', message: 'New entry' }])}>
           Append log
         </button>
       </div>
       <RightSidebar open={open} overlay={false} topmost width={400} resizing={false} onDismiss={() => setOpen(false)}>
-        <LogSidebar client={{ ...client, logs: rows }} />
+        <LogSidebar client={{ ...client, logs: rows, events }} />
       </RightSidebar>
     </div>
   );

--- a/packages/expo-device-hub/scripts/fixtures/sidebar-logs.tsx
+++ b/packages/expo-device-hub/scripts/fixtures/sidebar-logs.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { NOOP_DEVICE_CLIENT } from '../../../@expo/hub-client/src/useNoopDeviceClient';
+import { LogSidebar } from '../../../@expo/hub-components/src/dashboard/LogSidebar';
+import { RightSidebar } from '../../src/dashboard/RightSidebar';
+
+const entries = Array.from({ length: 100 }, (_, index) => ({
+  id: String(index),
+  source: 'test',
+  message: `Entry ${index}`,
+}));
+const client = {
+  ...NOOP_DEVICE_CLIENT,
+  capabilities: { ...NOOP_DEVICE_CLIENT.capabilities, events: true },
+  logs: entries,
+  events: entries.map((entry) => ({ ...entry, timestamp: '2026-09-10T00:00:00Z', kind: 'test' })),
+} satisfies typeof NOOP_DEVICE_CLIENT;
+
+function Fixture() {
+  const [open, setOpen] = useState(true);
+  const [rows, setRows] = useState(entries);
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div>
+        <button onClick={() => setOpen(!open)}>Toggle inspector</button>
+        <button onClick={() => setRows([...rows, { id: String(rows.length), source: 'test', message: 'New entry' }])}>
+          Append log
+        </button>
+      </div>
+      <RightSidebar open={open} overlay={false} topmost width={400} resizing={false} onDismiss={() => setOpen(false)}>
+        <LogSidebar client={{ ...client, logs: rows }} />
+      </RightSidebar>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<Fixture />);

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -49,6 +49,7 @@ import {
 import { useArgentInteractions } from './dashboard/useArgentInteraction';
 import { useNewDeviceOptions } from './dashboard/useNewDeviceOptions';
 import { SidebarOverlay } from './dashboard/SidebarOverlay';
+import { RightSidebar } from './dashboard/RightSidebar';
 import { useSidebarLayout } from './dashboard/useSidebarLayout';
 import {
   androidStreamModeAvailability,
@@ -397,11 +398,12 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           }
         />
       )}
-      <AnimatedDockedSidebar
-        side="right"
+      <RightSidebar
         width={logsWidth}
-        open={sidebars.rightDocked}
-        sidebarOpen={sidebars.rightOpen}
+        open={sidebars.rightOpen}
+        overlay={sidebars.containerWidth < logsWidth + MIN_STREAM_WIDTH}
+        topmost={sidebars.lastOpened === 'right' || !sidebars.leftOverlay}
+        onDismiss={sidebars.closeRight}
         resizing={resizing}>
         <LogSidebar
           device={selected}
@@ -418,7 +420,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           onToggle={sidebars.closeRight}
           width={logsWidth}
         />
-      </AnimatedDockedSidebar>
+      </RightSidebar>
 
       <SidebarOverlay
         side="left"
@@ -440,29 +442,6 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           onToggle={sidebars.closeLeft}
           platform={platform}
           width={sidebarWidth}
-        />
-      </SidebarOverlay>
-
-      <SidebarOverlay
-        side="right"
-        open={sidebars.rightOverlay}
-        sidebarOpen={sidebars.rightOpen}
-        topmost={sidebars.lastOpened === 'right' || !sidebars.leftOverlay}
-        onDismiss={sidebars.closeRight}>
-        <LogSidebar
-          device={selected}
-          client={client}
-          showDeviceFrame={showDeviceFrame}
-          onShowDeviceFrameChange={setShowDeviceFrame}
-          streamMode={streamMode}
-          httpCodec={httpCodec}
-          streamModeAvailability={selectedStreamModeAvailability}
-          onStreamModeChange={handleStreamModeChange}
-          onHttpCodecChange={setHttpCodec}
-          onShutdown={selected ? () => handleShutdown(selected) : undefined}
-          onRemove={selected ? () => handleRemove(selected) : undefined}
-          onToggle={sidebars.closeRight}
-          width={logsWidth}
         />
       </SidebarOverlay>
 

--- a/packages/expo-device-hub/src/dashboard/RightSidebar.tsx
+++ b/packages/expo-device-hub/src/dashboard/RightSidebar.tsx
@@ -1,0 +1,91 @@
+import { bg, border } from '@expo/hub-components';
+import { Activity, type ReactNode } from 'react';
+
+import {
+  SIDEBAR_TRANSITION_EASING,
+  SIDEBAR_TRANSITION_MS,
+  useSidebarPresence,
+} from './useSidebarPresence';
+
+/** One inspector tree across closing, reopening, and docked/overlay layout changes. */
+export function RightSidebar({
+  open,
+  overlay,
+  width,
+  resizing,
+  topmost,
+  onDismiss,
+  children,
+}: {
+  open: boolean;
+  /** Whether the available space requires an overlay, even while closed. */
+  overlay: boolean;
+  width: number;
+  resizing: boolean;
+  topmost: boolean;
+  onDismiss: () => void;
+  children: ReactNode;
+}) {
+  const { present, reducedMotion, visible } = useSidebarPresence(open, true);
+  const backdropZIndex = topmost ? 12 : 10;
+  const panelTransition = reducedMotion
+    ? undefined
+    : `transform ${SIDEBAR_TRANSITION_MS}ms ${SIDEBAR_TRANSITION_EASING}`;
+
+  return (
+    <>
+      {overlay && present && (
+        <div
+          aria-hidden="true"
+          data-sidebar-backdrop="right"
+          onClick={onDismiss}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: bg.overlay,
+            opacity: visible ? 0.35 : 0,
+            pointerEvents: visible ? undefined : 'none',
+            transition: reducedMotion ? undefined : `opacity ${SIDEBAR_TRANSITION_MS}ms ease`,
+            zIndex: backdropZIndex,
+          }}
+        />
+      )}
+      <div
+        aria-hidden={!visible || undefined}
+        inert={!visible || undefined}
+        data-sidebar-docked={overlay ? undefined : 'right'}
+        data-sidebar-overlay={overlay ? 'right' : undefined}
+        data-state={visible ? 'open' : 'closed'}
+        style={{
+          position: overlay ? 'absolute' : undefined,
+          top: overlay ? 0 : undefined,
+          right: overlay ? 0 : undefined,
+          zIndex: overlay ? backdropZIndex + 1 : undefined,
+          width: overlay ? `min(${width}px, 100vw)` : visible ? width : 0,
+          height: '100%',
+          flexShrink: 0,
+          overflow: 'hidden',
+          pointerEvents: visible ? undefined : 'none',
+          transition:
+            overlay || reducedMotion || resizing
+              ? undefined
+              : `width ${SIDEBAR_TRANSITION_MS}ms ${SIDEBAR_TRANSITION_EASING}`,
+        }}>
+        <div
+          style={{
+            width: `min(${width}px, 100vw)`,
+            height: '100%',
+            backgroundColor: bg.default,
+            borderLeft: overlay ? `1px solid ${border.default}` : undefined,
+            transform: visible ? 'translateX(0)' : 'translateX(100%)',
+            transition: panelTransition,
+            willChange: 'transform',
+          }}>
+          {/* Preserve section state and DOM scroll offsets, but release subscriptions
+              after the exit animation while the inspector is hidden. */}
+          <Activity mode={present ? 'visible' : 'hidden'}>{children}</Activity>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Closing the right inspector previously discarded its expanded sections and scroll position. Keep a single inspector across docked and overlay layouts, and preserve its React state and DOM with an Activity boundary after the exit animation. Hidden inspector subscriptions are still cleaned up and its controls are inert. Logs and Events also retain their nested scroll positions when Activity reactivates effects with unchanged data.

Validation:
- Added a browser regression against the exported dashboard with an empty device host. It failed on upstream and now passes for normal and reduced motion, expanded/collapsed sections, scrolling, overlay dismissal, and resizing while open or closed.
- Added a populated inspector fixture covering both Logs and Events scroll positions on reopen; new log data follows the tail when the viewer is at the bottom, while reading older entries preserves the scroll position.
- Web export succeeds; all 177 expo-device-hub tests and 24 hub-components tests pass. Hub-components lint and type checking pass.
- `bunx tsc --noEmit --types bun` reports the same three existing errors in `serve-emu-options.test.ts` on this branch and upstream `main`.
- Recorded a 20-second verification on an actual streaming iPhone 17 Pro simulator (iOS 26.5): expanded settings, 24 real touch events, and a moving timer in Safari. The sidebar offset remains 650 → 650 px; the Events pane remains 150 → 150 px across closing/reopening.
- The live recording exposed replayed event snapshots resetting the scroll. The follow-up fix preserves history positions across replaced buffers and incoming entries, with browser regression coverage.
- Independent deep review posted one finding about populated panes; fixed in the follow-up commit with regression coverage.

To reproduce the browser check: build the workspace dependencies and web client, install Chromium with `bunx playwright install chromium`, then run `bun run test:sidebar` from `packages/expo-device-hub`. Set `SIDEBAR_VIDEO_DIR` to record the run.

