### PR TITLE
Add hosted web animation fixture for encoder testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This is a [Bun](https://bun.sh) workspace orchestrated with [Turborepo](https://
 | [`packages/serve-sim`](packages/serve-sim) | Vendored source for [`@expo/serve-sim`](http://www.github.com/expo/serve-sim). |
 | [`packages/serve-emu`](packages/serve-emu) | Source for the `serve-emu` workspace package, maintained in this monorepo. |
 | [`example`](example) | A minimal Expo app with the plugin installed. |
+| [`packages/web-animation-test`](packages/web-animation-test) | Minimal Expo web animation for comparing H.264 encoders. [Open the hosted fixture](https://krystof-web-animation-test.expo.app). |
 
 ## Getting started
 

--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,7 @@
     },
     "packages/expo-device-hub": {
       "name": "expo-device-hub",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "bin": {
         "expo-device-hub": "dist/server/cli.mjs",
       },
@@ -192,6 +192,18 @@
         "tailwindcss": "^4.1.7",
         "typescript": "^5.7.0",
         "werift": "^0.24.4",
+      },
+    },
+    "packages/web-animation-test": {
+      "name": "web-animation-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@expo/metro-runtime": "catalog:",
+        "expo": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "react-native": "catalog:",
+        "react-native-web": "catalog:",
       },
     },
   },
