### PR TITLE
ci: build expo-device-hub releases with EAS Workflows

### DIFF
--- a/.eas/workflows/build-release.yml
+++ b/.eas/workflows/build-release.yml
@@ -1,0 +1,62 @@
+name: Build expo-device-hub release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: Final npm version calculated by the GitHub release workflow
+
+defaults:
+  tools:
+    node: 24
+    bun: 1.3.13
+
+jobs:
+  package:
+    name: Build and pack expo-device-hub
+    runs_on: macos-medium
+    image: macos-tahoe-26.5-xcode-26.6
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+    steps:
+      - uses: eas/checkout
+
+      - name: Initialize pinned submodules
+        run: git submodule update --init --recursive
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply final package version
+        run: |
+          bun -e '
+            const version = process.env.RELEASE_VERSION;
+            if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version ?? "")) {
+              throw new Error("Invalid release version");
+            }
+            const path = "packages/expo-device-hub/package.json";
+            const pkg = await Bun.file(path).json();
+            pkg.version = version;
+            await Bun.write(path, JSON.stringify(pkg, null, 2) + "\n");
+          '
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Test
+        run: bun run test && bun test scripts/lib/release-artifact.test.ts
+
+      - name: Pack and verify release
+        run: |
+          mkdir -p release-artifacts
+          npm pack --workspace packages/expo-device-hub --ignore-scripts --pack-destination release-artifacts
+          bun scripts/verify-release-artifact.ts "release-artifacts/expo-device-hub-${RELEASE_VERSION}.tgz"
+
+      - name: Upload npm package
+        uses: eas/upload_artifact
+        with:
+          type: other
+          name: expo-device-hub-package
+          path: release-artifacts/expo-device-hub-${{ inputs.version }}.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Test
         run: bun run test
 
+      - name: Test release artifact verification
+        run: bun test scripts/lib/release-artifact.test.ts
+
       - name: Serve-emu critical coverage
         run: bun run --filter serve-emu coverage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: npm-publish
     env:
       IS_CANARY: ${{ github.event_name == 'push' || inputs.canary }}
@@ -42,15 +43,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.x"
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Build packages
-        run: bun run build
-
-      - name: Test
-        run: bun run test
 
       - name: Configure git
         run: |
@@ -71,6 +67,36 @@ jobs:
       - name: Summarize versions
         run: ./scripts/summarize-versions.ts
 
