### PR TITLE
Shorten the default Android keyframe interval to one second

### DIFF
--- a/.changeset/short-android-keyframes.md
+++ b/.changeset/short-android-keyframes.md
@@ -1,0 +1,5 @@
+---
+"expo-device-hub": patch
+---
+
+Shorten the default Android video keyframe interval from ten seconds to one second, giving decoders more frequent opportunities to recover after lost frames. Explicit keyframe interval overrides remain supported.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -122,7 +122,7 @@ serve-emu --running-avds
 | `--max-fps` | `60` | Cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
 | `--max-size` | `1280` | Downscale the longest edge to N pixels; `0` keeps native size. The default balances detail and throughput, especially for the host-side software encoder used by `grpc-screenshot` |
-| `--key-frame-interval` | `10` | Ask the encoder for regular keyframes; `0` disables this codec option. Late joiners get keyframes on demand, so a long interval avoids periodic keyframe bursts |
+| `--key-frame-interval` | `1` | Ask the encoder for regular keyframes in seconds; `0` disables this codec option. Frequent keyframes help decoders recover after lost frames. Late joiners also get keyframes on demand |
 | `--repeat-frame-ms` | `0` | Re-encode the previous frame after N ms without screen changes (`16` ≈ steady 60fps on static screens, at extra CPU/bandwidth cost); `0` keeps the source default: 100ms for scrcpy and 500ms for `grpc-screenshot` |
 | `--transport` | `websocket` | Initial browser video transport: `websocket` or `webrtc`. Each tab can switch independently in the UI |
 | `--stun-url` | public STUN defaults | Comma-separated STUN URL(s) for WebRTC ICE |

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -124,7 +124,7 @@ serve-emu --running-avds
 | `--max-fps` | `60` | Cap source frame rate |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
 | `--max-size` | `1280` | Downscale the longest edge to N pixels; `0` keeps native size. The default balances detail and throughput, especially for the host-side software encoder used by `grpc-screenshot` |
-| `--key-frame-interval` | `10` | Ask the encoder for regular keyframes; `0` disables this codec option. Late joiners get keyframes on demand, so a long interval avoids periodic keyframe bursts |
+| `--key-frame-interval` | `1` | Ask the encoder for regular keyframes in seconds; `0` disables this codec option. Frequent keyframes help decoders recover after lost frames. Late joiners also get keyframes on demand |
 | `--repeat-frame-ms` | `0` | Re-encode the previous frame after N ms without screen changes (`16` ≈ steady 60fps on static screens, at extra CPU/bandwidth cost); `0` keeps the source default: 100ms for scrcpy and 500ms for `grpc-screenshot` |
 | `--transport` | `websocket` | Initial browser video transport: `websocket` or `webrtc`. Each tab can switch independently in the UI |
 | `--stun-url` | public STUN defaults | Comma-separated STUN URL(s) for WebRTC ICE |

--- a/packages/serve-emu/packages/serve-emu/src/cli.ts
+++ b/packages/serve-emu/packages/serve-emu/src/cli.ts
@@ -224,9 +224,9 @@ Options:
                          delivery for either source.
       --key-frame-interval <sec>
                          Ask the encoder for regular keyframes; 0 disables this
-                         codec option (default: ${SCRCPY_DEFAULTS.keyFrameInterval}). Late joiners get keyframes
-                         on demand via reset-video, so a long interval avoids
-                         periodic keyframe bursts.
+                         codec option (default: ${SCRCPY_DEFAULTS.keyFrameInterval}). Frequent keyframes help
+                         decoders recover after lost frames. Late joiners also
+                         get keyframes on demand via reset-video.
       --repeat-frame-ms <ms>
                          Re-encode the previous frame after this many ms with no
                          screen change, so static screens keep producing frames

--- a/packages/serve-emu/packages/serve-emu/src/scrcpy.ts
+++ b/packages/serve-emu/packages/serve-emu/src/scrcpy.ts
@@ -132,9 +132,9 @@ export const SCRCPY_DEFAULTS = {
   // (c2.android.avc.encoder) only sustains 60fps below roughly a megapixel,
   // so cap the longest edge at 1280 unless the caller overrides it.
   maxSize: 1280,
-  // Late joiners get keyframes on demand via reset-video, so a long interval
-  // avoids periodic keyframe bursts.
-  keyFrameInterval: 10,
+  // Frequent keyframes give decoders another recovery point after lost frames.
+  // Late joiners can still request an immediate keyframe via reset-video.
+  keyFrameInterval: 1,
   repeatFrameMs: 0,
 } as const;
 

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -1218,10 +1218,12 @@ describe("startGrpcSession integration", () => {
     try {
       expect(requests).toEqual([encoder]);
       expect(encoders[0]!.options.encoderName).toBe(resolved);
+      expect(encoders[0]!.options.keyFrameInterval).toBe(1);
       expect(session.diagnostics?.().grpcCapture?.encoderName).toBe(resolved);
       client.streamImage!(integrationImage(0, 6, 4), "stream", Date.now());
       await waitFor(() => encoders.length === 2);
       expect(encoders[1]!.options.encoderName).toBe(resolved);
+      expect(encoders[1]!.options.keyFrameInterval).toBe(1);
       expect(requests).toHaveLength(1);
     } finally {
       await session.close();

--- a/packages/serve-emu/packages/serve-emu/tests/scrcpy-lifecycle.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/scrcpy-lifecycle.test.ts
@@ -419,7 +419,7 @@ describe("scrcpy async lifecycle", () => {
       "max_size=1280",
       "video_bit_rate=8000000",
       "max_fps=60",
-      "video_codec_options=i-frame-interval=10",
+      "video_codec_options=i-frame-interval=1",
       "clipboard_autosync=false",
       "cleanup=true",
     ]);


### PR DESCRIPTION
Android streams currently default to ten seconds between keyframes, which can leave a decoder waiting for the next recovery point after losing reference frames. Shorten the shared scrcpy and gRPC default to one second, update CLI help and the generated documentation, and add a patch changeset. Explicit interval overrides and on-demand keyframe requests remain unchanged.

For host FFmpeg encoding this is a frame-count interval: at a configured 60 FPS, the GOP changes from 600 to 60 frames. Actual wall-clock spacing grows when the source produces fewer frames. More frequent keyframes trade some compression efficiency for more frequent recovery opportunities; this does not change WebRTC feedback handling.

Validation:

- `bun run --filter serve-emu check` passed: 973 tests, coverage checks, server/UI/test type checks, build, and package smoke test. Existing integration tests verify the one-second default for scrcpy and both gRPC encoder backends, including encoder replacement after a size change.
- Tested the built module on the staging Android machine with NVENC, RGB888 over gRPC, WebRTC, 60 FPS, 8 Mbps, and a 960-pixel maximum stream dimension. Confirmed `-g 60` and four keyframes in every 240-frame health window after warm-up.
- Sampled the animated test page's health endpoint every two seconds for one minute. After warm-up, gRPC delivery averaged 52.79 FPS and encoded/published output averaged 54.29 FPS (48.49–58.49), with no capture restarts or additional publisher drops.
- Twenty browser samples in two batches over 64 seconds showed 31–51 client FPS (43.5 average). One sample reported two brief freezes totaling 508 ms. No multi-second freeze was captured, but the baseline was disrupted by app/resolution changes, so this experiment does **not** establish that keyframe recovery caused the original freezes.

— Codex (GPT-6)