@@ -2178,6 +2190,8 @@
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "web-animation-test": ["web-animation-test@workspace:packages/web-animation-test"],
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "workspaces": {
     "packages": [
       "packages/expo-device-hub",
+      "packages/web-animation-test",
       "packages/@expo/hub-*",
       "packages/serve-sim/packages/*",
       "packages/serve-emu/packages/*",

--- a/packages/web-animation-test/.gitignore
+++ b/packages/web-animation-test/.gitignore
@@ -1,0 +1,2 @@
+.expo/
+dist/

--- a/packages/web-animation-test/README.md
+++ b/packages/web-animation-test/README.md
@@ -2,7 +2,13 @@
 
 A minimal Expo web app for comparing hardware and software H.264 encoding in
 Expo Device Hub. It preserves the original fixture: a yellow shape rotating once
-every two seconds over a striped background.
+every two seconds over a striped background, with FPS and total frame counters
+in place of the original heading and comparison text.
+
+The counters measure browser `requestAnimationFrame` callbacks, not encoded or
+decoded video frames. FPS updates once per second; the total increments every
+frame and resets on page reload. Returning from a hidden tab starts a fresh FPS
+sample so time spent in the background does not lower the next reading.
 
 Open [the hosted animation](https://krystof-web-animation-test.expo.app) in the
 device's browser, view the device through Expo Device Hub, and switch encoders to

--- a/packages/web-animation-test/README.md
+++ b/packages/web-animation-test/README.md
@@ -1,0 +1,31 @@
+# Web animation test
+
+A minimal Expo web app for comparing hardware and software H.264 encoding in
+Expo Device Hub. It preserves the original fixture: a yellow shape rotating once
+every two seconds over a striped background.
+
+Open [the hosted animation](https://krystof-web-animation-test.expo.app) in the
+device's browser, view the device through Expo Device Hub, and switch encoders to
+compare the same animation. No local server is needed.
+
+## Develop
+
+After following the repository's dependency setup, run from this directory:
+
+```sh
+bun start
+```
+
+## Deploy
+
+The app is linked to the personal
+[`@krystofwoldrich/web-animation-test`](https://expo.dev/accounts/krystofwoldrich/projects/web-animation-test)
+EAS project. Sign in with access to that project, then run from this directory:
+
+```sh
+bun run deploy
+```
+
+This exports the web app to `dist/` and deploys it to the stable testing URL above
+using EAS Hosting's production alias. To export without deploying, run
+`bun run build`. Generated files are ignored by Git.

--- a/packages/web-animation-test/app.json
+++ b/packages/web-animation-test/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "H.264 encoding test",
+    "slug": "web-animation-test",
+    "owner": "krystofwoldrich",
+    "platforms": [
+      "web"
+    ],
+    "web": {
+      "bundler": "metro",
+      "output": "single"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "7daafe62-9772-4adc-bd8d-80f4e71def8f"
+      }
+    }
+  }
+}

--- a/packages/web-animation-test/index.jsx
+++ b/packages/web-animation-test/index.jsx
@@ -1,0 +1,13 @@
+import '@expo/metro-runtime';
+import { createRoot } from 'react-dom/client';
+
+import './style.css';
+
+createRoot(document.getElementById('root')).render(
+  <>
+    <h1>H.264 encoding test</h1>
+    <section />
+    <div className="shape" />
+    <p>Hardware / software comparison</p>
+  </>
+);

--- a/packages/web-animation-test/index.jsx
+++ b/packages/web-animation-test/index.jsx
@@ -1,13 +1,60 @@
 import '@expo/metro-runtime';
+import { useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import './style.css';
 
+function FrameCounters() {
+  const fpsRef = useRef(null);
+  const framesRef = useRef(null);
+
+  useEffect(() => {
+    let totalFrames = 0;
+    let sampleFrames = 0;
+    let sampleStart = performance.now();
+    let animationFrame;
+
+    function resetSample() {
+      sampleFrames = 0;
+      sampleStart = performance.now();
+      fpsRef.current.textContent = '—';
+    }
+
+    function tick(now) {
+      totalFrames += 1;
+      sampleFrames += 1;
+      framesRef.current.textContent = String(totalFrames);
+
+      const elapsed = now - sampleStart;
+      if (elapsed >= 1000) {
+        fpsRef.current.textContent = String(Math.round((sampleFrames * 1000) / elapsed));
+        sampleFrames = 0;
+        sampleStart = now;
+      }
+
+      animationFrame = requestAnimationFrame(tick);
+    }
+
+    animationFrame = requestAnimationFrame(tick);
+    document.addEventListener('visibilitychange', resetSample);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      document.removeEventListener('visibilitychange', resetSample);
+    };
+  }, []);
+
+  return (
+    <div className="counters" role="group" aria-label="Browser frame counters">
+      <span>FPS: <span ref={fpsRef}>—</span></span>
+      <span>Frames: <span ref={framesRef}>0</span></span>
+    </div>
+  );
+}
+
 createRoot(document.getElementById('root')).render(
   <>
-    <h1>H.264 encoding test</h1>
+    <FrameCounters />
     <section />
     <div className="shape" />
-    <p>Hardware / software comparison</p>
   </>
 );

--- a/packages/web-animation-test/package.json
+++ b/packages/web-animation-test/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "web-animation-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Animated fixture for comparing hardware and software H.264 encoding.",
+  "main": "index.jsx",
+  "scripts": {
+    "start": "expo start --web",
+    "build": "expo export --platform web",
+    "deploy": "bun run build && bunx eas-cli@24.1.2 deploy --prod"
+  },
+  "dependencies": {
+    "@expo/metro-runtime": "catalog:",
+    "expo": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-native-web": "catalog:"
+  }
+}

--- a/packages/web-animation-test/style.css
+++ b/packages/web-animation-test/style.css
@@ -1,0 +1,47 @@
+body {
+  margin: 0;
+  background: #102020;
+  color: white;
+  font: 24px system-ui;
+  overflow: hidden;
+}
+
+#root {
+  display: block;
+}
+
+h1 {
+  font-size: 24px;
+  text-align: center;
+  margin-top: 28px;
+}
+
+section {
+  position: absolute;
+  inset: 170px 20px 60px;
+  overflow: hidden;
+  background: repeating-linear-gradient(45deg, #075e64 0 32px, #f6785f 32px 64px);
+}
+
+.shape {
+  position: absolute;
+  width: 65vw;
+  height: 65vw;
+  background: #ffda58;
+  border-radius: 20%;
+  animation: spin 2s linear infinite;
+  left: 17vw;
+  top: 200px;
+}
+
+p {
+  position: absolute;
+  bottom: 10px;
+  left: 20px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/web-animation-test/style.css
+++ b/packages/web-animation-test/style.css
@@ -10,10 +10,19 @@ body {
   display: block;
 }
 
-h1 {
-  font-size: 24px;
-  text-align: center;
-  margin-top: 28px;
+.counters {
+  position: fixed;
+  top: 28px;
+  left: 20px;
+  right: 20px;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px;
+  background: #102020;
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
 }
 
 section {
@@ -32,12 +41,6 @@ section {
   animation: spin 2s linear infinite;
   left: 17vw;
   top: 200px;
-}
-
-p {
-  position: absolute;
-  bottom: 10px;
-  left: 20px;
 }
 
 @keyframes spin {


### PR DESCRIPTION
The H.264 encoder comparison fixture needed a local server, making it awkward to open on test devices. Add it as a minimal, web-only Expo app in `packages/web-animation-test`, preserving the rotating shape, colors, and two-second animation. Replace the original heading and comparison text with live FPS and total frame counters.

The counters measure browser animation callbacks: FPS refreshes once per second, and the total increments each frame until page reload. FPS sampling restarts when tab visibility changes to exclude time spent in the background.

The app uses the workspace dependency catalog and is linked to the personal `@krystofwoldrich/web-animation-test` EAS project. `bun run deploy` exports and publishes it to a stable EAS Hosting URL; the package and repository READMEs link directly to the fixture.

Test URL: https://krystof-web-animation-test.expo.app

Validation:
- `bun install --frozen-lockfile` and `git diff --check` passed.
- `bun run build` successfully exported the Expo web app.
- Verified the live deployment in Chromium at mobile and desktop sizes: FPS is populated, the frame count increases, the original text is removed, and the shape keeps animating. No runtime errors.

— Codex (GPT-6)