+      - name: Read release version
+        id: release
+        run: echo "version=$(node -p 'require("./packages/expo-device-hub/package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Build npm package with EAS
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_DEV_EXPO_GITHUB_ROBOT_ACCESS_TOKEN }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          npx --yes eas-cli@24.0.0 workflow:run .eas/workflows/build-release.yml \
+            --ref "$RELEASE_SHA" \
+            --input "version=$RELEASE_VERSION" \
+            --wait --non-interactive --json > "$RUNNER_TEMP/eas-workflow.json"
+
+      - name: Download and verify EAS package
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          ARTIFACT_URL=$(jq -er '
+            if .status != "SUCCESS" then error("EAS workflow did not succeed") else . end
+            | [.jobs[].turtleJobRun.artifacts[]?
+                | select(.name == "expo-device-hub-package") | .downloadUrl]
+            | if length == 1 then .[0] else error("Expected exactly one npm artifact") end
+          ' "$RUNNER_TEMP/eas-workflow.json")
+          mkdir -p release-artifacts
+          curl --fail --location --retry 3 "$ARTIFACT_URL" \
+            --output "release-artifacts/expo-device-hub-${RELEASE_VERSION}.tgz"
+          bun scripts/verify-release-artifact.ts "release-artifacts/expo-device-hub-${RELEASE_VERSION}.tgz"
+
       - name: Commit & push version bump
         if: ${{ env.IS_CANARY != 'true' }}
         run: |
@@ -78,20 +104,21 @@ jobs:
           git commit -m "chore(release): version packages"
           git push origin "HEAD:${{ github.ref_name }}"
 
-      - name: Ignore packages excluded from release
-        run: ./scripts/ignore-packages.ts
-
       - name: Publish to npm
         if: ${{ env.IS_CANARY != 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: "true"
-        run: bun run changeset:publish
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          npm publish "release-artifacts/expo-device-hub-${RELEASE_VERSION}.tgz" --access public
+          git tag "expo-device-hub@${RELEASE_VERSION}"
 
       - name: Publish canary to npm
         if: ${{ env.IS_CANARY == 'true' }}
         env:
           NPM_CONFIG_PROVENANCE: "true"
-        run: bun run changeset:publish -- --tag canary
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: npm publish "release-artifacts/expo-device-hub-${RELEASE_VERSION}.tgz" --access public --tag canary
 
       - name: Push git tags
         if: ${{ env.IS_CANARY != 'true' }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,8 +10,41 @@ layer, is marked `private` and is skipped by the release tooling.
 Releases are driven by [changesets](https://github.com/changesets/changesets): the version
 bump and changelog for each package are computed from the `.changeset/*.md` entries that have
 accumulated since the last release. The **Release** GitHub Actions workflow
-(`.github/workflows/release.yml`) is dispatched manually and publishes to npm using **OIDC
-Trusted Publishing** (no long-lived `NPM_TOKEN`).
+(`.github/workflows/release.yml`) runs on Ubuntu and publishes to npm using **OIDC
+Trusted Publishing** (no long-lived `NPM_TOKEN`). Pushes to `main` publish canaries;
+manual dispatch selects a stable or canary release. The build runs on EAS macOS.
+
+## GitHub and EAS handoff
+
+The root `.eas/workflows/build-release.yml` installs the monorepo's locked dependencies,
+builds all workspaces (including serve-sim's native helpers), runs tests, and uploads the
+final npm tarball. Root `app.config.js` shares the existing hub EAS project identity from
+`packages/expo-device-hub/app.json`.
+
+GitHub calculates the final version with Changesets, then dispatches EAS at the triggering
+commit SHA with that version as an explicit workflow input. EAS initializes the pinned
+submodules and applies the version before building. This also supports canaries without
+pushing temporary version commits. The tarball's published files do not include the changelog;
+GitHub retains the locally generated changelog for its release notes.
+
+The Ubuntu job waits for EAS, downloads the named artifact, and verifies its package name,
+version, web/server output, native helpers, and WebRTC runtime files. Stable releases then
+commit/push the version changes, publish the downloaded tarball, create/push the npm-version
+tag, and attach the same tarball to the GitHub release. Canaries publish the tarball under
+`canary` without creating commits, tags, or GitHub releases. Publishing uses `npm publish`
+directly so the EAS artifact is never repacked on Ubuntu.
+
+Before using the pipeline, link the hub EAS project to this GitHub repository with the
+project directory at the repository root, and make
+`EXPO_DEV_EXPO_GITHUB_ROBOT_ACCESS_TOKEN` available to the GitHub `npm-publish` environment
+(an organization or repository secret also works). The token needs access to that EAS
+project. Keep the existing npm trusted publisher configured for `.github/workflows/release.yml`
+and the `npm-publish` environment. No npm publish credentials are required in EAS.
+
+This first version rebuilds on each release; it does not yet cache native artifacts. A failed
+EAS build stops before version changes are pushed or npm is published. Failures after the
+version push can still leave a release commit without a published package; inspect the npm
+version and Git tags before retrying. GitHub's 90-minute timeout includes EAS queue time.
 
 ## Cutting a release
 
@@ -33,10 +66,10 @@ largest one requested.
 
 Go to **Actions → Release → Run workflow**. The only input is **canary**:
 
-- **off** (default) → real release. The workflow tests, builds, versions, publishes to npm,
+- **off** (default) → real release. The workflow versions, builds/tests on EAS, publishes to npm,
   pushes the release commit and tags, and creates GitHub releases.
-- **on** → canary release. The workflow tests, builds, and versions as usual, then rewrites each
-  published package's version into a prerelease and publishes it under the **`canary`** npm
+- **on** → canary release. The workflow calculates a prerelease version, builds/tests it on
+  EAS, and publishes it under the **`canary`** npm
   dist-tag — without committing the version bump, pushing tags, or creating GitHub releases.
   Install it with `npm install expo-device-hub@canary`, and `latest` stays untouched.
 

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,5 @@
+// EAS Workflows run from the monorepo root. Keep the project identity shared
+// with the web app, without resolving its assets relative to this directory.
+const { name, slug, owner, extra } = require('./packages/expo-device-hub/app.json').expo;
+
+module.exports = { expo: { name, slug, owner, extra } };

--- a/scripts/create-github-releases.ts
+++ b/scripts/create-github-releases.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun";
-import { mkdir } from "node:fs/promises";
 import { getPublicPackages } from "./lib/public-packages.ts";
+import { getChangesetIgnoreList } from "./lib/changeset-ignore.ts";
+import { verifyReleaseArtifact } from "./lib/release-artifact.ts";
 
 const artifactsDir = `${process.cwd()}/release-artifacts`;
-await mkdir(artifactsDir, { recursive: true });
+const ignore = await getChangesetIgnoreList();
 
 function changelogSection(changelog: string, version: string): string {
   const lines = changelog.split("\n");
@@ -22,9 +23,10 @@ function changelogSection(changelog: string, version: string): string {
 }
 
 for (const pkg of await getPublicPackages()) {
+  if (ignore.has(pkg.name)) continue;
   const tag = `${pkg.name}@${pkg.version}`;
 
-  // Only release packages tagged in this run (changeset publish creates the tag).
+  // The release workflow tags the version after publishing the EAS tarball.
   const tagged =
     (await $`git rev-parse -q --verify refs/tags/${tag}`.nothrow().quiet()).exitCode === 0;
   if (!tagged) {
@@ -46,9 +48,9 @@ for (const pkg of await getPublicPackages()) {
     if (section) notes = section;
   }
 
-  const packOutput = await $`npm pack --pack-destination ${artifactsDir} --json`.cwd(pkg.dir).text();
-  const tarball = `${artifactsDir}/${JSON.parse(packOutput)[0].filename}`;
+  const tarball = `${artifactsDir}/expo-device-hub-${pkg.version}.tgz`;
+  verifyReleaseArtifact(tarball, pkg.version);
 
-  console.log(`- ${tag}: creating GitHub release with ${JSON.parse(packOutput)[0].filename}`);
+  console.log(`- ${tag}: creating GitHub release with ${tarball}`);
   await $`gh release create ${tag} ${tarball} --verify-tag --title ${tag} --notes ${notes}`;
 }

--- a/scripts/lib/release-artifact.test.ts
+++ b/scripts/lib/release-artifact.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { verifyReleaseArtifact } from "./release-artifact.ts";
+
+const dirs: string[] = [];
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+function artifact({ version = "1.2.3", name = "expo-device-hub", omit = "", privatePackage = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "hub-release-test-"));
+  dirs.push(dir);
+  const files = [
+    "dist/client/index.html", "dist/server/index.mjs", "dist/server/cli.mjs",
+    "vendor/serve-emu/dist/middleware.js",
+    ...["middleware.js", "serve-sim.js", "native/serve-sim-native.node",
+      "bin/LiveKitWebRTC.framework/LiveKitWebRTC",
+      "bin/LiveKitWebRTC.framework/Resources/LICENSE.webrtc",
+      "bin/LiveKitWebRTC.framework/Resources/PrivacyInfo.xcprivacy",
+      "simcam/libSimCameraInjector.dylib", "simcam/serve-sim-camera-helper",
+      "simax/serve-sim-ax-settings"].map((file) => `vendor/serve-sim/dist/${file}`),
+    "vendor/serve-sim/LICENSE", "vendor/serve-sim/NOTICE",
+  ];
+  for (const file of files.filter((file) => file !== omit)) {
+    const path = join(dir, "package", file);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "fixture");
+  }
+  writeFileSync(join(dir, "package/package.json"), JSON.stringify({ name, version, private: privatePackage }));
+  const tarball = join(dir, "release.tgz");
+  execFileSync("tar", ["-czf", tarball, "-C", dir, "package"]);
+  return tarball;
+}
+
+describe("release artifact verification", () => {
+  test.each(["1.2.3", "1.3.0-canary-20260910-abcdef0"])("accepts a complete %s package", (version) => {
+    expect(() => verifyReleaseArtifact(artifact({ version }), version)).not.toThrow();
+  });
+  test("rejects the wrong version", () => {
+    expect(() => verifyReleaseArtifact(artifact(), "1.2.4")).toThrow("Expected public");
+  });
+  test("rejects the wrong package", () => {
+    expect(() => verifyReleaseArtifact(artifact({ name: "@expo/serve-sim" }), "1.2.3")).toThrow("Expected public");
+  });
+  test("rejects private packages", () => {
+    expect(() => verifyReleaseArtifact(artifact({ privatePackage: true }), "1.2.3")).toThrow("Expected public");
+  });
+  test.each([
+    "vendor/serve-sim/dist/native/serve-sim-native.node",
+    "vendor/serve-sim/dist/bin/LiveKitWebRTC.framework/LiveKitWebRTC",
+    "vendor/serve-sim/dist/bin/LiveKitWebRTC.framework/Resources/LICENSE.webrtc",
+    "dist/client/index.html",
+  ])("rejects a package missing %s", (omit) => {
+    expect(() => verifyReleaseArtifact(artifact({ omit }), "1.2.3")).toThrow("missing");
+  });
+});

--- a/scripts/lib/release-artifact.ts
+++ b/scripts/lib/release-artifact.ts
@@ -1,0 +1,32 @@
+import { execFileSync } from "node:child_process";
+
+const requiredFiles = [
+  "dist/server/index.mjs",
+  "dist/server/cli.mjs",
+  "vendor/serve-sim/dist/middleware.js",
+  "vendor/serve-sim/dist/serve-sim.js",
+  "vendor/serve-sim/dist/native/serve-sim-native.node",
+  "vendor/serve-sim/dist/bin/LiveKitWebRTC.framework/LiveKitWebRTC",
+  "vendor/serve-sim/dist/bin/LiveKitWebRTC.framework/Resources/LICENSE.webrtc",
+  "vendor/serve-sim/dist/bin/LiveKitWebRTC.framework/Resources/PrivacyInfo.xcprivacy",
+  "vendor/serve-sim/dist/simcam/libSimCameraInjector.dylib",
+  "vendor/serve-sim/dist/simcam/serve-sim-camera-helper",
+  "vendor/serve-sim/dist/simax/serve-sim-ax-settings",
+  "vendor/serve-sim/LICENSE",
+  "vendor/serve-sim/NOTICE",
+  "vendor/serve-emu/dist/middleware.js",
+];
+
+export function verifyReleaseArtifact(tarball: string, version: string): void {
+  const pkg = JSON.parse(execFileSync("tar", ["-xOf", tarball, "package/package.json"], { encoding: "utf8" }));
+  if (pkg.name !== "expo-device-hub" || pkg.version !== version || pkg.private === true) {
+    throw new Error(`Expected public expo-device-hub@${version}, got ${pkg.name}@${pkg.version}`);
+  }
+  const files = new Set(execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" }).trim().split("\n"));
+  for (const file of requiredFiles) {
+    if (!files.has(`package/${file}`)) throw new Error(`Release artifact is missing ${file}`);
+  }
+  if (![...files].some((file) => file.startsWith("package/dist/client/") && !file.endsWith("/"))) {
+    throw new Error("Release artifact is missing the web client");
+  }
+}

--- a/scripts/verify-release-artifact.ts
+++ b/scripts/verify-release-artifact.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+import { verifyReleaseArtifact } from "./lib/release-artifact.ts";
+
+const tarball = process.argv[2];
+if (!tarball) throw new Error("Usage: bun scripts/verify-release-artifact.ts <tarball>");
+const { version } = await Bun.file("packages/expo-device-hub/package.json").json();
+verifyReleaseArtifact(tarball, version);
+console.log(`Verified ${tarball} for expo-device-hub@${version}`);


### PR DESCRIPTION
Move expo-device-hub release builds from GitHub macOS runners to a root EAS workflow. GitHub calculates the stable/canary version, dispatches the exact source SHA to EAS, waits for the package, and publishes the returned tarball using npm OIDC. The GitHub release attaches that same tarball.

The EAS job initializes pinned submodules, installs the root lockfile, applies the requested version, builds all packages, runs tests, and verifies the npm package includes the native helpers and WebRTC framework. Root EAS configuration reuses the existing hub project identity. Version commits now happen after the EAS build succeeds; native caching is deferred.

Validation:

- GitHub CI passed.
- [EAS build from this PR commit](https://expo.dev/accounts/expo/projects/expo-device-hub/workflows/01a08c81-8aff-7135-b728-a544a1045fb7) passed: full macOS build, tests, npm packing, verification, and upload.
- Downloaded that EAS artifact using the release workflow's JSON selection and verified it locally.
- EAS workflow validation, actionlint, and all nine artifact-verification tests passed.
- Local monorepo build/test passed (with existing Turbo cache hits).

No npm publication or release tags were created. The test invoked EAS CLI directly at the pushed commit; the publishing GitHub workflow itself was not dispatched. The existing EAS repository/root linkage works. Before enabling releases, ensure EXPO_DEV_EXPO_GITHUB_ROBOT_ACCESS_TOKEN is available to the GitHub npm-publish job. RELEASING.md documents setup and failure behavior.

Authored by Codex (GPT-6).
