### PR TITLE
Add Android video FPS and bitrate controls to Hub UI

### DIFF
--- a/.changeset/android-video-controls.md
+++ b/.changeset/android-video-controls.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': minor
+---
+
+Add Video FPS and Video bitrate controls to Android stream options for WebSocket and WebRTC playback.

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -74,7 +74,7 @@ describe('serve-emu stream contract', () => {
 });
 
 describe('serve-emu runtime stream settings contract', () => {
-  test('patches only Android resolution with a validated max dimension', () => {
+  test('patches Android encoder settings while omitting MJPEG-only fields', () => {
     expect(
       androidStreamSettingsPatch({
         maxDimension: 720,
@@ -83,12 +83,29 @@ describe('serve-emu runtime stream settings contract', () => {
         h264Fps: 30,
         h264Bitrate: 3_000_000,
       }),
-    ).toEqual({ maxDimension: 720 });
-    expect(androidStreamSettingsPatch({ h264Fps: 30 })).toBeNull();
+    ).toEqual({ maxDimension: 720, h264Fps: 30, h264Bitrate: 3_000_000 });
+    expect(androidStreamSettingsPatch({ h264Fps: 30 })).toEqual({ h264Fps: 30 });
+    expect(androidStreamSettingsPatch({ h264Bitrate: 8_000_000 })).toEqual({ h264Bitrate: 8_000_000 });
+    expect(androidStreamSettingsPatch({})).toBeNull();
+    expect(androidStreamSettingsPatch({ mjpegFps: 30 })).toBeNull();
     expect(androidStreamSettingsPatch({ maxDimension: Number.NaN })).toBeNull();
     expect(androidStreamSettingsPatch({ maxDimension: 720.5 })).toBeNull();
     expect(androidStreamSettingsPatch({ maxDimension: -1 })).toBeNull();
     expect(androidStreamSettingsPatch({ maxDimension: 4_097 })).toBeNull();
+  });
+
+  test('validates FPS and bitrate bounds without sending partial invalid updates', () => {
+    for (const [key, min, max] of [
+      ['h264Fps', 1, 120],
+      ['h264Bitrate', 100_000, 50_000_000],
+    ] as const) {
+      for (const value of [min, max]) {
+        expect(androidStreamSettingsPatch({ [key]: value })).toEqual({ [key]: value });
+      }
+      for (const value of [min - 1, max + 1, min + 0.5, Number.NaN, Infinity]) {
+        expect(androidStreamSettingsPatch({ maxDimension: 720, [key]: value })).toBeNull();
+      }
+    }
   });
 
   test('accepts only authoritative responses that include a valid max dimension', () => {

--- a/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
+++ b/packages/@expo/hub-client/src/__tests__/android-stream.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import { DEVICE_STREAM_SETTING_BOUNDS } from '../stream-settings';
+
 import {
   androidStreamSettingsPatch,
   parseAndroidStreamSettings,
@@ -95,10 +97,8 @@ describe('serve-emu runtime stream settings contract', () => {
   });
 
   test('validates FPS and bitrate bounds without sending partial invalid updates', () => {
-    for (const [key, min, max] of [
-      ['h264Fps', 1, 120],
-      ['h264Bitrate', 100_000, 50_000_000],
-    ] as const) {
+    for (const key of ['h264Fps', 'h264Bitrate'] as const) {
+      const [min, max] = DEVICE_STREAM_SETTING_BOUNDS[key];
       for (const value of [min, max]) {
         expect(androidStreamSettingsPatch({ [key]: value })).toEqual({ [key]: value });
       }

--- a/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
+++ b/packages/@expo/hub-client/src/__tests__/webrtc-stream-restart.test.tsx
@@ -136,7 +136,7 @@ for (const outcome of ['success', 'failure', 'superseded'] as const) {
     await act(async () => {
       renderer = create(<Harness />);
     });
-    expect(settings!.updateStreamSettings({ h264Fps: 30 })).toBeUndefined();
+    expect(settings!.updateStreamSettings({ mjpegFps: 30 })).toBeUndefined();
     let write: Promise<boolean> | undefined;
     await act(async () => {
       write = settings!.updateStreamSettings({ maxDimension: 720 });
@@ -239,7 +239,7 @@ async function androidHarness({ delaySource = false } = {}) {
     availableInputSources: ['scrcpy', 'grpc'],
     sessionGeneration: 1,
   };
-  const writes: { path: string; finish: (response: Response) => void }[] = [];
+  const writes: { path: string; body: unknown; finish: (response: Response) => void }[] = [];
   let finishSource!: (response: Response) => void;
   const sourceRead = new Promise<Response>((resolve) => {
     finishSource = resolve;
@@ -248,10 +248,12 @@ async function androidHarness({ delaySource = false } = {}) {
     const path = new URL(url).pathname;
     if (init?.method === 'PATCH' || init?.method === 'PUT') {
       return new Promise<Response>((finish) => {
-        writes.push({ path, finish });
+        writes.push({ path, body: JSON.parse(String(init.body)), finish });
       });
     }
-    if (path === '/api/stream-settings') return Response.json({ maxDimension: 1280 });
+    if (path === '/api/stream-settings') {
+      return Response.json({ maxDimension: 1280, h264Fps: 60, h264Bitrate: 6_000_000 });
+    }
     if (path === '/api/stream-mode') return delaySource ? sourceRead : Response.json(source);
     if (path === '/api') {
       return Response.json({
@@ -351,6 +353,35 @@ test('Android settings wait for fresh video, preserve the poster past grace, and
   expect(hub.client.status).toBe('streaming');
   expect(hub.video.poster).toBe('');
 });
+
+for (const patch of [{ h264Fps: 24 }, { h264Bitrate: 8_000_000 }]) {
+  for (const success of [true, false]) {
+    test(`Android ${Object.keys(patch)[0]} changes ${success ? 'restart after commit' : 'roll back on failure'}`, async () => {
+      const hub = await androidHarness();
+      expect(hub.client.capabilities.streamSettings).toMatchObject({
+        h264Fps: true,
+        h264Bitrate: true,
+      });
+      const previous = hub.client.streamSettings;
+      await act(async () => hub.client.updateStreamSettings(patch));
+      expect(hub.writes).toHaveLength(1);
+      expect(hub.writes[0]).toMatchObject({ path: '/api/stream-settings', body: patch });
+      expect(hub.client.streamSettingsPending).toBe(true);
+      expect(Peer.instances).toHaveLength(1);
+      await hub.finishWrite({ ...previous, ...patch }, success ? 200 : 503);
+      if (success) {
+        expect(Peer.instances).toHaveLength(2);
+        expect(hub.client.streamSettings).toMatchObject(patch);
+        await hub.paintReplacement();
+      } else {
+        expect(Peer.instances).toHaveLength(1);
+        expect(hub.client.streamSettings).toEqual(previous);
+      }
+      expect(hub.client.status).toBe('streaming');
+      expect(hub.client.streamSettingsPending).toBe(false);
+    });
+  }
+}
 
 test('Android source changes reject overlapping settings writes and wait for replacement frames', async () => {
   const hub = await androidHarness({ delaySource: true });

--- a/packages/@expo/hub-client/src/android-stream-settings.ts
+++ b/packages/@expo/hub-client/src/android-stream-settings.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_DEVICE_STREAM_SETTINGS,
+  DEVICE_STREAM_SETTING_BOUNDS,
   normalizeDeviceStreamSettings,
 } from './stream-settings';
 import { type DeviceStreamEncoderSettings } from './types';
@@ -13,11 +14,8 @@ export function androidStreamSettingsPatch(
   patch: Partial<DeviceStreamEncoderSettings>,
 ): AndroidStreamSettingsPatch | null {
   const result: AndroidStreamSettingsPatch = {};
-  for (const [key, min, max] of [
-    ['maxDimension', 0, 4096],
-    ['h264Fps', 1, 120],
-    ['h264Bitrate', 100_000, 50_000_000],
-  ] as const) {
+  for (const key of ['maxDimension', 'h264Fps', 'h264Bitrate'] as const) {
+    const [min, max] = DEVICE_STREAM_SETTING_BOUNDS[key];
     const value = patch[key];
     if (value === undefined) continue;
     if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
@@ -35,11 +33,12 @@ export function parseAndroidStreamSettings(
 ): DeviceStreamEncoderSettings | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const maxDimension = (value as Record<string, unknown>).maxDimension;
+  const [min, max] = DEVICE_STREAM_SETTING_BOUNDS.maxDimension;
   if (
     typeof maxDimension !== 'number' ||
     !Number.isInteger(maxDimension) ||
-    maxDimension < 0 ||
-    maxDimension > 4096
+    maxDimension < min ||
+    maxDimension > max
   ) {
     return null;
   }

--- a/packages/@expo/hub-client/src/android-stream-settings.ts
+++ b/packages/@expo/hub-client/src/android-stream-settings.ts
@@ -4,21 +4,28 @@ import {
 } from './stream-settings';
 import { type DeviceStreamEncoderSettings } from './types';
 
-export type AndroidStreamSettingsPatch = Pick<DeviceStreamEncoderSettings, 'maxDimension'>;
+export type AndroidStreamSettingsPatch = Partial<
+  Pick<DeviceStreamEncoderSettings, 'maxDimension' | 'h264Fps' | 'h264Bitrate'>
+>;
 
-/** Restrict the shared encoder patch API to the setting serve-emu can change at runtime. */
+/** Forward supported Android encoder settings with serve-emu's runtime bounds. */
 export function androidStreamSettingsPatch(
   patch: Partial<DeviceStreamEncoderSettings>,
 ): AndroidStreamSettingsPatch | null {
-  if (
-    typeof patch.maxDimension !== 'number' ||
-    !Number.isInteger(patch.maxDimension) ||
-    patch.maxDimension < 0 ||
-    patch.maxDimension > 4096
-  ) {
-    return null;
+  const result: AndroidStreamSettingsPatch = {};
+  for (const [key, min, max] of [
+    ['maxDimension', 0, 4096],
+    ['h264Fps', 1, 120],
+    ['h264Bitrate', 100_000, 50_000_000],
+  ] as const) {
+    const value = patch[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+      return null;
+    }
+    result[key] = value;
   }
-  return { maxDimension: patch.maxDimension };
+  return Object.keys(result).length > 0 ? result : null;
 }
 
 /** Parse the authoritative serve-emu response without inventing a resolution. */

--- a/packages/@expo/hub-client/src/stream-settings.ts
+++ b/packages/@expo/hub-client/src/stream-settings.ts
@@ -1,5 +1,13 @@
 import { type DeviceStreamEncoderSettings } from './types';
 
+export const DEVICE_STREAM_SETTING_BOUNDS = {
+  mjpegFps: [1, 120],
+  mjpegQuality: [0.05, 1],
+  maxDimension: [0, 4096],
+  h264Bitrate: [100_000, 50_000_000],
+  h264Fps: [1, 120],
+} as const satisfies Record<keyof DeviceStreamEncoderSettings, readonly [number, number]>;
+
 export const DEFAULT_DEVICE_STREAM_SETTINGS: DeviceStreamEncoderSettings = {
   mjpegFps: 60,
   mjpegQuality: 0.7,
@@ -45,10 +53,30 @@ export function normalizeDeviceStreamSettings(
       ? (value as Record<string, unknown>)
       : {};
   return {
-    mjpegFps: integerInRange(settings.mjpegFps, fallback.mjpegFps, 1, 120),
-    mjpegQuality: numberInRange(settings.mjpegQuality, fallback.mjpegQuality, 0.05, 1),
-    maxDimension: integerInRange(settings.maxDimension, fallback.maxDimension, 0, 4096),
-    h264Bitrate: integerInRange(settings.h264Bitrate, fallback.h264Bitrate, 100_000, 50_000_000),
-    h264Fps: integerInRange(settings.h264Fps, fallback.h264Fps, 1, 120),
+    mjpegFps: integerInRange(
+      settings.mjpegFps,
+      fallback.mjpegFps,
+      ...DEVICE_STREAM_SETTING_BOUNDS.mjpegFps,
+    ),
+    mjpegQuality: numberInRange(
+      settings.mjpegQuality,
+      fallback.mjpegQuality,
+      ...DEVICE_STREAM_SETTING_BOUNDS.mjpegQuality,
+    ),
+    maxDimension: integerInRange(
+      settings.maxDimension,
+      fallback.maxDimension,
+      ...DEVICE_STREAM_SETTING_BOUNDS.maxDimension,
+    ),
+    h264Bitrate: integerInRange(
+      settings.h264Bitrate,
+      fallback.h264Bitrate,
+      ...DEVICE_STREAM_SETTING_BOUNDS.h264Bitrate,
+    ),
+    h264Fps: integerInRange(
+      settings.h264Fps,
+      fallback.h264Fps,
+      ...DEVICE_STREAM_SETTING_BOUNDS.h264Fps,
+    ),
   };
 }

--- a/packages/@expo/hub-client/src/useAndroidDevice.ts
+++ b/packages/@expo/hub-client/src/useAndroidDevice.ts
@@ -1772,7 +1772,7 @@ export function useAndroidDeviceClient(options: DeviceConnectionOptions): Device
       activity: false,
       events: true,
       camera: cameraSupported,
-      streamSettings: { maxDimension: true },
+      streamSettings: { maxDimension: true, h264Fps: true, h264Bitrate: true },
     },
     foregroundApp,
     videoKind: useWebRtc ? 'video' : 'canvas',

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -69,7 +69,9 @@ npx expo-device-hub --platform android --transport webrtc
 Use `--stream-source scrcpy` to select scrcpy at startup, or `--grpc-image-mode png` to
 send a compressed image in each gRPC message. Use `--grpc-image-mode rgb888` for raw
 RGB888 pixels inside each gRPC response. The same source and PNG/MMAP/RGB888 choices
-are available at runtime under **Stream options**. Run `npx expo-device-hub --help`
+are available at runtime under **Stream options**. Android also exposes **Video FPS**
+and **Video bitrate** there for both WebSocket and WebRTC playback. Changing either
+restarts the stream with the selected encoder settings. Run `npx expo-device-hub --help`
 for the full option list.
 
 ```sh

--- a/packages/expo-device-hub/README.md
+++ b/packages/expo-device-hub/README.md
@@ -58,10 +58,6 @@ the device dashboard without a running Expo project:
 npx expo-device-hub
 ```
 
-Android exposes **Video FPS** and **Video bitrate** under **Stream options** for
-both WebSocket and WebRTC playback. Changing either restarts the stream with the
-selected encoder settings. Run `npx expo-device-hub --help` for the full CLI option list.
-
 ## Acknowledgements
 
 Device streaming and control are powered by two vendored, Apache-2.0-licensed

--- a/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
+++ b/packages/expo-device-hub/src/dashboard/__tests__/inspectorSections.test.tsx
@@ -104,7 +104,7 @@ function inspectorClient(platform: DevicePlatform): DeviceClient {
             h264Bitrate: true,
             h264Fps: true,
           }
-        : { maxDimension: true },
+        : { maxDimension: true, h264Fps: true, h264Bitrate: true },
     },
     foregroundApp: null,
     videoKind: 'img',
@@ -404,34 +404,40 @@ test('shows the Camera section only when the client reports camera feeds', () =>
   expect(iosHtml).not.toContain('<section aria-label="Camera"');
 });
 
-test('shows Android resolution while omitting encoder settings serve-emu cannot change', () => {
-  const html = renderToStaticMarkup(
-    <StreamOptionsSection
-      client={inspectorClient('android')}
-      defaultOpen
-      streamMode="webrtc"
-      httpCodec="h264"
-      streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
-      onStreamModeChange={() => {}}
-      onHttpCodecChange={() => {}}
-    />,
-  );
+for (const streamMode of ['h264', 'webrtc'] as const) {
+  test(`shows Android encoder controls over ${streamMode}`, () => {
+    const html = renderToStaticMarkup(
+      <StreamOptionsSection
+        client={inspectorClient('android')}
+        defaultOpen
+        streamMode={streamMode}
+        httpCodec="h264"
+        streamModeAvailability={{ mjpeg: true, h264: true, webrtc: true }}
+        onStreamModeChange={() => {}}
+        onHttpCodecChange={() => {}}
+      />,
+    );
 
-  expect(selectOptionLabels(html, 'Stream transport')).toEqual(['WebSocket', 'WebRTC']);
-  expect(selectValue(html, 'Stream transport')).toBe('WebRTC');
-  expect(selectOptionLabels(html, 'WebSocket codec')).toEqual(['H.264']);
-  expect(selectOptionLabels(html, 'WebRTC codec')).toEqual(['H.264']);
-  expect(html).not.toContain('>HTTP<');
-  expect(html).not.toContain('>MJPEG<');
-  expect(html).not.toContain('>VP8<');
-  expect(html).not.toContain('>VP9<');
-  expect(html).toContain('>Max size</span>');
-  expect(selectMarkup(html, 'Max size')).not.toContain('disabled=""');
-  expect(html).not.toContain('>MJPEG FPS</span>');
-  expect(html).not.toContain('>MJPEG quality</span>');
-  expect(html).not.toContain('>Video FPS</span>');
-  expect(html).not.toContain('>Video bitrate</span>');
-});
+    expect(selectOptionLabels(html, 'Stream transport')).toEqual(['WebSocket', 'WebRTC']);
+    expect(selectValue(html, 'Stream transport')).toBe(
+      streamMode === 'webrtc' ? 'WebRTC' : 'WebSocket',
+    );
+    expect(selectOptionLabels(html, 'WebSocket codec')).toEqual(['H.264']);
+    expect(selectOptionLabels(html, 'WebRTC codec')).toEqual(['H.264']);
+    expect(html).not.toContain('>HTTP<');
+    expect(html).not.toContain('>MJPEG<');
+    expect(html).not.toContain('>VP8<');
+    expect(html).not.toContain('>VP9<');
+    expect(html).toContain('>Max size</span>');
+    expect(selectMarkup(html, 'Max size')).not.toContain('disabled=""');
+    expect(html).not.toContain('>MJPEG FPS</span>');
+    expect(html).not.toContain('>MJPEG quality</span>');
+    expect(selectValue(html, 'Video FPS')).toBe('60 FPS');
+    expect(selectValue(html, 'Video bitrate')).toBe('6 Mbps');
+    expect(selectMarkup(html, 'Video FPS')).not.toContain('disabled=""');
+    expect(selectMarkup(html, 'Video bitrate')).not.toContain('disabled=""');
+  });
+}
 
 test('shows the Android emulator capture source select', () => {
   const html = renderToStaticMarkup(
@@ -544,14 +550,16 @@ test('hides the Android capture source row when gRPC is unavailable', () => {
   expect(html).not.toContain('aria-label="Stream source"');
 });
 
-test('disables Android resolution while a stream restart is pending', () => {
+test('disables Android encoder controls while a stream restart is pending', () => {
   const client = {
     ...inspectorClient('android'),
     streamSettingsPending: true,
   } satisfies DeviceClient;
   const html = renderToStaticMarkup(<StreamOptionsSection client={client} defaultOpen />);
 
-  expect(selectMarkup(html, 'Max size')).toContain('disabled=""');
+  for (const label of ['Max size', 'Video FPS', 'Video bitrate']) {
+    expect(selectMarkup(html, label)).toContain('disabled=""');
+  }
 });
 
 test('renders grouped WebRTC statistics with rich client, encoder, and capture values', () => {


### PR DESCRIPTION
Android stream options exposed only Max size even though serve-emu supports runtime FPS and bitrate changes. Enable the existing Video FPS and Video bitrate controls for Android WebSocket and WebRTC playback, and forward validated FPS/bitrate patches to the server.

Changes use the existing stream restart flow, disable controls while pending, and restore the previous settings if the update fails. Document the controls and add a minor changeset.

Validation:
- 67 targeted tests passed across Android stream contracts, hook restart/rollback behavior, and inspector rendering.
- hub-client and hub-components builds passed.
- hub-client typecheck and lint passed; git diff --check passed.
- Live device playback was not tested.
