### PR TITLE
Forward gRPC frames as soon as FFmpeg is ready

### DIFF
--- a/.changeset/grpc-ffmpeg-handoff.md
+++ b/.changeset/grpc-ffmpeg-handoff.md
@@ -1,0 +1,5 @@
+---
+'expo-device-hub': patch
+---
+
+Forward gRPC frames to FFmpeg as soon as its input is ready, with bounded backpressure and larger receive windows. Remove local RGB888 frame-write pacing and retry polling.

--- a/.changeset/grpc-ffmpeg-handoff.md
+++ b/.changeset/grpc-ffmpeg-handoff.md
@@ -2,4 +2,4 @@
 'expo-device-hub': patch
 ---
 
-Forward gRPC frames to FFmpeg as soon as its input is ready, with bounded backpressure and larger receive windows. Remove local RGB888 frame-write pacing and retry polling.
+Forward gRPC frames to FFmpeg as soon as its input is ready.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -119,7 +119,7 @@ serve-emu --running-avds
 | `--encoder` | `software` | Host H.264 encoder for gRPC streaming: `software` uses libx264; `hardware` requires VideoToolbox, NVENC, or VAAPI. No software fallback |
 | `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
-| `--max-fps` | `60` | Cap source frame rate |
+| `--max-fps` | `60` | Frame-rate target for capture and encoding; RGB888 forwards received frames whenever ffmpeg is ready without a local FPS cap |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
 | `--max-size` | `1280` | Downscale the longest edge to N pixels; `0` keeps native size. The default balances detail and throughput, especially for the host-side software encoder used by `grpc-screenshot` |
 | `--key-frame-interval` | `10` | Ask the encoder for regular keyframes; `0` disables this codec option. Late joiners get keyframes on demand, so a long interval avoids periodic keyframe bursts |
@@ -660,13 +660,18 @@ rotation or display resizing.
 
 This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
 texture sharing, zero-copy, or hardware encoding; speed depends on the workload
-and must be measured. RGB888 drains incoming gRPC responses continuously and
-retains only the latest image for the encoder. `--max-fps` limits fresh encoder
-submissions independently of incoming frame rate: excess images are replaced,
-so lowering encoded FPS does not queue old source frames for delayed playback.
-Encoder backpressure also retries the latest image. PNG retains its predecode
-message pacer; MMAP selects notifications before reading shared memory. None of
-these local limits impose a server-side screenshot FPS limit. Health
+and must be measured. All gRPC image modes submit usable images as soon as
+ffmpeg can accept them. Backpressure waits for ffmpeg's `drain` event, retaining
+only the newest pending image; there is no encoder write pacer or retry polling.
+RGB888 pauses screenshot reads while ffmpeg is blocked and resumes on drain.
+The gRPC connection and stream receive windows are 8 MiB so large RGB frames do
+not cycle through the default 64 KiB window. No experimental flags are needed.
+
+For RGB888, `--max-fps` configures ffmpeg's nominal input rate and the idle
+boundary cadence; it does not cap fresh frame submissions. PNG retains its
+predecode message pacer; MMAP selects notifications before reading shared
+memory so metadata remains paired with current pixels. Neither sets a
+server-side screenshot FPS limit. Health
 reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.

--- a/packages/serve-emu/README.md
+++ b/packages/serve-emu/README.md
@@ -663,9 +663,14 @@ texture sharing, zero-copy, or hardware encoding; speed depends on the workload
 and must be measured. All gRPC image modes submit usable images as soon as
 ffmpeg can accept them. Backpressure waits for ffmpeg's `drain` event, retaining
 only the newest pending image; there is no encoder write pacer or retry polling.
-RGB888 pauses screenshot reads while ffmpeg is blocked and resumes on drain.
+RGB888 keeps consuming screenshots while ffmpeg is blocked, replacing the
+pending image so a slow encoder does not create a FIFO of stale frames. Receive
+work yields after each 64 KiB batch to let encoder callbacks and other I/O run.
 The gRPC connection and stream receive windows are 8 MiB so large RGB frames do
 not cycle through the default 64 KiB window. No experimental flags are needed.
+A one-shot five-second stall watchdog rechecks encoder readiness after a missed
+`drain`; it resumes only if writable, otherwise reports an `encoder-exit` error.
+Screenshot inactivity probes remain active while ffmpeg is backpressured.
 
 For RGB888, `--max-fps` configures ffmpeg's nominal input rate and the idle
 boundary cadence; it does not cap fresh frame submissions. PNG retains its

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -121,7 +121,7 @@ serve-emu --running-avds
 | `--encoder` | `software` | Host H.264 encoder for gRPC streaming: `software` uses libx264; `hardware` requires VideoToolbox, NVENC, or VAAPI. No software fallback |
 | `--grpc-image-mode` | `png` | gRPC screenshot image delivery: compressed in-band `png`, raw pixels through shared-memory `mmap`, or raw pixels in each gRPC message with `rgb888`. The selected mode is strict; capture errors do not fall back to another mode |
 | `--input-source` | `scrcpy` | Input transport for gRPC streaming: a control-only `scrcpy` server, or the emulator's `grpc` endpoint |
-| `--max-fps` | `60` | Cap source frame rate |
+| `--max-fps` | `60` | Frame-rate target for capture and encoding; RGB888 forwards received frames whenever ffmpeg is ready without a local FPS cap |
 | `--bit-rate` | `8000000` | H.264 bit rate in bps |
 | `--max-size` | `1280` | Downscale the longest edge to N pixels; `0` keeps native size. The default balances detail and throughput, especially for the host-side software encoder used by `grpc-screenshot` |
 | `--key-frame-interval` | `10` | Ask the encoder for regular keyframes; `0` disables this codec option. Late joiners get keyframes on demand, so a long interval avoids periodic keyframe bursts |
@@ -662,13 +662,18 @@ rotation or display resizing.
 
 This path still requires GPU-to-CPU readback inside the emulator. It is not GPU
 texture sharing, zero-copy, or hardware encoding; speed depends on the workload
-and must be measured. RGB888 drains incoming gRPC responses continuously and
-retains only the latest image for the encoder. `--max-fps` limits fresh encoder
-submissions independently of incoming frame rate: excess images are replaced,
-so lowering encoded FPS does not queue old source frames for delayed playback.
-Encoder backpressure also retries the latest image. PNG retains its predecode
-message pacer; MMAP selects notifications before reading shared memory. None of
-these local limits impose a server-side screenshot FPS limit. Health
+and must be measured. All gRPC image modes submit usable images as soon as
+ffmpeg can accept them. Backpressure waits for ffmpeg's `drain` event, retaining
+only the newest pending image; there is no encoder write pacer or retry polling.
+RGB888 pauses screenshot reads while ffmpeg is blocked and resumes on drain.
+The gRPC connection and stream receive windows are 8 MiB so large RGB frames do
+not cycle through the default 64 KiB window. No experimental flags are needed.
+
+For RGB888, `--max-fps` configures ffmpeg's nominal input rate and the idle
+boundary cadence; it does not cap fresh frame submissions. PNG retains its
+predecode message pacer; MMAP selects notifications before reading shared
+memory so metadata remains paired with current pixels. Neither sets a
+server-side screenshot FPS limit. Health
 reports `grpcCapture.imageMode`, actual received `grpcMessageBytesReceived`,
 protobuf decode timing, and separate received/source/encoder frame rates.
 MMAP counters remain zero and shared-memory timing remains null for RGB888.

--- a/packages/serve-emu/packages/serve-emu/README.md
+++ b/packages/serve-emu/packages/serve-emu/README.md
@@ -665,9 +665,14 @@ texture sharing, zero-copy, or hardware encoding; speed depends on the workload
 and must be measured. All gRPC image modes submit usable images as soon as
 ffmpeg can accept them. Backpressure waits for ffmpeg's `drain` event, retaining
 only the newest pending image; there is no encoder write pacer or retry polling.
-RGB888 pauses screenshot reads while ffmpeg is blocked and resumes on drain.
+RGB888 keeps consuming screenshots while ffmpeg is blocked, replacing the
+pending image so a slow encoder does not create a FIFO of stale frames. Receive
+work yields after each 64 KiB batch to let encoder callbacks and other I/O run.
 The gRPC connection and stream receive windows are 8 MiB so large RGB frames do
 not cycle through the default 64 KiB window. No experimental flags are needed.
+A one-shot five-second stall watchdog rechecks encoder readiness after a missed
+`drain`; it resumes only if writable, otherwise reports an `encoder-exit` error.
+Screenshot inactivity probes remain active while ffmpeg is backpressured.
 
 For RGB888, `--max-fps` configures ffmpeg's nominal input rate and the idle
 boundary cadence; it does not cap fresh frame submissions. PNG retains its

--- a/packages/serve-emu/packages/serve-emu/src/cli.ts
+++ b/packages/serve-emu/packages/serve-emu/src/cli.ts
@@ -216,7 +216,7 @@ Options:
       --unsafe-no-auth   Allow a non-loopback bind with NO authentication.
                          Anyone who can reach the port can control the device.
   -s, --serial <serial>  adb device serial (defaults to the only booted device)
-      --max-fps <n>      Cap source frame rate (default: ${SCRCPY_DEFAULTS.maxFps})
+      --max-fps <n>      Frame-rate target; RGB888 handoff is uncapped (default: ${SCRCPY_DEFAULTS.maxFps})
       --bit-rate <bps>   H.264 bit rate (default: ${SCRCPY_DEFAULTS.bitRate})
       --max-size <px>    Cap longest screen edge in pixels; 0 = native. The
                          gRPC screenshot source uses host-side software H.264

--- a/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
+++ b/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
@@ -20,7 +20,7 @@ export type GrpcEndpoint = {
 
 const MAX_GRPC_MESSAGE_BYTES = 64 * 1024 * 1024;
 // Allow several full RGB frames in flight without a 64 KiB flow-control cycle
-// for each chunk. Consumer pause/resume still bounds downstream buffering.
+// for each chunk. Cooperative reads yield after a bounded amount of work.
 const GRPC_RECEIVE_WINDOW_BYTES = 8 * 1024 * 1024;
 const MAX_PROTO_VARINT_BYTES = 10;
 const CONTROLLER_PREFIX = "/android.emulation.control.EmulatorController/";
@@ -664,6 +664,93 @@ type PausableGrpcStream = {
   resume(): void;
 };
 
+/** Yield receive work between bounded batches, independently of FFmpeg. */
+export class GrpcReadScheduler {
+  readonly #stream: PausableGrpcStream;
+  readonly #consume: (chunk: Buffer) => void;
+  readonly #onError: (error: unknown) => void;
+  readonly #batchBytes: number;
+  #remainingBytes: number;
+  #pending: Buffer | null = null;
+  #immediate: ReturnType<typeof setImmediate> | null = null;
+  #paused = false;
+  #closed = false;
+  #onFinish: (() => void) | null = null;
+
+  constructor(options: {
+    stream: PausableGrpcStream;
+    consume(chunk: Buffer): void;
+    onError(error: unknown): void;
+    batchBytes?: number;
+  }) {
+    // Match an I/O-sized quantum: a full RGB frame per turn can still starve
+    // pipe progress when an unrestricted source stays continuously readable.
+    this.#batchBytes = options.batchBytes ?? 64 * 1024;
+    if (!Number.isSafeInteger(this.#batchBytes) || this.#batchBytes <= 0) {
+      throw new RangeError("batchBytes must be a positive safe integer");
+    }
+    this.#remainingBytes = this.#batchBytes;
+    this.#stream = options.stream;
+    this.#consume = options.consume;
+    this.#onError = options.onError;
+  }
+
+  push(chunk: Buffer): void {
+    if (this.#closed || chunk.length === 0) return;
+    try {
+      // pause() prevents another data event until the retained suffix is read.
+      if (this.#pending) throw new Error("gRPC source emitted data while paused");
+      const bytes = Math.min(chunk.length, this.#remainingBytes);
+      this.#remainingBytes -= bytes;
+      this.#consume(chunk.subarray(0, bytes));
+      if (this.#closed) return;
+      if (bytes < chunk.length) this.#pending = chunk.subarray(bytes);
+      if (this.#remainingBytes === 0) {
+        this.#paused = true;
+        this.#stream.pause();
+      }
+      if (!this.#immediate) {
+        this.#immediate = setImmediate(() => this.#continue());
+      }
+    } catch (error) {
+      this.close();
+      this.#onError(error);
+    }
+  }
+
+  finish(callback: () => void): void {
+    if (this.#closed) return;
+    if (this.#pending) this.#onFinish = callback;
+    else callback();
+  }
+
+  close(): void {
+    this.#closed = true;
+    if (this.#immediate) clearImmediate(this.#immediate);
+    this.#immediate = null;
+    this.#pending = null;
+    this.#onFinish = null;
+  }
+
+  #continue(): void {
+    this.#immediate = null;
+    if (this.#closed) return;
+    this.#remainingBytes = this.#batchBytes;
+    const pending = this.#pending;
+    this.#pending = null;
+    if (pending) this.push(pending);
+    if (this.#closed) return;
+    if (this.#onFinish && !this.#pending) {
+      const finish = this.#onFinish;
+      this.#onFinish = null;
+      finish();
+    } else if (this.#paused && this.#remainingBytes > 0) {
+      this.#paused = false;
+      this.#stream.resume();
+    }
+  }
+}
+
 export type GrpcMessagePacingEvent = "received" | "emitted" | "coalesced";
 
 export type GrpcMessagePacingDetail = {
@@ -854,13 +941,7 @@ export class GrpcMessagePacer {
   }
 }
 
-export type GrpcScreenshotReadControl = {
-  pause(): void;
-  resume(): void;
-};
-
 type RequestOptions = {
-  onReadControl?: (control: GrpcScreenshotReadControl) => void;
   onMessage?: (message: Buffer, receivedAtMs: number) => void;
   onPacingEvent?: (
     event: GrpcMessagePacingEvent,
@@ -961,8 +1042,8 @@ export class EmulatorGrpcClient {
       let timer: ReturnType<typeof setTimeout> | null = null;
       let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
       let activityGeneration = 0;
-      let consumerPaused = false;
       let pacer: GrpcMessagePacer | null = null;
+      let readScheduler: GrpcReadScheduler | null = null;
 
       const settle = (error?: Error) => {
         if (settled) return;
@@ -970,12 +1051,13 @@ export class EmulatorGrpcClient {
         if (timer) clearTimeout(timer);
         if (inactivityTimer) clearTimeout(inactivityTimer);
         pacer?.close();
+        readScheduler?.close();
         options.signal?.removeEventListener("abort", onAbort);
         if (error) reject(error);
         else resolve(messages);
       };
       const resetInactivityTimer = () => {
-        if (!options.inactivityTimeoutMs || settled || consumerPaused) return;
+        if (!options.inactivityTimeoutMs || settled) return;
         if (inactivityTimer) clearTimeout(inactivityTimer);
         const generation = ++activityGeneration;
         inactivityTimer = setTimeout(() => {
@@ -1005,6 +1087,7 @@ export class EmulatorGrpcClient {
         inactivityTimer.unref?.();
       };
       const onMessage = (body: Buffer, receivedAtMs = Date.now()) => {
+        if (settled) return;
         if (options.onMessage) options.onMessage(body, receivedAtMs);
         else messages.push(body);
         resetInactivityTimer();
@@ -1054,6 +1137,12 @@ export class EmulatorGrpcClient {
           onError: cancelForFrameError,
           signal: options.signal,
         });
+      } else if (options.onMessage) {
+        readScheduler = new GrpcReadScheduler({
+          stream,
+          consume: (chunk) => parser!.push(chunk),
+          onError: cancelForFrameError,
+        });
       }
 
       stream.on("response", (values) =>
@@ -1066,6 +1155,7 @@ export class EmulatorGrpcClient {
         if (settled) return;
         try {
           if (pacer) pacer.push(chunk);
+          else if (readScheduler) readScheduler.push(chunk);
           else parser!.push(chunk);
         } catch (error) {
           cancelForFrameError(error);
@@ -1076,8 +1166,10 @@ export class EmulatorGrpcClient {
       });
       stream.on("close", () => {
         if (settled) return;
-        if (grpcStatus === "0") settle();
-        else if (grpcStatus !== null) {
+        if (grpcStatus === "0") {
+          if (readScheduler) readScheduler.finish(() => settle());
+          else settle();
+        } else if (grpcStatus !== null) {
           settle(
             new Error(
               `${method}: grpc-status ${grpcStatus}${grpcMessage ? ` (${grpcMessage})` : ""}`,
@@ -1096,23 +1188,6 @@ export class EmulatorGrpcClient {
         }, options.timeoutMs);
       }
       options.signal?.addEventListener("abort", onAbort, { once: true });
-      options.onReadControl?.({
-        pause() {
-          if (settled) return;
-          consumerPaused = true;
-          // An intentional consumer stall is not a failed screenshot source.
-          activityGeneration++;
-          if (inactivityTimer) clearTimeout(inactivityTimer);
-          inactivityTimer = null;
-          stream.pause();
-        },
-        resume() {
-          if (settled || !consumerPaused) return;
-          consumerPaused = false;
-          stream.resume();
-          resetInactivityTimer();
-        },
-      });
       stream.end(grpcFrame(message));
     });
   }
@@ -1140,7 +1215,6 @@ export class EmulatorGrpcClient {
     signal: AbortSignal,
     options: {
       maxFps?: number;
-      onReadControl?: (control: GrpcScreenshotReadControl) => void;
       onPacingEvent?: (
         event: GrpcMessagePacingEvent,
         detail: GrpcMessagePacingDetail,
@@ -1161,7 +1235,6 @@ export class EmulatorGrpcClient {
       await this.#request("streamScreenshot", encodeImageFormat(format), {
         signal,
         messageIntervalMs,
-        onReadControl: options.onReadControl,
         inactivityTimeoutMs: this.#streamInactivityTimeoutMs,
         onInactivity: async () => {
           // Static emulator displays may legitimately stop producing stream

--- a/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
+++ b/packages/serve-emu/packages/serve-emu/src/emulator-grpc.ts
@@ -19,6 +19,9 @@ export type GrpcEndpoint = {
 };
 
 const MAX_GRPC_MESSAGE_BYTES = 64 * 1024 * 1024;
+// Allow several full RGB frames in flight without a 64 KiB flow-control cycle
+// for each chunk. Consumer pause/resume still bounds downstream buffering.
+const GRPC_RECEIVE_WINDOW_BYTES = 8 * 1024 * 1024;
 const MAX_PROTO_VARINT_BYTES = 10;
 const CONTROLLER_PREFIX = "/android.emulation.control.EmulatorController/";
 const UNARY_TIMEOUT_MS = 5_000;
@@ -851,7 +854,13 @@ export class GrpcMessagePacer {
   }
 }
 
+export type GrpcScreenshotReadControl = {
+  pause(): void;
+  resume(): void;
+};
+
 type RequestOptions = {
+  onReadControl?: (control: GrpcScreenshotReadControl) => void;
   onMessage?: (message: Buffer, receivedAtMs: number) => void;
   onPacingEvent?: (
     event: GrpcMessagePacingEvent,
@@ -897,7 +906,14 @@ export class EmulatorGrpcClient {
       options.streamInactivityTimeoutMs ?? STREAM_INACTIVITY_TIMEOUT_MS,
       "streamInactivityTimeoutMs",
     );
-    this.#session = http2.connect(`http://127.0.0.1:${endpoint.port}`);
+    this.#session = http2.connect(`http://127.0.0.1:${endpoint.port}`, {
+      settings: { initialWindowSize: GRPC_RECEIVE_WINDOW_BYTES },
+    });
+    this.#session.once("connect", () => {
+      if (!this.#closed) {
+        this.#session.setLocalWindowSize(GRPC_RECEIVE_WINDOW_BYTES);
+      }
+    });
     this.#session.on("error", (error: Error) => {
       if (!this.#closed) {
         for (const listener of this.#errorListeners) listener(error);
@@ -945,6 +961,7 @@ export class EmulatorGrpcClient {
       let timer: ReturnType<typeof setTimeout> | null = null;
       let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
       let activityGeneration = 0;
+      let consumerPaused = false;
       let pacer: GrpcMessagePacer | null = null;
 
       const settle = (error?: Error) => {
@@ -958,7 +975,7 @@ export class EmulatorGrpcClient {
         else resolve(messages);
       };
       const resetInactivityTimer = () => {
-        if (!options.inactivityTimeoutMs || settled) return;
+        if (!options.inactivityTimeoutMs || settled || consumerPaused) return;
         if (inactivityTimer) clearTimeout(inactivityTimer);
         const generation = ++activityGeneration;
         inactivityTimer = setTimeout(() => {
@@ -1079,6 +1096,23 @@ export class EmulatorGrpcClient {
         }, options.timeoutMs);
       }
       options.signal?.addEventListener("abort", onAbort, { once: true });
+      options.onReadControl?.({
+        pause() {
+          if (settled) return;
+          consumerPaused = true;
+          // An intentional consumer stall is not a failed screenshot source.
+          activityGeneration++;
+          if (inactivityTimer) clearTimeout(inactivityTimer);
+          inactivityTimer = null;
+          stream.pause();
+        },
+        resume() {
+          if (settled || !consumerPaused) return;
+          consumerPaused = false;
+          stream.resume();
+          resetInactivityTimer();
+        },
+      });
       stream.end(grpcFrame(message));
     });
   }
@@ -1106,6 +1140,7 @@ export class EmulatorGrpcClient {
     signal: AbortSignal,
     options: {
       maxFps?: number;
+      onReadControl?: (control: GrpcScreenshotReadControl) => void;
       onPacingEvent?: (
         event: GrpcMessagePacingEvent,
         detail: GrpcMessagePacingDetail,
@@ -1126,6 +1161,7 @@ export class EmulatorGrpcClient {
       await this.#request("streamScreenshot", encodeImageFormat(format), {
         signal,
         messageIntervalMs,
+        onReadControl: options.onReadControl,
         inactivityTimeoutMs: this.#streamInactivityTimeoutMs,
         onInactivity: async () => {
           // Static emulator displays may legitimately stop producing stream

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -17,6 +17,7 @@ import {
   type GrpcMessagePacingEvent,
   type GrpcMessagePacingDetail,
   type GrpcScreenshotImageSource,
+  type GrpcScreenshotReadControl,
   type ImageFormatRequest,
   type KeyboardEventRequest,
   type TouchPoint,
@@ -78,7 +79,6 @@ const ACCESS_UNIT_CADENCE_WINDOW = 8;
 const ACCESS_UNIT_CADENCE_OUTLIER_FLOOR_MS = 250;
 const ACCESS_UNIT_CADENCE_OUTLIER_MULTIPLIER = 4;
 const ACCESS_UNIT_SLOW_CADENCE_SIMILARITY = 1.5;
-const ENCODER_WRITE_RETRY_DELAY_MS = 8;
 const DEFAULT_IDLE_REPEAT_MS = 500;
 const FIRST_FRAME_TIMEOUT_MS = 10_000;
 const MAX_QUEUED_PACKET_BYTES = 64 * 1024 * 1024;
@@ -706,10 +706,8 @@ export function grpcImageModeBehavior(
   }
   return {
     encoderInputFormat: "rgb24",
-    // Drain raw RGB responses independently of encoder FPS. Pausing HTTP/2
-    // queues old pixels upstream; onImage keeps only the newest frame and the
-    // encoder write pacer decides when to submit it. MMAP also drains metadata
-    // immediately, then selects which notifications trigger memory reads.
+    // In-band RGB uses encoder readiness for flow control. MMAP drains
+    // metadata immediately, then selects notifications for memory reads.
     predecodeMaxFps: undefined,
     needsEncoderFollowUp: (repeat) => !repeat,
   };
@@ -1010,34 +1008,6 @@ export function resolveGrpcDisplayGeometry(options: {
       };
     },
   };
-}
-
-export class GrpcFrameWritePacer {
-  readonly #frameIntervalMs: number;
-  #nextFreshWriteAt = 0;
-
-  constructor(frameIntervalMs: number) {
-    if (!Number.isFinite(frameIntervalMs) || frameIntervalMs <= 0) {
-      throw new RangeError("frameIntervalMs must be a positive number");
-    }
-    this.#frameIntervalMs = frameIntervalMs;
-  }
-
-  reset(now: number): void {
-    this.#nextFreshWriteAt = now;
-  }
-
-  recordWrite(now: number, repeat: boolean, accepted = true): void {
-    if (repeat || !accepted) return;
-    this.#nextFreshWriteAt = Math.max(
-      this.#nextFreshWriteAt + this.#frameIntervalMs,
-      now + this.#frameIntervalMs,
-    );
-  }
-
-  waitMs(now: number): number {
-    return Math.max(0, this.#nextFreshWriteAt - now);
-  }
 }
 
 export class GrpcAccessUnitBoundaryCadence {
@@ -1357,6 +1327,7 @@ export type GrpcSessionClient = {
     signal: AbortSignal,
     options?: {
       maxFps?: number;
+      onReadControl?: (control: GrpcScreenshotReadControl) => void;
       onPacingEvent?: (
         event: GrpcMessagePacingEvent,
         detail: GrpcMessagePacingDetail,
@@ -1371,6 +1342,7 @@ export type GrpcSessionClient = {
 };
 
 export type GrpcSessionEncoder = {
+  readonly writable: boolean;
   readonly width: number;
   readonly height: number;
   readonly quarterTurn: QuarterTurn;
@@ -1739,7 +1711,6 @@ export async function startGrpcSession(
       ? configuredRepeatFrameMs
       : DEFAULT_IDLE_REPEAT_MS;
   const frameIntervalMs = 1_000 / maxFps;
-  const frameWritePacer = new GrpcFrameWritePacer(frameIntervalMs);
   const accessUnitBoundaryCadence = new GrpcAccessUnitBoundaryCadence(
     frameIntervalMs,
   );
@@ -1785,8 +1756,11 @@ export async function startGrpcSession(
   let encoderHasOutput = false;
   let captureTransport: GrpcImageCaptureTransport | null = null;
   let latest: EmuImage | null = null;
+  let lastSubmittedImage: EmuImage | null = null;
+  let waitingForEncoder = false;
+  let pendingRepeat = false;
+  let screenshotReadControl: GrpcScreenshotReadControl | null = null;
   let lastWriteAt = 0;
-  let writeTimer: ReturnType<typeof setTimeout> | null = null;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   let idleTimer: ReturnType<typeof setInterval> | null = null;
   let displaySizePollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1837,10 +1811,8 @@ export async function startGrpcSession(
     return new Promise((resolve) => waiters.push(resolve));
   };
 
-  const clearWriteTimers = () => {
-    if (writeTimer) clearTimeout(writeTimer);
+  const clearBoundaryTimer = () => {
     if (flushTimer) clearTimeout(flushTimer);
-    writeTimer = null;
     flushTimer = null;
   };
   const nowUs = () => BigInt(Math.round(performance.now() * 1_000));
@@ -1856,9 +1828,18 @@ export async function startGrpcSession(
     ) {
       return;
     }
+    if (waitingForEncoder) {
+      if (repeat) pendingRepeat = true;
+      return;
+    }
+    if (!repeat && latest === lastSubmittedImage) return;
     const now = performance.now();
     const accepted = encoder.write(latest.image, nowUs());
-    frameWritePacer.recordWrite(now, repeat, accepted);
+    waitingForEncoder = !accepted || !encoder.writable;
+    pendingRepeat = !accepted && repeat;
+    if (accepted) lastSubmittedImage = latest;
+    if (waitingForEncoder) screenshotReadControl?.pause();
+    else screenshotReadControl?.resume();
     captureDiagnostics.recordEncoderWrite(
       repeat,
       accepted,
@@ -1866,56 +1847,17 @@ export async function startGrpcSession(
       now,
     );
     if (accepted) lastWriteAt = Date.now();
-    const needsFollowUp = captureTransport.needsEncoderFollowUp(
-      repeat,
-      encoderHasOutput,
-    );
-    if (repeat) {
-      if (flushTimer) clearTimeout(flushTimer);
-      flushTimer = null;
-      if (!accepted || needsFollowUp) {
-        flushTimer = setTimeout(
-          () => {
-            flushTimer = null;
-            writeFrame(true);
-          },
-          accepted
-            ? accessUnitBoundaryCadence.boundaryDelayMs()
-            : Math.min(ENCODER_WRITE_RETRY_DELAY_MS, frameIntervalMs),
-        );
-        flushTimer.unref?.();
-      }
-      return;
-    }
-    if (accepted && needsFollowUp) {
-      if (flushTimer) clearTimeout(flushTimer);
+    // No timer or extra buffering while ffmpeg is blocked. Its drain event
+    // resumes the newest pending image; incoming images can still replace it.
+    if (!accepted) return;
+    clearBoundaryTimer();
+    if (captureTransport.needsEncoderFollowUp(repeat, encoderHasOutput)) {
       flushTimer = setTimeout(() => {
         flushTimer = null;
         writeFrame(true);
       }, accessUnitBoundaryCadence.boundaryDelayMs());
       flushTimer.unref?.();
-    } else if (needsFollowUp && !writeTimer) {
-      writeTimer = setTimeout(
-        () => {
-          writeTimer = null;
-          scheduleWrite();
-        },
-        Math.min(ENCODER_WRITE_RETRY_DELAY_MS, frameIntervalMs),
-      );
-      writeTimer.unref?.();
     }
-  };
-  const scheduleWrite = () => {
-    if (writeTimer || closed || !encoderLifecycle?.current || !latest) return;
-    const waitMs = frameWritePacer.waitMs(performance.now());
-    if (waitMs <= 0) {
-      writeFrame(false);
-      return;
-    }
-    writeTimer = setTimeout(() => {
-      writeTimer = null;
-      writeFrame(false);
-    }, waitMs);
   };
   const currentGeometry = (image = latest) => {
     if (!image) return null;
@@ -1937,7 +1879,9 @@ export async function startGrpcSession(
       emitFatal({ message: "emulator returned an image too small to encode" });
       return null;
     }
-    frameWritePacer.reset(performance.now());
+    waitingForEncoder = false;
+    pendingRepeat = false;
+    lastSubmittedImage = null;
     encoderHasOutput = false;
     if (sessionMeta) {
       sessionMeta.width = size.width;
@@ -1964,6 +1908,31 @@ export async function startGrpcSession(
         }
         emitFatal({ message, code: "encoder-exit" });
       },
+      onWritable: () => {
+        if (
+          stopping || closed || lifetime.signal.aborted || fatalFailure ||
+          encoderLifecycle?.current !== managed
+        ) return;
+        waitingForEncoder = false;
+        const repeat = latest === lastSubmittedImage;
+        if (!repeat) {
+          pendingRepeat = false;
+          writeFrame(false);
+        } else {
+          screenshotReadControl?.resume();
+          if (pendingRepeat) {
+            pendingRepeat = false;
+            // Let already-buffered source data arrive before deciding the
+            // source is idle and submitting a duplicate boundary frame.
+            if (flushTimer) clearTimeout(flushTimer);
+            flushTimer = setTimeout(() => {
+              flushTimer = null;
+              writeFrame(true);
+            }, accessUnitBoundaryCadence.boundaryDelayMs());
+            flushTimer.unref?.();
+          }
+        }
+      },
     });
     if (restart.announceSize) {
       pushPacket({
@@ -1973,7 +1942,8 @@ export async function startGrpcSession(
         clientResized: false,
       });
     }
-    return {
+    const managed: GrpcSessionEncoder = {
+      get writable() { return next.writable; },
       width: next.width,
       height: next.height,
       quarterTurn: next.quarterTurn,
@@ -1984,13 +1954,14 @@ export async function startGrpcSession(
         return next.close();
       },
     };
+    return managed;
   });
   const restartEncoder = (
     announceSize: boolean,
     clearPending: boolean,
   ): Promise<void> => {
     if (closed || lifetime.signal.aborted || !latest) return Promise.resolve();
-    clearWriteTimers();
+    clearBoundaryTimer();
     return encoderLifecycle!
       .restart({ announceSize, clearPending })
       .then((started) => {
@@ -2077,7 +2048,7 @@ export async function startGrpcSession(
       );
       return;
     }
-    scheduleWrite();
+    writeFrame(false);
   };
 
   const inputState = new GrpcInputState(client);
@@ -2269,7 +2240,7 @@ export async function startGrpcSession(
     transportToClose?.stop();
     options.signal?.removeEventListener("abort", abortFromParent);
     lifetime.abort(new Error("gRPC screenshot session closed"));
-    clearWriteTimers();
+    clearBoundaryTimer();
     if (idleTimer) clearInterval(idleTimer);
     idleTimer = null;
     if (displaySizePollTimer) clearTimeout(displaySizePollTimer);
@@ -2470,6 +2441,12 @@ export async function startGrpcSession(
         lifetime.signal,
         {
           maxFps: transport.predecodeMaxFps,
+          // PNG owns predecode pacing; MMAP must consume metadata promptly
+          // before its shared pixels are reused. Only in-band RGB applies
+          // FFmpeg backpressure directly to the HTTP/2 source.
+          onReadControl: imageMode === "rgb888" ? (control) => {
+            screenshotReadControl = control;
+          } : undefined,
           onPacingEvent: (event, detail) =>
             transport.recordRawPacingEvent(event, detail),
           onDecode: (event) => captureDiagnostics.recordImageDecode(event),

--- a/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
+++ b/packages/serve-emu/packages/serve-emu/src/grpc-session.ts
@@ -17,7 +17,6 @@ import {
   type GrpcMessagePacingEvent,
   type GrpcMessagePacingDetail,
   type GrpcScreenshotImageSource,
-  type GrpcScreenshotReadControl,
   type ImageFormatRequest,
   type KeyboardEventRequest,
   type TouchPoint,
@@ -80,6 +79,7 @@ const ACCESS_UNIT_CADENCE_OUTLIER_FLOOR_MS = 250;
 const ACCESS_UNIT_CADENCE_OUTLIER_MULTIPLIER = 4;
 const ACCESS_UNIT_SLOW_CADENCE_SIMILARITY = 1.5;
 const DEFAULT_IDLE_REPEAT_MS = 500;
+const ENCODER_DRAIN_TIMEOUT_MS = 5_000;
 const FIRST_FRAME_TIMEOUT_MS = 10_000;
 const MAX_QUEUED_PACKET_BYTES = 64 * 1024 * 1024;
 const DISPLAY_SIZE_POLL_MS = 2_000;
@@ -706,10 +706,13 @@ export function grpcImageModeBehavior(
   }
   return {
     encoderInputFormat: "rgb24",
-    // In-band RGB uses encoder readiness for flow control. MMAP drains
-    // metadata immediately, then selects notifications for memory reads.
+    // Keep receiving RGB independently of encoder readiness so the latest
+    // image stays fresh. MMAP selects metadata before shared-memory reads.
     predecodeMaxFps: undefined,
-    needsEncoderFollowUp: (repeat) => !repeat,
+    // A static source may send only one image. Keep warming the encoder until
+    // it emits output; the regular idle timer starts after that startup gate.
+    needsEncoderFollowUp: (repeat, encoderHasOutput) =>
+      !repeat || !encoderHasOutput,
   };
 }
 
@@ -1304,6 +1307,8 @@ export class GrpcNativeTouchGeometryMonitor {
 }
 
 export type GrpcSessionDependencies = {
+  /** Override the stall deadline for deterministic runtime tests. */
+  encoderDrainTimeoutMs?: number;
   readDisplaySizeSignal?: (
     serial: string,
     signal: AbortSignal,
@@ -1327,7 +1332,6 @@ export type GrpcSessionClient = {
     signal: AbortSignal,
     options?: {
       maxFps?: number;
-      onReadControl?: (control: GrpcScreenshotReadControl) => void;
       onPacingEvent?: (
         event: GrpcMessagePacingEvent,
         detail: GrpcMessagePacingDetail,
@@ -1710,6 +1714,11 @@ export async function startGrpcSession(
     configuredRepeatFrameMs > 0
       ? configuredRepeatFrameMs
       : DEFAULT_IDLE_REPEAT_MS;
+  const encoderDrainTimeoutMs = positiveNumber(
+    dependencies.encoderDrainTimeoutMs ?? ENCODER_DRAIN_TIMEOUT_MS,
+    "encoderDrainTimeoutMs",
+    60_000,
+  );
   const frameIntervalMs = 1_000 / maxFps;
   const accessUnitBoundaryCadence = new GrpcAccessUnitBoundaryCadence(
     frameIntervalMs,
@@ -1759,7 +1768,7 @@ export async function startGrpcSession(
   let lastSubmittedImage: EmuImage | null = null;
   let waitingForEncoder = false;
   let pendingRepeat = false;
-  let screenshotReadControl: GrpcScreenshotReadControl | null = null;
+  let encoderDrainTimer: ReturnType<typeof setTimeout> | null = null;
   let lastWriteAt = 0;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   let idleTimer: ReturnType<typeof setInterval> | null = null;
@@ -1815,6 +1824,46 @@ export async function startGrpcSession(
     if (flushTimer) clearTimeout(flushTimer);
     flushTimer = null;
   };
+  const clearEncoderDrainTimer = () => {
+    if (encoderDrainTimer) clearTimeout(encoderDrainTimer);
+    encoderDrainTimer = null;
+  };
+  const encoderWritable = (encoder: GrpcSessionEncoder) => {
+    if (
+      closed || lifetime.signal.aborted || fatalFailure ||
+      encoderLifecycle?.current !== encoder
+    ) return;
+    clearEncoderDrainTimer();
+    waitingForEncoder = false;
+    if (latest !== lastSubmittedImage) {
+      pendingRepeat = false;
+      writeFrame(false);
+    } else if (pendingRepeat) {
+      pendingRepeat = false;
+      writeFrame(true);
+    }
+  };
+  const watchEncoderDrain = (encoder: GrpcSessionEncoder) => {
+    if (encoderDrainTimer || closed || lifetime.signal.aborted || fatalFailure) return;
+    encoderDrainTimer = setTimeout(() => {
+      encoderDrainTimer = null;
+      if (
+        closed || lifetime.signal.aborted || fatalFailure ||
+        encoderLifecycle?.current !== encoder || !waitingForEncoder
+      ) return;
+      if (encoder.writable) {
+        // Recover a missed notification only when the encoder confirms it can
+        // accept input. A timer must never force more bytes into a blocked pipe.
+        encoderWritable(encoder);
+      } else {
+        emitFatal({
+          message: `ffmpeg input remained backpressured for ${encoderDrainTimeoutMs}ms`,
+          code: "encoder-exit",
+        });
+      }
+    }, encoderDrainTimeoutMs);
+    encoderDrainTimer.unref?.();
+  };
   const nowUs = () => BigInt(Math.round(performance.now() * 1_000));
   const writeFrame = (repeat: boolean) => {
     const encoder = encoderLifecycle?.current;
@@ -1838,8 +1887,8 @@ export async function startGrpcSession(
     waitingForEncoder = !accepted || !encoder.writable;
     pendingRepeat = !accepted && repeat;
     if (accepted) lastSubmittedImage = latest;
-    if (waitingForEncoder) screenshotReadControl?.pause();
-    else screenshotReadControl?.resume();
+    if (waitingForEncoder) watchEncoderDrain(encoder);
+    else clearEncoderDrainTimer();
     captureDiagnostics.recordEncoderWrite(
       repeat,
       accepted,
@@ -1847,8 +1896,8 @@ export async function startGrpcSession(
       now,
     );
     if (accepted) lastWriteAt = Date.now();
-    // No timer or extra buffering while ffmpeg is blocked. Its drain event
-    // resumes the newest pending image; incoming images can still replace it.
+    // Keep receiving while ffmpeg is blocked so drain submits the newest
+    // complete image, without building a FIFO of stale frames upstream.
     if (!accepted) return;
     clearBoundaryTimer();
     if (captureTransport.needsEncoderFollowUp(repeat, encoderHasOutput)) {
@@ -1888,6 +1937,7 @@ export async function startGrpcSession(
       sessionMeta.height = size.height;
     }
     let stopping = false;
+    let managed: GrpcSessionEncoder | null = null;
     const next = runtime.createEncoder({
       encoderName,
       width: latest.width,
@@ -1909,29 +1959,8 @@ export async function startGrpcSession(
         emitFatal({ message, code: "encoder-exit" });
       },
       onWritable: () => {
-        if (
-          stopping || closed || lifetime.signal.aborted || fatalFailure ||
-          encoderLifecycle?.current !== managed
-        ) return;
-        waitingForEncoder = false;
-        const repeat = latest === lastSubmittedImage;
-        if (!repeat) {
-          pendingRepeat = false;
-          writeFrame(false);
-        } else {
-          screenshotReadControl?.resume();
-          if (pendingRepeat) {
-            pendingRepeat = false;
-            // Let already-buffered source data arrive before deciding the
-            // source is idle and submitting a duplicate boundary frame.
-            if (flushTimer) clearTimeout(flushTimer);
-            flushTimer = setTimeout(() => {
-              flushTimer = null;
-              writeFrame(true);
-            }, accessUnitBoundaryCadence.boundaryDelayMs());
-            flushTimer.unref?.();
-          }
-        }
+        // A runtime adapter may notify synchronously during construction.
+        if (!stopping && managed) encoderWritable(managed);
       },
     });
     if (restart.announceSize) {
@@ -1942,7 +1971,7 @@ export async function startGrpcSession(
         clientResized: false,
       });
     }
-    const managed: GrpcSessionEncoder = {
+    managed = {
       get writable() { return next.writable; },
       width: next.width,
       height: next.height,
@@ -1962,6 +1991,7 @@ export async function startGrpcSession(
   ): Promise<void> => {
     if (closed || lifetime.signal.aborted || !latest) return Promise.resolve();
     clearBoundaryTimer();
+    clearEncoderDrainTimer();
     return encoderLifecycle!
       .restart({ announceSize, clearPending })
       .then((started) => {
@@ -2241,6 +2271,7 @@ export async function startGrpcSession(
     options.signal?.removeEventListener("abort", abortFromParent);
     lifetime.abort(new Error("gRPC screenshot session closed"));
     clearBoundaryTimer();
+    clearEncoderDrainTimer();
     if (idleTimer) clearInterval(idleTimer);
     idleTimer = null;
     if (displaySizePollTimer) clearTimeout(displaySizePollTimer);
@@ -2441,12 +2472,6 @@ export async function startGrpcSession(
         lifetime.signal,
         {
           maxFps: transport.predecodeMaxFps,
-          // PNG owns predecode pacing; MMAP must consume metadata promptly
-          // before its shared pixels are reused. Only in-band RGB applies
-          // FFmpeg backpressure directly to the HTTP/2 source.
-          onReadControl: imageMode === "rgb888" ? (control) => {
-            screenshotReadControl = control;
-          } : undefined,
           onPacingEvent: (event, detail) =>
             transport.recordRawPacingEvent(event, detail),
           onDecode: (event) => captureDiagnostics.recordImageDecode(event),

--- a/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
+++ b/packages/serve-emu/packages/serve-emu/src/h264-encoder.ts
@@ -45,6 +45,8 @@ export type H264EncoderOpts = {
   onFrame: (frame: VideoFrame) => void;
   /** Called once when ffmpeg or its output parser fails unexpectedly. */
   onExit: (reason: string) => void;
+  /** Input backpressure cleared; a previously rejected frame can be retried. */
+  onWritable?: () => void;
 };
 
 export type QuarterTurn = 0 | 1 | 2 | 3;
@@ -810,6 +812,7 @@ export class H264Encoder {
   readonly #stderr = new FfmpegStderrTail();
   #resolveProcessDone!: () => void;
   #closed = false;
+  #waitingForDrain = false;
   #failureReported = false;
   #closeTask: Promise<void> | null = null;
 
@@ -851,6 +854,10 @@ export class H264Encoder {
     this.#proc.stdin.once("error", (error) => {
       this.#reportFailure(`ffmpeg stdin failed: ${error.message}`);
     });
+    this.#proc.stdin.on("drain", () => {
+      this.#waitingForDrain = false;
+      if (!this.#closed) this.#opts.onWritable?.();
+    });
     this.#proc.once("error", (error) => {
       this.#reportFailure(`ffmpeg failed to start: ${error.message}`);
       this.#resolveProcessDone();
@@ -864,6 +871,16 @@ export class H264Encoder {
       }
       this.#resolveProcessDone();
     });
+  }
+
+  /** Whether one more complete source image can be accepted now. */
+  get writable(): boolean {
+    return (
+      !this.#closed &&
+      !this.#waitingForDrain &&
+      this.#proc.stdin.writable &&
+      !this.#proc.stdin.writableNeedDrain
+    );
   }
 
   /** Feed one complete source image; false means backpressure rejected it. */
@@ -894,17 +911,13 @@ export class H264Encoder {
     if (typeof ptsUs !== "bigint" || ptsUs < 0n) {
       throw new RangeError("ptsUs must be a non-negative bigint");
     }
-    if (
-      this.#closed ||
-      !this.#proc.stdin.writable ||
-      this.#proc.stdin.writableNeedDrain
-    ) {
-      return false;
-    }
+    if (!this.writable) return false;
     try {
       // A false return from Writable.write means "accepted, wait for drain",
       // not "rejected", so every successful call receives a PTS entry.
-      this.#proc.stdin.write(image);
+      // Bun's child-process stdin can leave writableNeedDrain false after a
+      // backpressured write, so retain the write result until drain fires.
+      this.#waitingForDrain = !this.#proc.stdin.write(image);
       this.#parser.enqueuePts(ptsUs);
       return true;
     } catch (error) {

--- a/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
@@ -14,6 +14,7 @@ import {
   IMAGE_TRANSPORT_MMAP,
   IMG_FORMAT_RGB888,
   parseEmulatorGrpcPort,
+  type GrpcScreenshotReadControl,
 } from "../src/emulator-grpc.ts";
 import type { ExecResult } from "../src/exec.ts";
 import { encodeEmulatorImage, grpcFrame } from "./fixtures/grpc.ts";
@@ -278,9 +279,11 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
       timestampUs: 1n,
     });
     let authorization: string | undefined;
+    let receiveWindow: number | undefined;
     const server = http2.createServer();
     server.on("stream", (stream: ServerHttp2Stream, headers) => {
       authorization = headers.authorization as string | undefined;
+      receiveWindow = stream.session?.remoteSettings.initialWindowSize;
       stream.respond({
         ":status": 200,
         "content-type": "application/grpc",
@@ -303,6 +306,7 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
     try {
       const image = await client.getScreenshot({ format: 2 });
       expect(authorization).toBe("Bearer discovered-token");
+      expect(receiveWindow).toBe(8 * 1024 * 1024);
       expect(image).toMatchObject({ width: 2, height: 1, format: 2, seq: 1 });
       expect(image.image).toEqual(Buffer.from([1, 2, 3, 4, 5, 6]));
     } finally {
@@ -310,6 +314,80 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
       await new Promise<void>((resolve, reject) =>
         server.close((error) => (error ? reject(error) : resolve())),
       );
+    }
+  });
+
+  test("consumer backpressure pauses delivery and inactivity probes until resumed", async () => {
+    const frame = (seq: number) => grpcFrame(encodeEmulatorImage({
+      format: IMG_FORMAT_RGB888,
+      width: 2,
+      height: 1,
+      image: Buffer.alloc(6, seq),
+      seq,
+    }));
+    let screenshotStream: ServerHttp2Stream | undefined;
+    let probes = 0;
+    const server = http2.createServer();
+    server.on("stream", (stream: ServerHttp2Stream, headers) => {
+      stream.on("error", () => {});
+      stream.resume();
+      const streaming = String(headers[":path"]).endsWith("/streamScreenshot");
+      stream.respond({
+        ":status": 200,
+        "content-type": "application/grpc",
+        ...(streaming ? {} : { "grpc-status": "0" }),
+      });
+      if (streaming) {
+        screenshotStream = stream;
+        stream.write(frame(1));
+      } else {
+        probes++;
+        stream.end(frame(3));
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing test port");
+    const client = new EmulatorGrpcClient(
+      { port: address.port, token: null, avdName: null },
+      { streamInactivityTimeoutMs: 25 },
+    );
+    const controller = new AbortController();
+    let control!: GrpcScreenshotReadControl;
+    let firstImage!: () => void;
+    const first = new Promise<void>((resolve) => { firstImage = resolve; });
+    const images: number[] = [];
+    const streaming = client.streamScreenshot(
+      { format: IMG_FORMAT_RGB888 },
+      (image) => {
+        images.push(image.seq);
+        if (image.seq === 1) {
+          control.pause();
+          firstImage();
+        } else if (image.seq === 3) {
+          controller.abort();
+        }
+      },
+      controller.signal,
+      { onReadControl: (value) => { control = value; } },
+    );
+    try {
+      await first;
+      screenshotStream!.write(frame(2));
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      expect(images).toEqual([1]);
+      expect(probes).toBe(0);
+      control.resume();
+      await streaming;
+      expect(images).toEqual([1, 2, 3]);
+      expect(probes).toBe(1);
+      // A late encoder drain after close must be harmless.
+      expect(() => { control.pause(); control.resume(); }).not.toThrow();
+    } finally {
+      controller.abort();
+      await streaming;
+      client.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
 

--- a/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/emulator-grpc.test.ts
@@ -14,7 +14,7 @@ import {
   IMAGE_TRANSPORT_MMAP,
   IMG_FORMAT_RGB888,
   parseEmulatorGrpcPort,
-  type GrpcScreenshotReadControl,
+  GrpcReadScheduler,
 } from "../src/emulator-grpc.ts";
 import type { ExecResult } from "../src/exec.ts";
 import { encodeEmulatorImage, grpcFrame } from "./fixtures/grpc.ts";
@@ -268,6 +268,69 @@ describe("emulator gRPC discovery", () => {
   });
 });
 
+describe("gRPC receive work scheduling", () => {
+  test("splits a large chunk across turns and drains its suffix before finishing", async () => {
+    const messages: string[] = [];
+    const events: string[] = [];
+    const parser = new GrpcMessageParser(100, (body) => {
+      messages.push(body.toString());
+      events.push(body.toString());
+    });
+    const chunks: number[] = [];
+    const scheduler = new GrpcReadScheduler({
+      stream: { pause() {}, resume() {} },
+      batchBytes: 8,
+      consume(chunk) { chunks.push(chunk.length); parser.push(chunk); },
+      onError(error) { throw error; },
+    });
+    scheduler.push(Buffer.concat(["one", "two", "end"].map((s) => grpcFrame(Buffer.from(s)))));
+    expect(messages).toEqual(["one"]);
+    setImmediate(() => events.push("other I/O"));
+    await new Promise<void>((resolve) => scheduler.finish(resolve));
+    expect(messages).toEqual(["one", "two", "end"]);
+    expect(events.indexOf("other I/O")).toBeLessThan(events.indexOf("end"));
+    expect(chunks).toEqual([8, 8, 8]);
+    scheduler.close();
+  });
+
+  test("budgets multiple data events together and resumes on the next turn", async () => {
+    let paused = false;
+    let bytes = 0;
+    const scheduler = new GrpcReadScheduler({
+      stream: { pause() { paused = true; }, resume() { paused = false; } },
+      batchBytes: 4,
+      consume(chunk) { bytes += chunk.length; },
+      onError(error) { throw error; },
+    });
+    scheduler.push(Buffer.alloc(2));
+    expect(paused).toBe(false);
+    scheduler.push(Buffer.alloc(2));
+    expect(paused).toBe(true);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(paused).toBe(false);
+    expect(bytes).toBe(4);
+    scheduler.close();
+  });
+
+  test("close and parse errors cancel pending receive work", async () => {
+    for (const fails of [false, true]) {
+      let bytes = 0;
+      const errors: unknown[] = [];
+      const scheduler = new GrpcReadScheduler({
+        stream: { pause() {}, resume() {} }, batchBytes: 4,
+        consume(chunk) { bytes += chunk.length; if (fails) throw new Error("bad frame"); },
+        onError(error) { errors.push(error); },
+      });
+      scheduler.push(Buffer.alloc(20));
+      scheduler.close();
+      scheduler.push(Buffer.alloc(20));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(bytes).toBe(4);
+      expect(errors).toHaveLength(fails ? 1 : 0);
+    }
+  });
+});
+
 describe("EmulatorGrpcClient HTTP/2 integration", () => {
   test("sends the discovered bearer token and decodes a screenshot", async () => {
     const imageBody = encodeEmulatorImage({
@@ -314,80 +377,6 @@ describe("EmulatorGrpcClient HTTP/2 integration", () => {
       await new Promise<void>((resolve, reject) =>
         server.close((error) => (error ? reject(error) : resolve())),
       );
-    }
-  });
-
-  test("consumer backpressure pauses delivery and inactivity probes until resumed", async () => {
-    const frame = (seq: number) => grpcFrame(encodeEmulatorImage({
-      format: IMG_FORMAT_RGB888,
-      width: 2,
-      height: 1,
-      image: Buffer.alloc(6, seq),
-      seq,
-    }));
-    let screenshotStream: ServerHttp2Stream | undefined;
-    let probes = 0;
-    const server = http2.createServer();
-    server.on("stream", (stream: ServerHttp2Stream, headers) => {
-      stream.on("error", () => {});
-      stream.resume();
-      const streaming = String(headers[":path"]).endsWith("/streamScreenshot");
-      stream.respond({
-        ":status": 200,
-        "content-type": "application/grpc",
-        ...(streaming ? {} : { "grpc-status": "0" }),
-      });
-      if (streaming) {
-        screenshotStream = stream;
-        stream.write(frame(1));
-      } else {
-        probes++;
-        stream.end(frame(3));
-      }
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const address = server.address();
-    if (!address || typeof address === "string") throw new Error("missing test port");
-    const client = new EmulatorGrpcClient(
-      { port: address.port, token: null, avdName: null },
-      { streamInactivityTimeoutMs: 25 },
-    );
-    const controller = new AbortController();
-    let control!: GrpcScreenshotReadControl;
-    let firstImage!: () => void;
-    const first = new Promise<void>((resolve) => { firstImage = resolve; });
-    const images: number[] = [];
-    const streaming = client.streamScreenshot(
-      { format: IMG_FORMAT_RGB888 },
-      (image) => {
-        images.push(image.seq);
-        if (image.seq === 1) {
-          control.pause();
-          firstImage();
-        } else if (image.seq === 3) {
-          controller.abort();
-        }
-      },
-      controller.signal,
-      { onReadControl: (value) => { control = value; } },
-    );
-    try {
-      await first;
-      screenshotStream!.write(frame(2));
-      await new Promise((resolve) => setTimeout(resolve, 75));
-      expect(images).toEqual([1]);
-      expect(probes).toBe(0);
-      control.resume();
-      await streaming;
-      expect(images).toEqual([1, 2, 3]);
-      expect(probes).toBe(1);
-      // A late encoder drain after close must be harmless.
-      expect(() => { control.pause(); control.resume(); }).not.toThrow();
-    } finally {
-      controller.abort();
-      await streaming;
-      client.close();
-      await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
 

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, test } from "bun:test";
 import {
   GrpcAccessUnitBoundaryCadence,
   GrpcEncoderLifecycle,
-  GrpcFrameWritePacer,
   GrpcCaptureDiagnosticsTracker,
   GrpcInputState,
   GrpcMmapNotificationScheduler,
@@ -404,23 +403,6 @@ describe("gRPC screenshot session helpers", () => {
 
     expect(consumed).toEqual([1]);
     expect(() => scheduler.close()).not.toThrow();
-  });
-
-  test("does not let a boundary repeat delay the next fresh frame", () => {
-    const pacer = new GrpcFrameWritePacer(50);
-    pacer.reset(0);
-    pacer.recordWrite(0, false, false);
-    expect(pacer.waitMs(0)).toBe(0);
-
-    pacer.recordWrite(0, false);
-    expect(pacer.waitMs(40)).toBe(10);
-
-    pacer.recordWrite(40, true);
-    expect(pacer.waitMs(40)).toBe(10);
-    expect(pacer.waitMs(50)).toBe(0);
-
-    pacer.recordWrite(50, false);
-    expect(pacer.waitMs(50)).toBe(50);
   });
 
   test("learns a robust boundary cadence without retaining idle gaps", () => {
@@ -1035,6 +1017,11 @@ describe("gRPC screenshot session helpers", () => {
 });
 
 class FakeGrpcClient implements GrpcSessionClient {
+  readonly readControl = {
+    paused: false,
+    pause() { this.paused = true; },
+    resume() { this.paused = false; },
+  };
   readonly keys: KeyboardEventRequest[] = [];
   readonly touches: unknown[] = [];
   closed = false;
@@ -1071,12 +1058,14 @@ class FakeGrpcClient implements GrpcSessionClient {
     signal: AbortSignal,
     _options?: {
       maxFps?: number;
+      onReadControl?: (control: { pause(): void; resume(): void }) => void;
       onPacingEvent?: (event: "received" | "emitted" | "coalesced") => void;
     },
   ): Promise<void> {
     this.streamFormat = format;
     this.streamMaxFps = _options?.maxFps;
     this.streamImage = onImage;
+    _options?.onReadControl?.(this.readControl);
     if (this.emitInitialStreamImage) onImage(this.probe, "stream", Date.now());
     return new Promise((resolve) => {
       signal.addEventListener("abort", () => resolve(), { once: true });
@@ -1104,6 +1093,7 @@ class FakeGrpcClient implements GrpcSessionClient {
 }
 
 class FakeGrpcEncoder implements GrpcSessionEncoder {
+  writable = true;
   readonly width: number;
   readonly height: number;
   readonly quarterTurn: QuarterTurn;
@@ -1118,6 +1108,7 @@ class FakeGrpcEncoder implements GrpcSessionEncoder {
     readonly behavior: {
       writeResults?: boolean[];
       publishAfterAcceptedWrites?: number;
+      autoBackpressure?: boolean;
     } = {},
   ) {
     this.width = options.width;
@@ -1131,6 +1122,7 @@ class FakeGrpcEncoder implements GrpcSessionEncoder {
     const accepted = this.behavior.writeResults?.shift() ?? true;
     if (!accepted) return false;
     this.acceptedWrites++;
+    if (this.behavior.autoBackpressure) this.writable = false;
     if (
       !this.#published &&
       this.acceptedWrites >= (this.behavior.publishAfterAcceptedWrites ?? 1)
@@ -1165,6 +1157,7 @@ function integrationRuntime(
   encoderBehavior: {
     writeResults?: boolean[];
     publishAfterAcceptedWrites?: number;
+    autoBackpressure?: boolean;
   } = {},
 ): GrpcSessionRuntime {
   return {
@@ -1196,6 +1189,108 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("startGrpcSession integration", () => {
+  test("RGB handoff pauses source reads until ffmpeg drains", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc", maxFps: 1 },
+      { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
+    );
+    try {
+      const encoder = encoders[0]!;
+      expect(client.readControl.paused).toBe(true);
+      expect(encoder.acceptedWrites).toBe(1);
+      encoder.writable = true;
+      encoder.options.onWritable!();
+      expect(client.readControl.paused).toBe(false);
+      client.streamImage!({ ...rgb, seq: 2 }, "stream", Date.now());
+      expect(encoder.acceptedWrites).toBe(2);
+      expect(client.readControl.paused).toBe(true);
+      encoder.writable = true;
+      encoder.options.onWritable!();
+      expect(client.readControl.paused).toBe(false);
+      expect(encoder.acceptedWrites).toBe(2);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test.each(["png", "rgb888"] as const)("%s handoff submits immediately whenever the encoder is ready", async (grpcImageMode) => {
+    const rgb = grpcImageMode === "png" ? integrationImage() :
+      { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode, inputSource: "grpc", maxFps: 1 },
+      { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders) },
+    );
+    try {
+      const initial = encoders[0]!.acceptedWrites;
+      for (let seq = 2; seq <= 5; seq++) {
+        client.streamImage!({ ...rgb, seq, image: Buffer.from(rgb.image) }, "stream", Date.now());
+        expect(encoders[0]!.acceptedWrites).toBe(initial + seq - 1);
+      }
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("RGB handoff resumes the newest pending frame on drain without polling", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const behavior = { writeResults: [true] };
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc", maxFps: 1 },
+      { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, behavior) },
+    );
+    try {
+      const encoder = encoders[0]!;
+      behavior.writeResults.push(false);
+      client.streamImage!({ ...rgb, seq: 2 }, "stream", Date.now());
+      const attempts = encoder.writes;
+      client.streamImage!({ ...rgb, seq: 3, image: Buffer.alloc(72, 3) }, "stream", Date.now());
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(encoder.writes).toBe(attempts);
+      expect(encoder.options.onWritable).toBeDefined();
+      encoder.options.onWritable!();
+      expect(encoder.acceptedWrites).toBe(2);
+      expect(encoder.lastBuffer).toEqual(Buffer.alloc(72, 3));
+      encoder.options.onWritable!();
+      expect(encoder.acceptedWrites).toBe(2);
+      await session.close();
+      encoder.options.onWritable!();
+      expect(encoder.acceptedWrites).toBe(2);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("ignores stale drains after replacing a backpressured encoder", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc" },
+      { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
+    );
+    try {
+      expect(client.readControl.paused).toBe(true);
+      client.streamImage!({ ...rgb, width: 6, height: 4 }, "stream", Date.now());
+      await waitFor(() => encoders[1]?.acceptedWrites === 1);
+      expect(encoders[0]!.closed).toBe(true);
+      encoders[0]!.options.onWritable!();
+      expect(client.readControl.paused).toBe(true);
+      expect(encoders[1]!.acceptedWrites).toBe(1);
+      encoders[1]!.writable = true;
+      encoders[1]!.options.onWritable!();
+      expect(client.readControl.paused).toBe(false);
+    } finally {
+      await session.close();
+    }
+  });
+
   test.each(["software", "hardware"] as const)("resolves %s once and keeps the backend across size changes", async (encoder) => {
     const client = new FakeGrpcClient(integrationImage());
     const encoders: FakeGrpcEncoder[] = [];
@@ -1446,7 +1541,7 @@ describe("startGrpcSession integration", () => {
       });
       expect(encoders[0]!.lastBuffer!.readUInt32LE()).toBe(frameCount);
       expect(encoders[0]!.options).toMatchObject({ fps: 30, inputFormat: "rgb24" });
-      expect(encoders[0]!.writes).toBeLessThan(frameCount / 2);
+      expect(encoders[0]!.acceptedWrites).toBeGreaterThanOrEqual(frameCount + 1);
     } finally {
       await session?.close();
       client.close();
@@ -1631,7 +1726,11 @@ describe("startGrpcSession integration", () => {
         newest = { ...rgb, seq, image: Buffer.alloc(72, seq) };
         client.streamImage!(newest, "stream", Date.now());
       }
-      await waitFor(() => encoders[0]!.acceptedWrites === 2);
+      expect(encoders[0]!.writes).toBe(2);
+      encoders[0]!.options.onWritable!();
+      expect(encoders[0]!.writes).toBe(3);
+      encoders[0]!.options.onWritable!();
+      expect(encoders[0]!.acceptedWrites).toBe(2);
       expect(encoders[0]!.lastBuffer).toBe(newest.image);
       expect(encoders[0]!.writes).toBe(4);
       expect(session.diagnostics!().grpcCapture).toMatchObject({
@@ -1753,7 +1852,7 @@ describe("startGrpcSession integration", () => {
   test("retries a boundary write rejected by encoder backpressure", async () => {
     const client = new FakeGrpcClient(integrationImage());
     const encoders: FakeGrpcEncoder[] = [];
-    const session = await startGrpcSession(
+    const starting = startGrpcSession(
       {
         serial: "emulator-5554",
         mode: "grpc-screenshot",
@@ -1769,6 +1868,11 @@ describe("startGrpcSession integration", () => {
       },
     );
 
+    await waitFor(() => encoders[0]?.writes === 2);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(encoders[0]!.writes).toBe(2);
+    encoders[0]!.options.onWritable!();
+    const session = await starting;
     expect(encoders[0]!.writes).toBe(3);
     expect(encoders[0]!.acceptedWrites).toBe(2);
     await session.close();

--- a/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/grpc-session.test.ts
@@ -253,13 +253,15 @@ describe("gRPC screenshot session helpers", () => {
     expect(rgbBehavior.encoderInputFormat).toBe("rgb24");
     expect(rgbBehavior.predecodeMaxFps).toBeUndefined();
     expect(rgbBehavior.needsEncoderFollowUp(false, true)).toBe(true);
-    expect(rgbBehavior.needsEncoderFollowUp(true, false)).toBe(false);
+    expect(rgbBehavior.needsEncoderFollowUp(true, false)).toBe(true);
+    expect(rgbBehavior.needsEncoderFollowUp(true, true)).toBe(false);
 
     const mmapBehavior = grpcImageModeBehavior("mmap", 60);
     expect(mmapBehavior.encoderInputFormat).toBe("rgb24");
     expect(mmapBehavior.predecodeMaxFps).toBeUndefined();
     expect(mmapBehavior.needsEncoderFollowUp(false, true)).toBe(true);
-    expect(mmapBehavior.needsEncoderFollowUp(true, false)).toBe(false);
+    expect(mmapBehavior.needsEncoderFollowUp(true, false)).toBe(true);
+    expect(mmapBehavior.needsEncoderFollowUp(true, true)).toBe(false);
   });
 
   test("treats an empty 0x0 MMAP notification as an inactive-display marker", () => {
@@ -1017,11 +1019,6 @@ describe("gRPC screenshot session helpers", () => {
 });
 
 class FakeGrpcClient implements GrpcSessionClient {
-  readonly readControl = {
-    paused: false,
-    pause() { this.paused = true; },
-    resume() { this.paused = false; },
-  };
   readonly keys: KeyboardEventRequest[] = [];
   readonly touches: unknown[] = [];
   closed = false;
@@ -1058,14 +1055,12 @@ class FakeGrpcClient implements GrpcSessionClient {
     signal: AbortSignal,
     _options?: {
       maxFps?: number;
-      onReadControl?: (control: { pause(): void; resume(): void }) => void;
       onPacingEvent?: (event: "received" | "emitted" | "coalesced") => void;
     },
   ): Promise<void> {
     this.streamFormat = format;
     this.streamMaxFps = _options?.maxFps;
     this.streamImage = onImage;
-    _options?.onReadControl?.(this.readControl);
     if (this.emitInitialStreamImage) onImage(this.probe, "stream", Date.now());
     return new Promise((resolve) => {
       signal.addEventListener("abort", () => resolve(), { once: true });
@@ -1189,31 +1184,129 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("startGrpcSession integration", () => {
-  test("RGB handoff pauses source reads until ffmpeg drains", async () => {
+  test("consumes buffered RGB frames during encoder backpressure and submits the newest", async () => {
+    const width = 540, height = 1170, count = 8;
+    const frame = (seq: number) => {
+      const pixels = Buffer.alloc(width * height * 3);
+      pixels.writeUInt32LE(seq);
+      return grpcFrame(encodeEmulatorImage({ format: IMG_FORMAT_RGB888, width, height, image: pixels, seq }));
+    };
+    let source: ServerHttp2Stream | undefined;
+    const server = http2.createServer();
+    server.on("stream", (stream: ServerHttp2Stream, headers) => {
+      stream.on("error", () => {});
+      stream.resume();
+      const streaming = String(headers[":path"]).endsWith("/streamScreenshot");
+      stream.respond({ ":status": 200, "content-type": "application/grpc", ...(streaming ? {} : { "grpc-status": "0" }) });
+      if (streaming) { source = stream; stream.write(frame(0)); }
+      else stream.end(frame(0));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing test port");
+    const endpoint = { port: address.port, token: null, avdName: "test" };
+    const client = new EmulatorGrpcClient(endpoint);
+    const encoders: FakeGrpcEncoder[] = [];
+    let session: Awaited<ReturnType<typeof startGrpcSession>> | undefined;
+    try {
+      session = await startGrpcSession(
+        { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc" },
+        { readDisplaySizeSignal: async () => `physical:${width}x${height}`, runtime: {
+          ...integrationRuntime(client, encoders, { autoBackpressure: true }),
+          ensureEndpoint: async () => endpoint,
+        } },
+      );
+      for (let seq = 1; seq <= count; seq++) source!.write(frame(seq));
+      await waitFor(() => session!.diagnostics!().grpcCapture!.usableImages === count + 1);
+      expect(encoders[0]!.acceptedWrites).toBe(1);
+      encoders[0]!.writable = true;
+      encoders[0]!.options.onWritable!();
+      expect(encoders[0]!.acceptedWrites).toBe(2);
+      expect(encoders[0]!.lastBuffer!.readUInt32LE()).toBe(count);
+    } finally {
+      await session?.close();
+      client.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test.each([false, true])("recovers or fails a missing drain when writable=%s", async (writable) => {
     const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
     const client = new FakeGrpcClient(rgb);
     const encoders: FakeGrpcEncoder[] = [];
     const session = await startGrpcSession(
-      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc", maxFps: 1 },
-      { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc" },
+      { encoderDrainTimeoutMs: 25, readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
     );
     try {
-      const encoder = encoders[0]!;
-      expect(client.readControl.paused).toBe(true);
-      expect(encoder.acceptedWrites).toBe(1);
-      encoder.writable = true;
-      encoder.options.onWritable!();
-      expect(client.readControl.paused).toBe(false);
+      const failures: string[] = [];
+      session.onFatal((failure) => failures.push(failure.code!));
       client.streamImage!({ ...rgb, seq: 2 }, "stream", Date.now());
-      expect(encoder.acceptedWrites).toBe(2);
-      expect(client.readControl.paused).toBe(true);
-      encoder.writable = true;
-      encoder.options.onWritable!();
-      expect(client.readControl.paused).toBe(false);
-      expect(encoder.acceptedWrites).toBe(2);
+      encoders[0]!.writable = writable;
+      await waitFor(() => writable ? encoders[0]!.acceptedWrites === 2 : failures.length > 0);
+      expect(failures).toEqual(writable ? [] : ["encoder-exit"]);
+      expect(encoders[0]!.writes).toBe(writable ? 2 : 1);
     } finally {
       await session.close();
     }
+  });
+
+  test("fails startup promptly if the encoder never drains", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    await expect(startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc" },
+      { encoderDrainTimeoutMs: 25, readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, {
+        autoBackpressure: true, publishAfterAcceptedWrites: 2,
+      }) },
+    )).rejects.toThrow("ffmpeg input remained backpressured for 25ms");
+    expect(client.closed).toBe(true);
+    expect(encoders[0]!.closed).toBe(true);
+  });
+
+  test("a successful drain or close cancels the stall watchdog", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888", inputSource: "grpc" },
+      { encoderDrainTimeoutMs: 25, readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
+    );
+    const failures: string[] = [];
+    session.onFatal((failure) => failures.push(failure.message));
+    try {
+      encoders[0]!.writable = true;
+      encoders[0]!.options.onWritable!();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(failures).toEqual([]);
+      client.streamImage!({ ...rgb, seq: 2 }, "stream", Date.now());
+      await session.close();
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      expect(failures).toEqual([]);
+      expect(encoders[0]!.acceptedWrites).toBe(2);
+    } finally {
+      await session.close();
+    }
+  });
+
+  test("ignores a synchronous writable callback during encoder construction", async () => {
+    const client = new FakeGrpcClient(integrationImage());
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      { serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "png", inputSource: "grpc" },
+      { readDisplaySizeSignal: async () => "physical:4x6", runtime: {
+        ...integrationRuntime(client, encoders),
+        createEncoder(options) {
+          options.onWritable!();
+          const encoder = new FakeGrpcEncoder(options);
+          encoders.push(encoder);
+          return encoder;
+        },
+      } },
+    );
+    expect(encoders[0]!.acceptedWrites).toBe(1);
+    await session.close();
   });
 
   test.each(["png", "rgb888"] as const)("%s handoff submits immediately whenever the encoder is ready", async (grpcImageMode) => {
@@ -1276,16 +1369,16 @@ describe("startGrpcSession integration", () => {
       { readDisplaySizeSignal: async () => "physical:4x6", runtime: integrationRuntime(client, encoders, { autoBackpressure: true }) },
     );
     try {
-      expect(client.readControl.paused).toBe(true);
       client.streamImage!({ ...rgb, width: 6, height: 4 }, "stream", Date.now());
       await waitFor(() => encoders[1]?.acceptedWrites === 1);
       expect(encoders[0]!.closed).toBe(true);
+      client.streamImage!({ ...rgb, width: 6, height: 4, image: Buffer.alloc(72, 9) }, "stream", Date.now());
       encoders[0]!.options.onWritable!();
-      expect(client.readControl.paused).toBe(true);
       expect(encoders[1]!.acceptedWrites).toBe(1);
       encoders[1]!.writable = true;
       encoders[1]!.options.onWritable!();
-      expect(client.readControl.paused).toBe(false);
+      expect(encoders[1]!.acceptedWrites).toBe(2);
+      expect(encoders[1]!.lastBuffer).toEqual(Buffer.alloc(72, 9));
     } finally {
       await session.close();
     }
@@ -1876,6 +1969,29 @@ describe("startGrpcSession integration", () => {
     expect(encoders[0]!.writes).toBe(3);
     expect(encoders[0]!.acceptedWrites).toBe(2);
     await session.close();
+  });
+
+  test("warms up a static RGB encoder until it produces its first frame", async () => {
+    const rgb = { ...integrationImage(), format: IMG_FORMAT_RGB888, image: Buffer.alloc(72) };
+    const client = new FakeGrpcClient(rgb);
+    const encoders: FakeGrpcEncoder[] = [];
+    const session = await startGrpcSession(
+      {
+        serial: "emulator-5554", mode: "grpc-screenshot", grpcImageMode: "rgb888",
+        inputSource: "grpc", maxFps: 120, signal: AbortSignal.timeout(1_500),
+      },
+      {
+        readDisplaySizeSignal: async () => "physical:4x6",
+        runtime: integrationRuntime(client, encoders, { publishAfterAcceptedWrites: 4 }),
+      },
+    );
+    try {
+      expect(encoders[0]!.acceptedWrites).toBe(4);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(encoders[0]!.acceptedWrites).toBe(4);
+    } finally {
+      await session.close();
+    }
   });
 
   test("uses the bounded startup boundary flush at a very low max FPS", async () => {

--- a/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
+++ b/packages/serve-emu/packages/serve-emu/tests/h264-encoder.test.ts
@@ -802,6 +802,42 @@ describe("H264Encoder validation", () => {
     await encoder.close();
   });
 
+  realFfmpegTest("signals readiness after RGB frames backpressure stdin", async () => {
+    let resolveDrain!: () => void;
+    let rejectDrain!: (error: Error) => void;
+    const drained = new Promise<void>((resolve, reject) => {
+      resolveDrain = resolve;
+      rejectDrain = reject;
+    });
+    const timeout = setTimeout(() => rejectDrain(new Error("ffmpeg did not drain")), 2_000);
+    const encoder = new H264Encoder({
+      ...valid,
+      width: 512,
+      height: 512,
+      onWritable: resolveDrain,
+      onExit: (reason) => rejectDrain(new Error(reason)),
+    });
+    const pixels = Buffer.alloc(512 * 512 * 3);
+    try {
+      expect(encoder.writable).toBe(true);
+      // Node and Bun have different pipe buffering capacities. Fill the pipe
+      // without yielding, then verify the readiness contract at its actual limit.
+      let pts = 1n;
+      while (encoder.writable && pts <= 64n) {
+        expect(encoder.write(pixels, pts++)).toBe(true);
+      }
+      expect(encoder.writable).toBe(false);
+      expect(encoder.write(pixels, pts)).toBe(false);
+      await drained;
+      expect(encoder.writable).toBe(true);
+      expect(encoder.write(pixels, pts)).toBe(true);
+    } finally {
+      clearTimeout(timeout);
+      await encoder.close();
+    }
+    expect(encoder.writable).toBe(false);
+  });
+
   realFfmpegTest(
     "accepts concatenated PNG images through image2pipe",
     async () => {


### PR DESCRIPTION
gRPC frames currently wait for a local FPS pacer and retry rejected FFmpeg writes on an 8 ms timer. Submit usable frames immediately when FFmpeg is ready and continue from its `drain` event, retaining the newest pending image. This is the only encoder handoff path, with no experimental switches.

Keep consuming RGB888 screenshots during encoder backpressure so HTTP/2 does not become a FIFO of stale frames. Receive work yields after each 64 KiB batch so a busy source cannot starve pipe callbacks; stream and connection receive windows are 8 MiB. Track stdin's write result explicitly because Bun can report backpressure while `writableNeedDrain` remains false.

A one-shot five-second watchdog recovers a missed drain only when the encoder reports writable; otherwise it emits `encoder-exit`. Screenshot inactivity probes remain active. Guard synchronous construction callbacks and callbacks from replaced encoders. Continue startup boundary repeats until encoded output arrives, including on static RGB screens, then use the existing idle cadence. PNG predecode pacing and MMAP shared-memory selection remain in place. For RGB888, `--max-fps` configures the nominal encoder rate and idle cadence without capping fresh submissions; the documentation and CLI help explain this.

Validation:

- `bun run --filter serve-emu check`: 987 tests pass, critical coverage, typechecks, build and package smoke pass. Regressions cover an actual HTTP/2 full-size frame burst during encoder backpressure, lost drains, stall cancellation, startup failures and synchronous/stale callbacks.
- Hub: 184 tests pass; repository lint and Hub vendor/server builds pass.
- Live 540×1170 Android emulator: Bun/software and Node/VideoToolbox each delivered 10 frames. Node/VideoToolbox also passed on a static home screen. The rebuilt Node CLI streams the animated workload over WebRTC without experimental flags.
- Backpressure test with a 240 FPS synthetic source and FFmpeg limited to 30 FPS: P95 source-to-submit frame age fell from 170.12 ms to 41.84 ms (mean 90.97 → 12.56 ms; P90 154.26 → 27.88 ms), with unchanged 30 FPS output. Baseline is the earlier PR commit `43e447316`; each run measured 10 seconds after warm-up.
- Local production gRPC → FFmpeg rawvideo copy path reached 288.88 fresh FPS over 8 seconds. With a target 240 FPS source, it wrote 228.40 fresh FPS over 10 seconds; complete-image receipt to pipe-write completion averaged 3.51 ms, P90 7.17 ms, P95 9.73 ms. All completed writes matched FFmpeg's frame count, with zero write errors.
- The production software H.264 encoder accepted 237.46 fresh FPS over 10 seconds with the unrestricted synthetic source. These are short local capacity measurements at 540×1170, not emulator/browser display FPS. Older pending images are intentionally replaced during stalls, and synthetic frames compress easily. Benchmark artifacts remain local.

— Codex (GPT-6)
