### PR TITLE
Select devices by URL and retain offline device views

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,8 +96,10 @@
         "@swc/core": "^1.15.43",
         "@types/react": "~19.2.2",
         "@types/react-dom": "~19.2.0",
+        "@types/react-test-renderer": "^19.1.0",
         "oxfmt": "^0.56.0",
         "oxlint": "^1.71.0",
+        "react-test-renderer": "19.2.3",
         "typescript": "~6.0.3",
       },
       "peerDependencies": {

--- a/packages/@expo/hub-components/package.json
+++ b/packages/@expo/hub-components/package.json
@@ -56,8 +56,10 @@
     "@swc/core": "^1.15.43",
     "@types/react": "~19.2.2",
     "@types/react-dom": "~19.2.0",
+    "@types/react-test-renderer": "^19.1.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "react-test-renderer": "19.2.3",
     "typescript": "~6.0.3"
   },
   "engines": {

--- a/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/camera-section.test.tsx
@@ -157,3 +157,17 @@ describe("CameraSection", () => {
     expect(alert?.[1]).toBe("The emulator rejected the image.");
   });
 });
+
+test("retains camera previews while disabling every offline upload control", () => {
+  const html = renderToStaticMarkup(
+    <CameraSection client={cameraClient({ camera: cameraStatus(true) })} available={false} defaultOpen />
+  );
+  expect(html).toContain('/camera/back.png');
+  expect(html).toContain('/camera/front.png');
+  const pickers = [...html.matchAll(/<div[^>]*role="button"[^>]*>/g)].map((match) => match[0]);
+  expect(pickers).toHaveLength(2);
+  for (const picker of pickers) expect(picker).toContain('aria-disabled="true"');
+  const inputs = [...html.matchAll(/<input[^>]*type="file"[^>]*>/g)].map((match) => match[0]);
+  expect(inputs).toHaveLength(2);
+  for (const input of inputs) expect(input).toContain('disabled');
+});

--- a/packages/@expo/hub-components/src/__tests__/dashboard-device-updates.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/dashboard-device-updates.test.tsx
@@ -1,0 +1,215 @@
+import '../../../../expo-device-hub/types.d.ts';
+
+import { expect, spyOn, test } from 'bun:test';
+import * as hubClient from '@expo/hub-client';
+import { act, type ReactPortal } from 'react';
+import * as ReactDOM from 'react-dom';
+import { create, type ReactTestRenderer } from 'react-test-renderer';
+
+import Dashboard from '../../../../expo-device-hub/src/Dashboard';
+import { DEVICE_LIST_MESSAGE_TYPE } from '../../../../expo-device-hub/src/device-list-protocol';
+import { useDashboardStore } from '../../../../expo-device-hub/src/dashboard/dashboardStore';
+import { useDeviceSessionStore } from '../../../../expo-device-hub/src/dashboard/deviceSessionStore';
+import { type DeviceList } from '../../../../expo-device-hub/src/dashboard/useDevices';
+import { NOOP_DEVICE_CLIENT } from '../../../hub-client/src/useNoopDeviceClient';
+import { type Device } from '../dashboard/data';
+
+const IPHONE: Device = {
+  id: 'A671E25C-3A15-4738-8B49-8FACD3AE5ACD',
+  name: 'Opened iPhone',
+  version: 'iOS 27.0',
+  platform: 'ios',
+  booted: true,
+  physical: false,
+  supported: true,
+  deviceFrame: 'ios:iphone-17-pro',
+};
+
+class FakeWebSocket {
+  static sockets: FakeWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.sockets.push(this);
+  }
+
+  close() {}
+
+  snapshot(devices: DeviceList) {
+    this.onmessage?.({ data: JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices }) });
+  }
+}
+
+function browserEnvironment(path: string) {
+  const events = new EventTarget();
+  let location = new URL(path, 'http://localhost:8081');
+  const browser = {
+    __EXPO_DEVICE_HUB_BASE_PATH__: '',
+    innerWidth: 1440,
+    isSecureContext: true,
+    localStorage: { getItem: () => null, setItem: () => {} },
+    get location() {
+      return location;
+    },
+    history: {
+      state: null,
+      pushState(_state: unknown, _unused: string, url: string) {
+        location = new URL(url, location);
+      },
+      replaceState(_state: unknown, _unused: string, url: string) {
+        location = new URL(url, location);
+      },
+    },
+    matchMedia: (query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      addEventListener() {},
+      removeEventListener() {},
+    }),
+    setTimeout,
+    clearTimeout,
+    addEventListener: events.addEventListener.bind(events),
+    removeEventListener: events.removeEventListener.bind(events),
+    dispatchEvent: events.dispatchEvent.bind(events),
+  };
+  const replacements = {
+    window: browser,
+    document: {
+      body: {},
+      documentElement: { classList: { toggle() {}, remove() {} } },
+    },
+    WebSocket: FakeWebSocket,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  const descriptors = new Map(
+    Object.keys(replacements).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)])
+  );
+  for (const [key, value] of Object.entries(replacements)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  return {
+    browser,
+    restore() {
+      for (const [key, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else Reflect.deleteProperty(globalThis, key);
+      }
+    },
+  };
+}
+
+test('dashboard isolates device-list updates and retains the selected offline frame', async () => {
+  const environment = browserEnvironment(`/device/${IPHONE.id}`);
+  const previousSession = useDeviceSessionStore.getState();
+  const previousDashboard = useDashboardStore.getState();
+  useDeviceSessionStore.setState(useDeviceSessionStore.getInitialState(), true);
+  useDashboardStore.setState(useDashboardStore.getInitialState(), true);
+  FakeWebSocket.sockets = [];
+
+  // Count the actual DashboardLayout render through its viewer hook. The fake
+  // client avoids opening device transports while discovery and UI stay real.
+  const connectedClient = {
+    ...NOOP_DEVICE_CLIENT,
+    screen: { width: 2400, height: 1080, orientation: 'landscape_right' as const },
+  };
+  const viewer = spyOn(hubClient, 'useActiveDeviceClient').mockImplementation((target) =>
+    target ? connectedClient : NOOP_DEVICE_CLIENT
+  );
+  const portal = spyOn(ReactDOM, 'createPortal').mockImplementation(
+    (children) => children as ReactPortal
+  );
+  const fetchOptions = spyOn(globalThis, 'fetch').mockResolvedValue(
+    Response.json({ ios: { runtimes: [] }, android: { runtimes: [] } })
+  );
+  let renderer: ReactTestRenderer | undefined;
+
+  const row = (name: string) =>
+    renderer!.root.find(
+      (element) =>
+        element.type === 'button' && String(element.props['aria-label']).startsWith(`${name}, `)
+    );
+  const frame = () => renderer!.root.findByProps({ 'data-testid': 'device-screen-frame' });
+  const emit = async (devices: DeviceList) => {
+    const socket = FakeWebSocket.sockets.find((socket) => socket.url.endsWith('/api/devices/ws'));
+    expect(socket).toBeDefined();
+    await act(() => socket!.snapshot(devices));
+  };
+
+  try {
+    await act(async () => {
+      renderer = create(<Dashboard />);
+    });
+    const other: Device = { ...IPHONE, id: 'other-ios', name: 'Other iPhone' };
+    await emit({ simulators: [IPHONE, other], emulators: [] });
+    expect(row(IPHONE.name).props['aria-pressed']).toBe(true);
+    expect(environment.browser.location.pathname).toBe(`/device/${IPHONE.id}`);
+    const initialRenders = viewer.mock.calls.length;
+    const openedFrame = frame();
+    const frameStyle = openedFrame.props.style;
+    const deviceOptions = renderer!.root.findByProps({ 'aria-label': 'Device options' });
+    const optionCount = deviceOptions.findAllByType('button').length;
+
+    await emit({ simulators: structuredClone([IPHONE, other]), emulators: [] });
+    expect(viewer.mock.calls.length).toBe(initialRenders);
+
+    const renamed = { ...other, name: 'Renamed iPhone' };
+    await emit({ simulators: structuredClone([IPHONE, renamed]), emulators: [] });
+    expect(row('Renamed iPhone')).toBeDefined();
+    expect(viewer.mock.calls.length).toBe(initialRenders);
+
+    const android: Device = {
+      ...IPHONE,
+      id: '192.168.1.10:5555',
+      name: 'Pixel',
+      platform: 'android',
+      version: 'Android 17.0',
+      deviceFrame: 'android:pixel-10-pro',
+    };
+    await emit({ simulators: structuredClone([IPHONE, renamed]), emulators: [android] });
+    expect(row('Pixel')).toBeDefined();
+    expect(viewer.mock.calls.length).toBe(initialRenders);
+    await emit({ simulators: [{ ...IPHONE }], emulators: [{ ...android }] });
+    expect(viewer.mock.calls.length).toBe(initialRenders);
+    expect(frame()).toBe(openedFrame);
+
+    await emit({ simulators: [], emulators: [{ ...android }] });
+    expect(environment.browser.location.pathname).toBe(`/device/${IPHONE.id}`);
+    expect(row(IPHONE.name).props['aria-label']).toContain('Offline');
+    expect(
+      renderer!.root.findByProps({ 'data-testid': 'device-unavailable-screen' })
+    ).toBeDefined();
+    expect(frame()).toBe(openedFrame);
+    expect(frame().props.style).toEqual(frameStyle);
+    expect(renderer!.root.findByProps({ 'aria-label': 'Device options' })).toBe(deviceOptions);
+    expect(deviceOptions.findAllByType('button')).toHaveLength(optionCount);
+    expect(viewer.mock.calls.at(-1)?.[0]).toBeNull();
+
+    await act(() => row('Pixel').props.onClick());
+    expect(environment.browser.location.pathname).toBe('/device/192.168.1.10%3A5555');
+    expect(row('Pixel').props['aria-pressed']).toBe(true);
+    expect(
+      renderer!.root.findAll(
+        (element) =>
+          element.type === 'button' &&
+          String(element.props['aria-label']).startsWith(`${IPHONE.name}, `)
+      )
+    ).toHaveLength(0);
+    expect(
+      renderer!.root.findAllByProps({ 'data-testid': 'device-unavailable-screen' })
+    ).toHaveLength(0);
+    expect(viewer.mock.calls.at(-1)?.[0]).toMatchObject({
+      platform: 'android',
+      device: android.id,
+    });
+  } finally {
+    await act(() => renderer?.unmount());
+    viewer.mockRestore();
+    portal.mockRestore();
+    fetchOptions.mockRestore();
+    useDeviceSessionStore.setState(previousSession, true);
+    useDashboardStore.setState(previousDashboard, true);
+    environment.restore();
+  }
+});

--- a/packages/@expo/hub-components/src/__tests__/device-section-renders.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/device-section-renders.test.tsx
@@ -1,0 +1,119 @@
+import { expect, mock, spyOn, test } from 'bun:test';
+import { act } from 'react';
+import { create, type ReactTestRenderer } from 'react-test-renderer';
+
+import {
+  reconcileDeviceList,
+  type DeviceList,
+} from '../../../../expo-device-hub/src/dashboard/useDevices';
+import { DeviceListItem } from '../components/DeviceListItem';
+import * as compactStatus from '../components/useCompactAgentDeviceStatus';
+import { DeviceSection } from '../dashboard/DeviceSection';
+import { type Device } from '../dashboard/data';
+
+const IPHONE: Device = {
+  id: 'first-ios',
+  name: 'First iPhone',
+  version: 'iOS 27.0',
+  platform: 'ios',
+  booted: true,
+  physical: false,
+  supported: true,
+  deviceFrame: 'ios:iphone-17-pro',
+};
+
+test('device snapshots render only rows whose device data changes', async () => {
+  const environment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+  const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+
+  // This hook runs inside the actual DeviceListItem render. Count its stable
+  // row refs without substituting the row component or its memo boundary.
+  const renders = spyOn(compactStatus, 'useCompactAgentDeviceStatus').mockReturnValue(false);
+  const onSelect = mock((_id: string) => {});
+  const recent: Device[] = [];
+  const options = { runtimes: [] };
+  let devices: DeviceList = {
+    simulators: [IPHONE, { ...IPHONE, id: 'second-ios', name: 'Second iPhone' }],
+    emulators: [],
+  };
+  let renderer: ReactTestRenderer | undefined;
+
+  const section = () => (
+    <DeviceSection
+      title="Simulators"
+      addLabel="Add simulator"
+      kind="simulator"
+      emptyLabel="No simulators"
+      devices={devices.simulators}
+      recent={recent}
+      options={options}
+      selectedId={IPHONE.id}
+      onSelect={onSelect}
+    />
+  );
+  const update = async (snapshot: DeviceList) => {
+    devices = reconcileDeviceList(devices, snapshot);
+    await act(() => renderer!.update(section()));
+  };
+  const rowNames = () => renderer!.root.findAllByType(DeviceListItem).map((row) => row.props.name);
+  const renderCount = (ref: object) =>
+    renders.mock.calls.filter(([props]) => props.buttonRef === ref).length;
+
+  try {
+    await act(() => {
+      renderer = create(section());
+    });
+    expect(rowNames()).toEqual(['First iPhone', 'Second iPhone']);
+    expect(renders).toHaveBeenCalledTimes(2);
+    const firstRef = renders.mock.calls[0][0].buttonRef;
+    const secondRef = renders.mock.calls[1][0].buttonRef;
+
+    await update(JSON.parse(JSON.stringify(devices)));
+    expect(renderCount(firstRef)).toBe(1);
+    expect(renderCount(secondRef)).toBe(1);
+
+    const renamed = structuredClone(devices);
+    renamed.simulators[1].name = 'Renamed iPhone';
+    await update(renamed);
+    expect(rowNames()).toEqual(['First iPhone', 'Renamed iPhone']);
+    expect(renderCount(firstRef)).toBe(1);
+    expect(renderCount(secondRef)).toBe(2);
+
+    const third: Device = { ...IPHONE, id: 'third-ios', name: 'Third iPhone' };
+    await update({
+      ...structuredClone(devices),
+      simulators: [{ ...third }, ...structuredClone(devices.simulators)],
+    });
+    expect(rowNames()).toEqual(['Third iPhone', 'First iPhone', 'Renamed iPhone']);
+    expect(renders).toHaveBeenCalledTimes(4);
+    const thirdRef = renders.mock.calls[3][0].buttonRef;
+    expect(renderCount(firstRef)).toBe(1);
+    expect(renderCount(secondRef)).toBe(2);
+    expect(renderCount(thirdRef)).toBe(1);
+
+    await update({
+      ...structuredClone(devices),
+      simulators: structuredClone(
+        devices.simulators.filter((device) => device.id !== 'second-ios')
+      ),
+    });
+    expect(rowNames()).toEqual(['Third iPhone', 'First iPhone']);
+    expect(renders).toHaveBeenCalledTimes(4);
+    expect(renderCount(firstRef)).toBe(1);
+    expect(renderCount(thirdRef)).toBe(1);
+
+    await update({ ...structuredClone(devices), simulators: [...devices.simulators].reverse() });
+    expect(rowNames()).toEqual(['First iPhone', 'Third iPhone']);
+    expect(renders).toHaveBeenCalledTimes(4);
+
+    renderer!.root.findAllByType(DeviceListItem)[1].props.onClick();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('third-ios');
+  } finally {
+    await act(() => renderer?.unmount());
+    renders.mockRestore();
+    if (previousActEnvironment === undefined) delete environment.IS_REACT_ACT_ENVIRONMENT;
+    else environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});

--- a/packages/@expo/hub-components/src/__tests__/offline-device.test.tsx
+++ b/packages/@expo/hub-components/src/__tests__/offline-device.test.tsx
@@ -1,0 +1,339 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { type DeviceClient } from '@expo/hub-client';
+import { NOOP_DEVICE_CLIENT } from '../../../hub-client/src/useNoopDeviceClient';
+import { DeviceListItem } from '../components/DeviceListItem';
+import { type Device } from '../dashboard/data';
+import { type DeviceFrameAssets } from '../dashboard/deviceFrame';
+import { DeviceOptionsSection } from '../dashboard/DeviceOptionsSection';
+import { DeviceSection } from '../dashboard/DeviceSection';
+import { LogControls } from '../dashboard/LogControls';
+import { LogSidebar } from '../dashboard/LogSidebar';
+import { PhoneFrame } from '../dashboard/PhoneFrame';
+import { RecentDevicesModal } from '../dashboard/RecentDevicesModal';
+import { Select } from '../components/Select';
+import { StreamOptionsSection } from '../dashboard/StreamOptionsSection';
+import { StreamPanel } from '../dashboard/StreamPanel';
+
+const DEVICE: Device = {
+  id: 'A671E25C-3A15-4738-8B49-8FACD3AE5ACD',
+  name: 'iPhone 17 Pro',
+  version: 'iOS 27.0',
+  platform: 'ios',
+  booted: true,
+  physical: false,
+  supported: true,
+  deviceFrame: 'ios:iphone-17-pro',
+};
+
+const FRAME_ASSET = {
+  src: '/iphone.png',
+  width: 2620,
+  height: 5420,
+  screen: { x: 104, y: 88, width: 2412, height: 5244 },
+  screenRadius: 340,
+};
+
+const FRAME_ASSETS: DeviceFrameAssets = {
+  'ios:iphone-17-pro': FRAME_ASSET,
+  'android:pixel-9': FRAME_ASSET,
+  'android:pixel-10-pro': FRAME_ASSET,
+};
+
+const CLIENT: DeviceClient = {
+  ...NOOP_DEVICE_CLIENT,
+  status: 'streaming',
+  appearance: 'dark',
+  hardwareKeyboardConnected: true,
+  deviceSettings: { appearance: 'dark', 'text-size': 'large' },
+  capabilities: {
+    ...NOOP_DEVICE_CLIENT.capabilities,
+    deviceSettings: true,
+    streamSettings: { maxDimension: true },
+  },
+  streamSettings: {
+    mjpegFps: 30,
+    mjpegQuality: 0.7,
+    maxDimension: 1920,
+    h264Bitrate: 6000000,
+    h264Fps: 30,
+  },
+  streamCapabilities: {
+    modeAvailability: { mjpeg: true, h264: true, webrtc: true },
+    httpCodecs: ['auto', 'h264', 'mjpeg'],
+    webRtcCodecs: ['h264'],
+  },
+};
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+function buttonTags(markup: string) {
+  return [...markup.matchAll(/<button[^>]*>/g)].map((match) => match[0]);
+}
+
+function buttonNamed(markup: string, name: string) {
+  const button = buttonTags(markup).find((tag) => tag.includes(`aria-label="${name}"`));
+  expect(button).toBeDefined();
+  return button!;
+}
+
+function elementTag(markup: string, testId: string) {
+  return markup.match(new RegExp(`<[^>]*data-testid="${testId}"[^>]*>`))?.[0];
+}
+
+describe('offline selected device', () => {
+  test('retains landscape geometry after the client resets, and clears it when switching devices', async () => {
+    let renderer: ReactTestRenderer;
+    const props = {
+      device: DEVICE,
+      DeviceScreen: () => <div data-testid="live-screen" />,
+      displayScreen: (screen: DeviceClient['screen'] = null) => screen,
+      deviceFrameAssets: FRAME_ASSETS,
+    };
+    const client = {
+      ...CLIENT,
+      screen: { width: 2400, height: 1080, orientation: 'landscape_right' as const },
+    };
+    await act(() => {
+      renderer = create(<PhoneFrame {...props} client={client} />);
+    });
+    try {
+      const frame = renderer!.root.findByProps({ 'data-testid': 'device-screen-frame' });
+      const artwork = renderer!.root.findByProps({ 'data-testid': 'device-frame-artwork' });
+      const frameStyle = frame.props.style;
+      const artworkStyle = artwork.props.style;
+
+      await act(() => {
+        renderer!.update(<PhoneFrame {...props} client={NOOP_DEVICE_CLIENT} available={false} />);
+      });
+      expect(renderer!.root.findByProps({ 'data-testid': 'device-screen-frame' })).toBe(frame);
+      expect(frame.props.style).toEqual(frameStyle);
+      expect(artwork.props.style).toEqual(artworkStyle);
+      expect(artwork.props.style.transform).toContain('rotate(-90deg)');
+      expect(
+        renderer!.root.findAllByProps({ 'data-testid': 'device-unavailable-screen' })
+      ).toHaveLength(1);
+
+      await act(() => {
+        renderer!.update(
+          <PhoneFrame
+            {...props}
+            device={{ ...DEVICE, id: 'another-device' }}
+            client={NOOP_DEVICE_CLIENT}
+            available={false}
+          />
+        );
+      });
+      expect(artwork.props.style.transform).toContain('rotate(0deg)');
+    } finally {
+      await act(() => renderer!.unmount());
+    }
+  });
+
+  test('retains inspector values when the client resets and clears them for a different device', async () => {
+    // The renderer has no DOM nodes; these browser globals support the closed
+    // Radix selects and reduced-motion subscriptions exercised by the inspector.
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousForm = Object.getOwnPropertyDescriptor(globalThis, 'HTMLFormElement');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { clearTimeout, setTimeout },
+    });
+    Object.defineProperty(globalThis, 'HTMLFormElement', { configurable: true, value: class {} });
+    let renderer: ReactTestRenderer;
+    const props = {
+      device: DEVICE,
+      onShowDeviceFrameChange: () => {},
+      onShutdown: () => {},
+      onRemove: () => {},
+    };
+    try {
+      await act(() => {
+        renderer = create(<LogSidebar {...props} client={CLIENT} />);
+      });
+      const deviceOptions = renderer!.root.findByType(DeviceOptionsSection);
+      await act(() => {
+        renderer!.update(<LogSidebar {...props} client={NOOP_DEVICE_CLIENT} available={false} />);
+      });
+      expect(renderer!.root.findByType(DeviceOptionsSection)).toBe(deviceOptions);
+      expect(deviceOptions.props.client).toBe(CLIENT);
+      expect(deviceOptions.props.available).toBeFalse();
+      const appearance = renderer!.root
+        .findAllByType(Select)
+        .find((node) => node.props.ariaLabel === 'Appearance');
+      expect(appearance?.props.value).toBe('dark');
+      expect(appearance?.props.disabled).toBeTrue();
+      expect(renderer!.root.findAllByType(StreamOptionsSection)).toHaveLength(1);
+
+      await act(() => {
+        renderer!.update(
+          <LogSidebar
+            {...props}
+            device={{ ...DEVICE, id: 'another-device' }}
+            client={NOOP_DEVICE_CLIENT}
+            available={false}
+          />
+        );
+      });
+      expect(deviceOptions.props.client).toBe(NOOP_DEVICE_CLIENT);
+      expect(renderer!.root.findAllByType(StreamOptionsSection)).toHaveLength(0);
+    } finally {
+      await act(() => renderer?.unmount());
+      if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+      if (previousForm) Object.defineProperty(globalThis, 'HTMLFormElement', previousForm);
+      else Reflect.deleteProperty(globalThis, 'HTMLFormElement');
+    }
+  });
+
+  test('offers the retained offline device in the restart picker', async () => {
+    let renderer: ReactTestRenderer;
+    const props = {
+      title: 'Simulators',
+      addLabel: 'Add simulator',
+      kind: 'simulator' as const,
+      emptyLabel: 'No booted simulators.',
+      devices: [DEVICE],
+      recent: [DEVICE],
+      options: { runtimes: [] },
+      selectedId: DEVICE.id,
+      onSelect: () => {},
+    };
+    await act(() => {
+      renderer = create(<DeviceSection {...props} offlineDeviceId={DEVICE.id} />);
+    });
+    try {
+      expect(renderer!.root.findByType(RecentDevicesModal).props.devices).toEqual([DEVICE]);
+      await act(() => renderer!.update(<DeviceSection {...props} />));
+      expect(renderer!.root.findByType(RecentDevicesModal).props.devices).toEqual([]);
+    } finally {
+      await act(() => renderer!.unmount());
+    }
+  });
+
+  test('replaces the stream inside the same frame and keeps the title and toolbar', () => {
+    const panelProps = {
+      device: DEVICE,
+      client: CLIENT,
+      DeviceScreen: () => <div data-testid="live-screen" />,
+      displayScreen: () => null,
+      deviceFrameAssets: FRAME_ASSETS,
+    };
+    const live = renderToStaticMarkup(<StreamPanel {...panelProps} />);
+    const offline = renderToStaticMarkup(<StreamPanel {...panelProps} available={false} />);
+
+    expect(live).toContain('data-testid="live-screen"');
+    expect(offline).not.toContain('data-testid="live-screen"');
+    expect(offline).not.toContain('data-testid="agent-device-overlay-clip"');
+    expect(offline).toContain('role="status" aria-live="polite"');
+    expect(offline).toContain('Device unavailable');
+    expect(offline).toContain('This device is offline. Its screen will return when it reconnects.');
+    expect(offline).toContain('>Offline</span>');
+    expect(offline).not.toContain('>Live</span>');
+    for (const testId of [
+      'device-frame-viewport',
+      'device-screen-frame',
+      'device-screen-clip',
+      'device-frame-artwork',
+    ]) {
+      expect(elementTag(offline, testId)).toBe(elementTag(live, testId));
+    }
+    for (const name of ['Save', 'Theme', 'Home', 'Reload', 'Rotate']) {
+      expect(buttonNamed(offline, name)).toContain('disabled=""');
+      expect(buttonNamed(live, name)).not.toContain('disabled=""');
+    }
+  });
+
+  test('labels a retained sidebar row Offline and clears its agent status', () => {
+    const markup = renderToStaticMarkup(
+      <DeviceListItem name={DEVICE.name} version={DEVICE.version} offline selected usedByAgent />
+    );
+
+    expect(markup).toContain('aria-label="iPhone 17 Pro, iOS 27.0, Offline"');
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain('>Offline</span>');
+    expect(markup).toContain('data-agent-device-status="inactive"');
+    expect(buttonTags(markup)[0]).not.toContain('disabled');
+  });
+
+  test('keeps device options in place with backend controls disabled and the frame toggle usable', () => {
+    const props = {
+      client: CLIENT,
+      deviceFrame: { available: true, visible: true, onVisibleChange: () => {} },
+      onShutdown: () => {},
+      onRemove: () => {},
+    };
+    const live = renderToStaticMarkup(<DeviceOptionsSection {...props} />);
+    const offline = renderToStaticMarkup(<DeviceOptionsSection {...props} available={false} />);
+    const liveButtons = buttonTags(live);
+    const offlineButtons = buttonTags(offline);
+
+    expect(offlineButtons).toHaveLength(liveButtons.length);
+    expect(buttonNamed(offline, 'Appearance')).toContain('disabled=""');
+    expect(buttonNamed(offline, 'Text size')).toContain('disabled=""');
+    expect(buttonNamed(offline, 'Show device frame')).not.toContain('disabled=""');
+    expect(offline).toContain('Hardware keyboard');
+    expect(offline).toContain('Software keyboard');
+    expect(offline).toContain('Shut down device');
+    expect(offline).toContain('Remove device');
+    // Only the section collapse button and viewer-local frame toggle remain enabled.
+    expect(offlineButtons.filter((tag) => !tag.includes('disabled=""'))).toHaveLength(2);
+  });
+
+  test('keeps transport and HTTP codec preferences available while disabling host encoder controls', () => {
+    const markup = renderToStaticMarkup(
+      <StreamOptionsSection
+        client={CLIENT}
+        available={false}
+        defaultOpen
+        onStreamModeChange={() => {}}
+        onHttpCodecChange={() => {}}
+      />
+    );
+
+    expect(buttonNamed(markup, 'Stream transport')).not.toContain('disabled=""');
+    expect(buttonNamed(markup, 'HTTP codec')).not.toContain('disabled=""');
+    expect(buttonNamed(markup, 'Max size')).toContain('disabled=""');
+  });
+
+  test('disables log collection controls while the selected device is unavailable', () => {
+    const markup = renderToStaticMarkup(
+      <LogControls
+        count={8}
+        running={false}
+        disabled
+        onStart={() => {}}
+        onStop={() => {}}
+        onClear={() => {}}
+      />
+    );
+    expect(buttonTags(markup)).toHaveLength(2);
+    expect(buttonTags(markup).every((tag) => tag.includes('disabled=""'))).toBeTrue();
+  });
+});
+
+test('disables the upstream hardware encoder control while retaining the offline selection', () => {
+  const client: DeviceClient = {
+    ...CLIENT,
+    platform: 'android',
+    streamSource: {
+      mode: 'grpc-screenshot',
+      grpcImageMode: 'rgb888',
+      encoder: 'hardware',
+      encoderName: 'h264_videotoolbox',
+      availableEncoders: ['software', 'hardware'],
+      inputSource: 'grpc',
+      availableInputSources: ['grpc', 'scrcpy'],
+      availableModes: ['grpc-screenshot', 'scrcpy'],
+      sessionGeneration: 1,
+    },
+  };
+  const html = renderToStaticMarkup(
+    <StreamOptionsSection client={client} available={false} defaultOpen />
+  );
+  expect(buttonNamed(html, 'gRPC encoder')).toContain('disabled');
+  expect(html).toContain('Hardware');
+  expect(html).toContain('h264_videotoolbox');
+});

--- a/packages/@expo/hub-components/src/components/ControlButton.tsx
+++ b/packages/@expo/hub-components/src/components/ControlButton.tsx
@@ -20,7 +20,19 @@ export type ControlButtonProps = {
 
 export const ControlButton = forwardRef<HTMLButtonElement, ControlButtonProps>(
   function ControlButton(
-    { icon, label, style, onMouseEnter, onMouseLeave, onMouseDown, onMouseUp, onFocus, onBlur, ...rest },
+    {
+      icon,
+      label,
+      disabled,
+      style,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseDown,
+      onMouseUp,
+      onFocus,
+      onBlur,
+      ...rest
+    },
     ref
   ) {
     const [hovered, setHovered] = useState(false);
@@ -33,6 +45,7 @@ export const ControlButton = forwardRef<HTMLButtonElement, ControlButtonProps>(
         <button
           ref={ref}
           type="button"
+          disabled={disabled}
           aria-label={label}
           onMouseEnter={(event) => {
             setHovered(true);
@@ -70,13 +83,13 @@ export const ControlButton = forwardRef<HTMLButtonElement, ControlButtonProps>(
             // Concentric with the surrounding group (radius.xl minus its padding).
             borderRadius: `calc(${radius.xl} - 4px)`,
             outline: 'none',
-            backgroundColor: hovered ? bg.hover : 'transparent',
+            backgroundColor: hovered && !disabled ? bg.hover : 'transparent',
             boxShadow: focused ? `0 0 0 2px ${border.secondary}` : 'none',
-            color: iconColor.default,
-            cursor: 'pointer',
+            color: disabled ? iconColor.quaternary : iconColor.default,
+            cursor: disabled ? 'not-allowed' : 'pointer',
             fontFamily: 'inherit',
             transition: 'background-color 150ms ease, transform 100ms ease',
-            transform: pressed ? 'scale(0.96)' : undefined,
+            transform: pressed && !disabled ? 'scale(0.96)' : undefined,
             ...style,
           }}
           {...rest}>

--- a/packages/@expo/hub-components/src/components/DeviceListItem.tsx
+++ b/packages/@expo/hub-components/src/components/DeviceListItem.tsx
@@ -16,6 +16,8 @@ export type DeviceListItemProps = {
   unsupported?: boolean;
   usedByAgent?: boolean;
   selected?: boolean;
+  /** Selected device retained in the list until the viewer switches away. */
+  offline?: boolean;
   onClick?: () => void;
 };
 
@@ -25,6 +27,7 @@ export function DeviceListItem({
   unsupported = false,
   usedByAgent = false,
   selected = false,
+  offline = false,
   onClick,
 }: DeviceListItemProps) {
   const [hovered, setHovered] = useState(false);
@@ -68,7 +71,7 @@ export function DeviceListItem({
       style={style}
       onClick={onClick}
       aria-pressed={selected}
-      aria-label={`${name}, ${version}${usedByAgent ? ', used by agent' : ''}`}
+      aria-label={`${name}, ${version}${offline ? ', Offline' : usedByAgent ? ', used by agent' : ''}`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
         setHovered(false);
@@ -110,7 +113,7 @@ export function DeviceListItem({
           {name}
         </span>
         <AgentDeviceStatus
-          active={usedByAgent}
+          active={!offline && usedByAgent}
           compact={compactAgentStatus}
           labelRef={statusLabelRef}
         />
@@ -124,7 +127,7 @@ export function DeviceListItem({
           whiteSpace: 'nowrap',
           flexShrink: 0,
         }}>
-        {version}
+        {offline ? 'Offline' : version}
       </span>
     </button>
   );

--- a/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/CameraSection.tsx
@@ -38,10 +38,13 @@ function feedStatus(feed: DeviceCameraFeed) {
 export function CameraSection({
   client,
   defaultOpen = false,
+  available = true,
 }: {
   client: DeviceClient;
   /** Whether the section is initially expanded. */
   defaultOpen?: boolean;
+  /** Retain camera previews while preventing changes to an offline device. */
+  available?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const inputs = useRef<Record<DeviceCameraFacing, HTMLInputElement | null>>({
@@ -68,7 +71,7 @@ export function CameraSection({
 
             const label = FACING_LABELS[facing];
             const pending = client.cameraPending.has(facing);
-            const disabled = pending || !wired;
+            const disabled = !available || pending || !wired;
             const pickerHandlers = disabled
               ? {}
               : {
@@ -76,7 +79,7 @@ export function CameraSection({
                   onDrop: (event: DragEvent<HTMLDivElement>) => {
                     event.preventDefault();
                     const file = event.dataTransfer.files[0];
-                    if (file) client.setCameraImage(facing, file);
+                    if (file && !disabled) client.setCameraImage(facing, file);
                   },
                   onClick: () => openPicker(facing),
                   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
@@ -155,10 +158,11 @@ export function CameraSection({
                     inputs.current[facing] = node;
                   }}
                   type="file"
+                  disabled={disabled}
                   accept="image/png"
                   onChange={(event) => {
                     const file = event.target.files?.[0];
-                    if (file) client.setCameraImage(facing, file);
+                    if (file && !disabled) client.setCameraImage(facing, file);
                     event.target.value = "";
                   }}
                   style={{ display: "none" }}

--- a/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceOptionsSection.tsx
@@ -97,6 +97,7 @@ export function DeviceOptionsSection({
   client,
   deviceFrame,
   showDeviceSettings = true,
+  available = true,
   onShutdown,
   onRemove,
 }: {
@@ -104,6 +105,8 @@ export function DeviceOptionsSection({
   deviceFrame?: DeviceFrameOption;
   /** Whether backend-controlled appearance and accessibility settings are available. */
   showDeviceSettings?: boolean;
+  /** Disable backend actions while retaining their last known values. */
+  available?: boolean;
   /** Shut the device down on the host. */
   onShutdown?: () => void;
   /** Remove/delete the device on the host. Omit for physical devices. */
@@ -127,11 +130,11 @@ export function DeviceOptionsSection({
   }
 
   function disabled(key: DeviceSettingKey) {
-    return settings === null || pending.has(key);
+    return !available || settings === null || pending.has(key);
   }
 
   function setValue(key: DeviceSettingKey, nextValue: string) {
-    if (settings !== null && !pending.has(key)) client?.setDeviceSetting(key, nextValue);
+    if (!disabled(key)) client?.setDeviceSetting(key, nextValue);
   }
 
   function settingSelect(key: DeviceSettingKey, label: string, options: SelectOption[]) {
@@ -177,7 +180,7 @@ export function DeviceOptionsSection({
         settingSelect(
           'text-size',
           'Text size',
-          platform === 'android' ? ANDROID_TEXT_SIZE_OPTIONS : TEXT_SIZE_OPTIONS,
+          platform === 'android' ? ANDROID_TEXT_SIZE_OPTIONS : TEXT_SIZE_OPTIONS
         )}
 
       {showDeviceSettings && platform === 'android' && visible('display-size') && (
@@ -207,7 +210,7 @@ export function DeviceOptionsSection({
                 onChange={(checked) => setValue(key, checked ? 'on' : 'off')}
               />
             </SidebarRow>
-          ) : null,
+          ) : null
         )}
 
       {deviceFrame && (
@@ -225,15 +228,19 @@ export function DeviceOptionsSection({
         </SidebarRow>
       )}
 
-      {keyboardVisible && client && <KeyboardSection client={client} />}
+      {keyboardVisible && client && <KeyboardSection client={client} disabled={!available} />}
 
       {client && platform === 'android' && (
         <>
           <SidebarRow label="Back button">
-            <SidebarActionButton onClick={() => client.pressButton('back')}>Press</SidebarActionButton>
+            <SidebarActionButton disabled={!available} onClick={() => client.pressButton('back')}>
+              Press
+            </SidebarActionButton>
           </SidebarRow>
           <SidebarRow label="Recents button">
-            <SidebarActionButton onClick={() => client.pressButton('recents')}>
+            <SidebarActionButton
+              disabled={!available}
+              onClick={() => client.pressButton('recents')}>
               Press
             </SidebarActionButton>
           </SidebarRow>
@@ -242,13 +249,15 @@ export function DeviceOptionsSection({
 
       {client && onShutdown && (
         <SidebarRow label="Shut down device">
-          <SidebarActionButton onClick={onShutdown}>Shut down</SidebarActionButton>
+          <SidebarActionButton disabled={!available} onClick={onShutdown}>
+            Shut down
+          </SidebarActionButton>
         </SidebarRow>
       )}
 
       {client && onRemove && (
         <SidebarRow label="Remove device">
-          <SidebarActionButton destructive onClick={onRemove}>
+          <SidebarActionButton disabled={!available} destructive onClick={onRemove}>
             Remove
           </SidebarActionButton>
         </SidebarRow>

--- a/packages/@expo/hub-components/src/dashboard/DeviceSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/DeviceSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 
 import { DeviceListItem, PlusIcon, bg, border, icon, radius, text, textSize } from '../primitives';
 import { RecentDevicesModal } from './RecentDevicesModal';
@@ -30,12 +30,14 @@ export type DeviceSectionProps = {
   options: NewDeviceOptions;
   agentDeviceIds?: readonly string[];
   selectedId: string;
+  /** Retained selected device missing from the running-device list. */
+  offlineDeviceId?: string;
   onSelect: (id: string) => void;
   /** Starts the existing or newly configured device selected in the modal. */
   onAdd?: (target: AddDeviceTarget) => Promise<AddDeviceOutcome>;
 };
 
-export function DeviceSection({
+export const DeviceSection = memo(function DeviceSection({
   title,
   addLabel,
   kind,
@@ -45,6 +47,7 @@ export function DeviceSection({
   options,
   agentDeviceIds = [],
   selectedId,
+  offlineDeviceId,
   onSelect,
   onAdd,
 }: DeviceSectionProps) {
@@ -52,8 +55,10 @@ export function DeviceSection({
   const [addPressed, setAddPressed] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
 
-  // Don't offer devices that are already in this section's list.
-  const shownIds = new Set(devices.map((device) => device.id));
+  // A retained offline row can still be restarted from the add-device picker.
+  const shownIds = new Set(
+    devices.filter((device) => device.id !== offlineDeviceId).map((device) => device.id)
+  );
   const candidates = recent.filter((device) => !shownIds.has(device.id));
 
   return (
@@ -107,14 +112,13 @@ export function DeviceSection({
           </p>
         ) : (
           devices.map((device) => (
-            <DeviceListItem
+            <DeviceRow
               key={device.id}
-              name={device.name}
-              version={device.version}
-              unsupported={!device.supported}
-              usedByAgent={agentDeviceIds.includes(device.id)}
+              device={device}
+              offline={device.id === offlineDeviceId}
+              usedByAgent={device.id !== offlineDeviceId && agentDeviceIds.includes(device.id)}
               selected={device.id === selectedId}
-              onClick={() => onSelect(device.id)}
+              onSelect={onSelect}
             />
           ))
         )}
@@ -130,4 +134,32 @@ export function DeviceSection({
       />
     </section>
   );
-}
+});
+
+// Keep the per-device click closure behind this memo boundary. A new list can
+// insert, remove, or update a row without rerendering all its unchanged peers.
+const DeviceRow = memo(function DeviceRow({
+  device,
+  offline,
+  usedByAgent,
+  selected,
+  onSelect,
+}: {
+  device: Device;
+  offline: boolean;
+  usedByAgent: boolean;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <DeviceListItem
+      name={device.name}
+      version={device.version}
+      unsupported={!device.supported}
+      offline={offline}
+      usedByAgent={usedByAgent}
+      selected={selected}
+      onClick={() => onSelect(device.id)}
+    />
+  );
+});

--- a/packages/@expo/hub-components/src/dashboard/EventsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/EventsSection.tsx
@@ -6,10 +6,16 @@ import { LogControls } from './LogControls';
 import { LogList } from './LogList';
 
 /** Touch, UI, and command events reported by the selected device backend. */
-export function EventsSection({ client }: { client?: DeviceClient }) {
+export function EventsSection({
+  client,
+  available = true,
+}: {
+  client?: DeviceClient;
+  available?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const events = client?.events;
-  const enabled = client?.eventsEnabled ?? false;
+  const enabled = available && (client?.eventsEnabled ?? false);
   const attachEvents = client?.attachEvents;
   const detachEvents = client?.detachEvents;
   const rows: ReadonlyArray<DeviceLog> = useMemo(
@@ -19,21 +25,22 @@ export function EventsSection({ client }: { client?: DeviceClient }) {
         source: event.source,
         message: event.message,
       })),
-    [events],
+    [events]
   );
 
   useEffect(() => {
-    if (open) attachEvents?.();
+    if (available && open) attachEvents?.();
     else detachEvents?.();
 
     return () => detachEvents?.();
-  }, [attachEvents, detachEvents, open]);
+  }, [attachEvents, available, detachEvents, open]);
 
   return (
     <CollapsibleSection title="Events" open={open} onOpenChange={setOpen}>
       <LogControls
         count={events?.length ?? 0}
         running={enabled}
+        disabled={!available}
         unit="event"
         onClear={() => client?.clearEvents()}
         onStart={() => client?.attachEvents()}
@@ -43,9 +50,11 @@ export function EventsSection({ client }: { client?: DeviceClient }) {
         logs={rows}
         enabled={enabled}
         emptyMessage={
-          enabled
-            ? 'No events yet. Touch or interact with the device to see them here.'
-            : 'Events are paused. Press Start to observe device events.'
+          !available
+            ? 'Device offline. Events will be available when it reconnects.'
+            : enabled
+              ? 'No events yet. Touch or interact with the device to see them here.'
+              : 'Events are paused. Press Start to observe device events.'
         }
       />
     </CollapsibleSection>

--- a/packages/@expo/hub-components/src/dashboard/KeyboardSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/KeyboardSection.tsx
@@ -3,21 +3,27 @@ import { SidebarActionButton } from './SidebarActionButton';
 import { SidebarRow } from './SidebarRow';
 
 /** iOS keyboard connection controls. Browser HID forwarding stays independent. */
-export function KeyboardSection({ client }: { client: DeviceClient }) {
+export function KeyboardSection({
+  client,
+  disabled = false,
+}: {
+  client: DeviceClient;
+  disabled?: boolean;
+}) {
   const connected = client.hardwareKeyboardConnected;
 
   return (
     <>
       <SidebarRow label="Hardware keyboard">
         <SidebarActionButton
-          disabled={connected === null}
+          disabled={disabled || connected === null}
           onClick={() => client.setHardwareKeyboardConnected(!connected)}>
           Toggle
         </SidebarActionButton>
       </SidebarRow>
       <SidebarRow label="Software keyboard">
         <SidebarActionButton
-          disabled={connected === null}
+          disabled={disabled || connected === null}
           onClick={() => client.toggleSoftwareKeyboard()}>
           Toggle
         </SidebarActionButton>

--- a/packages/@expo/hub-components/src/dashboard/LogControls.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogControls.tsx
@@ -5,6 +5,7 @@ import { SidebarActionButton } from './SidebarActionButton';
 export function LogControls({
   count,
   running,
+  disabled = false,
   unit = 'line',
   onClear,
   onStart,
@@ -12,6 +13,7 @@ export function LogControls({
 }: {
   count: number;
   running: boolean;
+  disabled?: boolean;
   unit?: string;
   onClear: () => void;
   onStart: () => void;
@@ -41,10 +43,10 @@ export function LogControls({
         }}>
         {count} {count === 1 ? unit : `${unit}s`}
       </span>
-      <SidebarActionButton onClick={running ? onStop : onStart}>
+      <SidebarActionButton disabled={disabled} onClick={running ? onStop : onStart}>
         {running ? 'Stop' : 'Start'}
       </SidebarActionButton>
-      <SidebarActionButton disabled={count === 0} onClick={onClear}>
+      <SidebarActionButton disabled={disabled || count === 0} onClick={onClear}>
         Clear
       </SidebarActionButton>
     </div>

--- a/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogSidebar.tsx
@@ -1,8 +1,6 @@
-import {
-  type DeviceClient,
-  type DeviceHttpCodec,
-  type DeviceStreamMode,
-} from '@expo/hub-client';
+import { memo, useEffect, useRef } from 'react';
+
+import { type DeviceClient, type DeviceHttpCodec, type DeviceStreamMode } from '@expo/hub-client';
 import { SidebarToggle, bg } from '../primitives';
 import { CameraSection } from './CameraSection';
 import { SIDEBAR_SECTION_INSET } from './CollapsibleSection';
@@ -21,6 +19,8 @@ export type LogSidebarProps = {
   client?: DeviceClient;
   /** Selected device metadata used by viewer-local options. */
   device?: Device;
+  /** Preserve inspector options while the selected device is offline. */
+  available?: boolean;
   /** Viewer-local preference for supported device-frame artwork. */
   showDeviceFrame?: boolean;
   /** Change the viewer-local device-frame preference. */
@@ -47,10 +47,11 @@ export type LogSidebarProps = {
  * Right column: a compact inspector for the selected device, rendered directly
  * on the dashboard canvas so it matches the existing sidebar treatment.
  */
-export function LogSidebar({
+export const LogSidebar = memo(function LogSidebar({
   onToggle,
   client,
   device,
+  available = true,
   showDeviceFrame = true,
   onShowDeviceFrameChange,
   streamMode,
@@ -62,6 +63,20 @@ export function LogSidebar({
   onRemove,
   width = 400,
 }: LogSidebarProps) {
+  const lastClient = useRef<{ deviceId: string; client: DeviceClient } | null>(null);
+  useEffect(() => {
+    if (available && device && client) {
+      lastClient.current = { deviceId: device.id, client };
+    } else if (lastClient.current?.deviceId !== device?.id) {
+      lastClient.current = null;
+    }
+  }, [available, client, device]);
+  // The connection hook resets on disconnect. Retain the selected device's
+  // metadata and values so the same inspector sections and rows stay in place.
+  const inspectorClient =
+    !available && lastClient.current?.deviceId === device?.id
+      ? (lastClient.current?.client ?? client)
+      : client;
   const deviceFrame = device
     ? {
         available: isDeviceFrameProfileId(device.deviceFrame),
@@ -105,22 +120,24 @@ export function LogSidebar({
           overflowX: 'hidden',
           overflowY: 'auto',
         }}>
-        <CurrentAppSection client={client} />
-        {(client?.capabilities.deviceSettings ||
-          client?.platform === 'android' ||
+        <CurrentAppSection client={inspectorClient} />
+        {(inspectorClient?.capabilities.deviceSettings ||
+          inspectorClient?.platform === 'android' ||
           deviceFrame ||
-          (client && (onShutdown || onRemoveDevice))) && (
+          (inspectorClient && (onShutdown || onRemoveDevice))) && (
           <DeviceOptionsSection
-            client={client}
+            client={inspectorClient}
+            available={available}
             deviceFrame={deviceFrame}
-            showDeviceSettings={client?.capabilities.deviceSettings ?? false}
+            showDeviceSettings={inspectorClient?.capabilities.deviceSettings ?? false}
             onShutdown={onShutdown}
             onRemove={onRemoveDevice}
           />
         )}
-        {client?.streamCapabilities && (
+        {inspectorClient?.streamCapabilities && (
           <StreamOptionsSection
-            client={client}
+            client={inspectorClient}
+            available={available}
             streamMode={streamMode}
             httpCodec={httpCodec}
             streamModeAvailability={streamModeAvailability}
@@ -128,10 +145,14 @@ export function LogSidebar({
             onHttpCodecChange={onHttpCodecChange}
           />
         )}
-        {client?.capabilities.camera && <CameraSection client={client} />}
-        {client?.capabilities.events && <EventsSection client={client} />}
-        <LogsSection client={client} />
+        {inspectorClient?.capabilities.camera && (
+          <CameraSection client={inspectorClient} available={available} />
+        )}
+        {inspectorClient?.capabilities.events && (
+          <EventsSection client={inspectorClient} available={available} />
+        )}
+        <LogsSection client={inspectorClient} available={available} />
       </div>
     </aside>
   );
-}
+});

--- a/packages/@expo/hub-components/src/dashboard/LogsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/LogsSection.tsx
@@ -6,30 +6,43 @@ import { LogControls } from './LogControls';
 import { LogList } from './LogList';
 
 /** Device syslog/logcat output in its own collapsible inspector section. */
-export function LogsSection({ client }: { client?: DeviceClient }) {
+export function LogsSection({
+  client,
+  available = true,
+}: {
+  client?: DeviceClient;
+  available?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const logs = client?.logs ?? [];
-  const enabled = client?.logsEnabled ?? false;
+  const enabled = available && (client?.logsEnabled ?? false);
   const attachLogs = client?.attachLogs;
   const detachLogs = client?.detachLogs;
 
   useEffect(() => {
-    if (open) attachLogs?.();
+    if (available && open) attachLogs?.();
     else detachLogs?.();
 
     return () => detachLogs?.();
-  }, [attachLogs, detachLogs, open]);
+  }, [attachLogs, available, detachLogs, open]);
 
   return (
     <CollapsibleSection title="Logs" open={open} onOpenChange={setOpen}>
       <LogControls
         count={logs.length}
         running={enabled}
+        disabled={!available}
         onClear={() => client?.clearLogs()}
         onStart={() => client?.attachLogs()}
         onStop={() => client?.detachLogs()}
       />
-      <LogList logs={logs} enabled={enabled} />
+      <LogList
+        logs={logs}
+        enabled={enabled}
+        emptyMessage={
+          available ? undefined : 'Device offline. Logs will be available when it reconnects.'
+        }
+      />
     </CollapsibleSection>
   );
 }

--- a/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
+++ b/packages/@expo/hub-components/src/dashboard/PhoneFrame.tsx
@@ -1,4 +1,4 @@
-import { type ComponentType, type CSSProperties, useState } from 'react';
+import { type ComponentType, type CSSProperties, useEffect, useRef, useState } from 'react';
 
 import {
   type AgentInteraction,
@@ -6,7 +6,16 @@ import {
   type DeviceScreenProps,
   type ScreenSize,
 } from '@expo/hub-client';
-import { bg } from '../primitives';
+import {
+  CableDisconnectIcon,
+  bg,
+  border,
+  heading,
+  icon,
+  radius,
+  text,
+  textSize,
+} from '../primitives';
 import { AgentDeviceOverlay } from './AgentDeviceOverlay';
 import { type Device } from './data';
 import {
@@ -59,6 +68,7 @@ export function PhoneFrame({
   displayScreen,
   showDeviceFrame = true,
   deviceFrameAssets,
+  available = true,
 }: {
   device: Device;
   client?: DeviceClient;
@@ -71,15 +81,30 @@ export function PhoneFrame({
   showDeviceFrame?: boolean;
   /** Consumer-owned frame artwork so this shared component remains asset-system agnostic. */
   deviceFrameAssets?: DeviceFrameAssets;
+  /** Keep the frame visible while replacing an unavailable device's stream. */
+  available?: boolean;
 }) {
   const [hovered, setHovered] = useState(false);
   const [dismissedInteractionId, setDismissedInteractionId] = useState<string | null>(null);
+  const lastScreen = useRef<{ deviceId: string; screen: ScreenSize } | null>(null);
+  useEffect(() => {
+    if (available && client?.screen) {
+      lastScreen.current = { deviceId: device.id, screen: client.screen };
+    } else if (lastScreen.current?.deviceId !== device.id) {
+      lastScreen.current = null;
+    }
+  }, [available, client?.screen, device.id]);
   const { ratio: fallbackRatio, radiusFraction, squircle } = CONFIG[device.platform];
 
   // Prefer the live screen's aspect ratio once known, so the stream fills the
   // frame 1:1 instead of being stretched to the placeholder's body ratio. Uses
   // the orientation-corrected (display) size so a rotated device shows landscape.
-  const display = client ? displayScreen(client.screen) : null;
+  // Disconnecting resets the client's screen. Keep the last geometry for this
+  // device so an offline landscape screen and its controls do not jump.
+  const screen =
+    (available ? client?.screen : null) ??
+    (lastScreen.current?.deviceId === device.id ? lastScreen.current.screen : null);
+  const display = displayScreen(screen);
   const ratio = display && display.height > 0 ? display.width / display.height : fallbackRatio;
 
   // The container's width is the phone width; `cqw` on the child resolves
@@ -96,9 +121,9 @@ export function PhoneFrame({
   // the *short* side so the corners look the same in portrait and landscape.
   const radiusCqw = (radiusFraction / Math.max(ratio, 1)) * 100;
   const borderRadius = `${radiusCqw.toFixed(3)}cqw`;
-  const live = client && client.status !== 'idle';
+  const live = available && client && client.status !== 'idle';
   const overlayVisible =
-    !!agentInteraction && hovered && dismissedInteractionId !== agentInteraction.id;
+    available && !!agentInteraction && hovered && dismissedInteractionId !== agentInteraction.id;
 
   const deviceSurface = live ? (
     <DeviceScreen client={client} agentInteraction={agentInteraction} />
@@ -126,7 +151,7 @@ export function PhoneFrame({
   const framed = frameAsset
     ? deviceFramePresentation({
         asset: frameAsset,
-        orientation: client?.screen?.orientation,
+        orientation: screen?.orientation,
         displayRatio: ratio,
         maxScreenShortSide: MAX_SHORT_SIDE,
       })
@@ -145,7 +170,7 @@ export function PhoneFrame({
     <div
       data-testid="device-screen-frame"
       data-device-frame-kind={framed ? device.deviceFrame : 'none'}
-      data-agent-active={agentInteraction ? 'true' : 'false'}
+      data-agent-active={available && agentInteraction ? 'true' : 'false'}
       style={framed ? framed.frameStyle : { ...wrapperStyle, borderRadius }}
       onPointerEnter={(event) => {
         if (event.pointerType === 'mouse') setHovered(true);
@@ -158,9 +183,10 @@ export function PhoneFrame({
         <div
           data-testid="device-frame-stream-cover"
           style={framed ? framed.streamStyle : { position: 'absolute', inset: 0 }}>
-          {deviceSurface}
+          {available ? deviceSurface : null}
         </div>
-        {takeoverOverlay}
+        {!available && <UnavailableDeviceScreen />}
+        {available && takeoverOverlay}
       </div>
       {deviceFrameAssets
         ? (Object.keys(deviceFrameAssets) as (keyof DeviceFrameAssets)[]).map((kind) => {
@@ -183,6 +209,52 @@ export function PhoneFrame({
             );
           })
         : null}
+    </div>
+  );
+}
+
+/** Stays inside the calibrated screen opening, independent of stream cropping. */
+function UnavailableDeviceScreen() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="device-unavailable-screen"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        boxSizing: 'border-box',
+        padding: '24px 20px',
+        gap: 16,
+        backgroundColor: bg.screen,
+        textAlign: 'center',
+      }}>
+      <span
+        aria-hidden="true"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          width: 48,
+          height: 48,
+          border: `1px solid ${border.default}`,
+          borderRadius: radius.xl,
+          backgroundColor: bg.default,
+          color: icon.secondary,
+        }}>
+        <CableDisconnectIcon size={24} />
+      </span>
+      <div style={{ display: 'grid', gap: 8, maxWidth: 240 }}>
+        <span style={{ ...heading.base, color: text.default }}>Device unavailable</span>
+        <p style={{ ...textSize.sm, color: text.secondary, margin: 0 }}>
+          This device is offline. Its screen will return when it reconnects.
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
+++ b/packages/@expo/hub-components/src/dashboard/Sidebar.tsx
@@ -18,6 +18,7 @@ export function Sidebar({
   emulatorOptions,
   agentDeviceIds = [],
   selectedId,
+  offlineDeviceId,
   onSelect,
   onAddDevice,
   onToggle,
@@ -39,6 +40,8 @@ export function Sidebar({
   /** Devices with an unexpired Argent interaction. */
   agentDeviceIds?: readonly string[];
   selectedId: string;
+  /** Retained selected device missing from the running-device list. */
+  offlineDeviceId?: string;
   onSelect: (id: string) => void;
   /** Starts the existing or new device chosen in either add-device picker. */
   onAddDevice?: (target: AddDeviceTarget) => Promise<AddDeviceOutcome>;
@@ -83,6 +86,7 @@ export function Sidebar({
           options={simulatorOptions}
           agentDeviceIds={agentDeviceIds}
           selectedId={selectedId}
+          offlineDeviceId={offlineDeviceId}
           onSelect={onSelect}
           onAdd={onAddDevice}
         />
@@ -102,6 +106,7 @@ export function Sidebar({
           options={emulatorOptions}
           agentDeviceIds={agentDeviceIds}
           selectedId={selectedId}
+          offlineDeviceId={offlineDeviceId}
           onSelect={onSelect}
           onAdd={onAddDevice}
         />

--- a/packages/@expo/hub-components/src/dashboard/StreamControls.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamControls.tsx
@@ -58,6 +58,7 @@ export function StreamControls({
   onReload,
   onRotate,
   onSave,
+  disabled = false,
 }: {
   /** The device's current dark/light appearance; null while unknown. */
   appearance: ColorScheme | null;
@@ -71,6 +72,8 @@ export function StreamControls({
   onRotate?: () => void;
   /** Save a screenshot of the device (triggers a file download). */
   onSave?: () => void;
+  /** Preserve the toolbar while device actions are unavailable. */
+  disabled?: boolean;
 }) {
   return (
     <div
@@ -81,11 +84,13 @@ export function StreamControls({
         <ControlButton
           icon={<CameraIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />}
           label="Save"
+          disabled={disabled}
           onClick={onSave}
         />
         <ControlButton
           icon={<ThemeIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />}
           label="Theme"
+          disabled={disabled}
           role="switch"
           aria-checked={appearance === 'dark'}
           onClick={onToggleAppearance}
@@ -93,11 +98,13 @@ export function StreamControls({
         <ControlButton
           icon={<HomeIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />}
           label="Home"
+          disabled={disabled}
           onClick={onHome}
         />
         <ControlButton
           icon={<RefreshIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />}
           label="Reload"
+          disabled={disabled}
           onClick={onReload}
         />
       </ControlGroup>
@@ -105,6 +112,7 @@ export function StreamControls({
         <ControlButton
           icon={<RotateIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />}
           label="Rotate"
+          disabled={disabled}
           onClick={onRotate}
         />
       </ControlGroup>

--- a/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamOptionsSection.tsx
@@ -23,6 +23,8 @@ type StreamTransport = 'http' | 'websocket' | 'webrtc';
 
 export type StreamOptionsSectionProps = {
   client: DeviceClient;
+  /** Keep local transport choices enabled while backend controls are offline. */
+  available?: boolean;
   /** Whether the section is initially expanded. */
   defaultOpen?: boolean;
   streamMode?: DeviceStreamMode;
@@ -116,7 +118,7 @@ const BITRATE_OPTIONS: SelectOption[] = [
 function withCurrentValue(
   value: number,
   options: SelectOption[],
-  label: (value: number) => string,
+  label: (value: number) => string
 ) {
   const current = String(value);
   return options.some((option) => option.value === current)
@@ -127,6 +129,7 @@ function withCurrentValue(
 /** Viewer transport, backend-supported codecs, and optional runtime encoder controls. */
 export function StreamOptionsSection({
   client,
+  available = true,
   defaultOpen = false,
   streamMode = 'mjpeg',
   httpCodec,
@@ -149,10 +152,10 @@ export function StreamOptionsSection({
     client.platform === 'android' ? 'websocket' : 'http';
   const primaryTransportLabel = client.platform === 'android' ? 'WebSocket' : 'HTTP';
   const httpCodecOptions = HTTP_CODEC_OPTIONS.filter((option) =>
-    backend.httpCodecs.includes(option.value),
+    backend.httpCodecs.includes(option.value)
   );
   const webRtcCodecOptions = WEBRTC_CODEC_OPTIONS.filter((option) =>
-    backend.webRtcCodecs.includes(option.value),
+    backend.webRtcCodecs.includes(option.value)
   );
   const settings = client.streamSettings ?? DEFAULT_SETTINGS;
   const settingsCapabilities = client.capabilities.streamSettings;
@@ -161,15 +164,14 @@ export function StreamOptionsSection({
     client.streamSourceError ??
     (streamSource?.mode === 'grpc-screenshot' ? streamSource.hardwareEncoderError : undefined);
   const sourceOptions = STREAM_SOURCE_OPTIONS.filter((option) =>
-    streamSource?.availableModes.includes(option.value),
+    streamSource?.availableModes.includes(option.value)
   );
   const inputSourceOptions = GRPC_INPUT_SOURCE_OPTIONS.filter((option) =>
-    streamSource?.availableInputSources.includes(option.value),
+    streamSource?.availableInputSources.includes(option.value)
   );
   const settingsReady = client.streamSettings !== null;
-  const settingsDisabled = !settingsReady || client.streamSettingsPending;
-  const transport: StreamTransport =
-    activeStreamMode === 'webrtc' ? 'webrtc' : primaryTransport;
+  const settingsDisabled = !available || !settingsReady || client.streamSettingsPending;
+  const transport: StreamTransport = activeStreamMode === 'webrtc' ? 'webrtc' : primaryTransport;
   const setStreamStatsEnabled = client.setStreamStatsEnabled;
   const httpAvailable = availability.mjpeg || availability.h264;
   const transportOptions: ReadonlyArray<SelectOption<StreamTransport>> = [
@@ -178,9 +180,9 @@ export function StreamOptionsSection({
   ];
 
   useEffect(() => {
-    setStreamStatsEnabled(open && transport === 'webrtc');
+    setStreamStatsEnabled(available && open && transport === 'webrtc');
     return () => setStreamStatsEnabled(false);
-  }, [open, setStreamStatsEnabled, transport]);
+  }, [available, open, setStreamStatsEnabled, transport]);
 
   function httpCodecAvailable(codec: DeviceHttpCodec): boolean {
     if (codec === 'h264') return availability.h264;
@@ -206,9 +208,7 @@ export function StreamOptionsSection({
   const selectedWebRtcCodec = backend.webRtcCodecs.includes(client.webRtcCodec)
     ? client.webRtcCodec
     : (webRtcCodecOptions[0]?.value ?? client.webRtcCodec);
-  const h264Active =
-    transport === 'webrtc' ||
-    (availability.h264 && selectedHttpCodec !== 'mjpeg');
+  const h264Active = transport === 'webrtc' || (availability.h264 && selectedHttpCodec !== 'mjpeg');
 
   function httpMode(codec: DeviceHttpCodec): DeviceStreamMode {
     if (codec === 'mjpeg') return 'mjpeg';
@@ -227,7 +227,7 @@ export function StreamOptionsSection({
 
   function patchSetting<Key extends keyof DeviceStreamEncoderSettings>(
     key: Key,
-    value: DeviceStreamEncoderSettings[Key],
+    value: DeviceStreamEncoderSettings[Key]
   ) {
     if (!settingsDisabled) client.updateStreamSettings({ [key]: value });
   }
@@ -235,8 +235,7 @@ export function StreamOptionsSection({
   const restricted =
     (backend.modeAvailability.h264 && !streamModeAvailability.h264) ||
     (backend.modeAvailability.webrtc && !streamModeAvailability.webrtc);
-  const hostWebRtcDisabled =
-    client.platform === 'android' && !backend.modeAvailability.webrtc;
+  const hostWebRtcDisabled = client.platform === 'android' && !backend.modeAvailability.webrtc;
 
   return (
     <CollapsibleSection title="Stream options" open={open} onOpenChange={setOpen}>
@@ -247,7 +246,7 @@ export function StreamOptionsSection({
               ariaLabel="Stream source"
               options={sourceOptions}
               value={streamSource.mode}
-              disabled={client.streamSourcePending}
+              disabled={!available || client.streamSourcePending}
               onChange={client.setStreamSource}
             />
           </SidebarRow>
@@ -261,7 +260,7 @@ export function StreamOptionsSection({
                 ariaLabel="Input source"
                 options={inputSourceOptions}
                 value={streamSource.inputSource}
-                disabled={client.streamSourcePending}
+                disabled={!available || client.streamSourcePending}
                 onChange={client.setGrpcInputSource}
               />
             </SidebarRow>
@@ -271,7 +270,7 @@ export function StreamOptionsSection({
               ariaLabel="gRPC image mode"
               options={GRPC_IMAGE_MODE_OPTIONS}
               value={streamSource.grpcImageMode}
-              disabled={client.streamSourcePending}
+              disabled={!available || client.streamSourcePending}
               onChange={client.setGrpcImageMode}
             />
           </SidebarRow>
@@ -283,7 +282,7 @@ export function StreamOptionsSection({
                 disabled: !streamSource.availableEncoders.includes(option.value),
               }))}
               value={streamSource.encoder}
-              disabled={client.streamSourcePending}
+              disabled={!available || client.streamSourcePending}
               onChange={client.setGrpcEncoder}
             />
           </SidebarRow>
@@ -324,7 +323,7 @@ export function StreamOptionsSection({
             ariaLabel="WebRTC codec"
             options={webRtcCodecOptions}
             value={selectedWebRtcCodec}
-            disabled={transport !== 'webrtc' || !availability.webrtc}
+            disabled={!available || transport !== 'webrtc' || !availability.webrtc}
             onChange={(codec: DeviceWebRtcCodec) => client.setWebRtcCodec(codec)}
           />
         </SidebarRow>
@@ -337,7 +336,9 @@ export function StreamOptionsSection({
         </SectionNote>
       )}
       {hostWebRtcDisabled && (
-        <SectionNote>Start the standalone server with --transport webrtc to enable WebRTC.</SectionNote>
+        <SectionNote>
+          Start the standalone server with --transport webrtc to enable WebRTC.
+        </SectionNote>
       )}
       {settingsCapabilities && (
         <>
@@ -347,7 +348,7 @@ export function StreamOptionsSection({
                 ariaLabel="Max size"
                 value={String(settings.maxDimension)}
                 options={withCurrentValue(settings.maxDimension, MAX_DIMENSION_OPTIONS, (value) =>
-                  value === 0 ? 'Full' : `${value} px`,
+                  value === 0 ? 'Full' : `${value} px`
                 )}
                 disabled={settingsDisabled}
                 onChange={(value) => patchSetting('maxDimension', Number(value))}
@@ -359,7 +360,11 @@ export function StreamOptionsSection({
               <Select
                 ariaLabel="MJPEG FPS"
                 value={String(settings.mjpegFps)}
-                options={withCurrentValue(settings.mjpegFps, FPS_OPTIONS, (value) => `${value} FPS`)}
+                options={withCurrentValue(
+                  settings.mjpegFps,
+                  FPS_OPTIONS,
+                  (value) => `${value} FPS`
+                )}
                 disabled={settingsDisabled || transport !== 'http'}
                 onChange={(value) => patchSetting('mjpegFps', Number(value))}
               />
@@ -373,7 +378,7 @@ export function StreamOptionsSection({
                 options={withCurrentValue(
                   settings.mjpegQuality,
                   QUALITY_OPTIONS,
-                  (value) => `${Math.round(value * 100)}%`,
+                  (value) => `${Math.round(value * 100)}%`
                 )}
                 disabled={settingsDisabled || transport !== 'http'}
                 onChange={(value) => patchSetting('mjpegQuality', Number(value))}
@@ -399,7 +404,7 @@ export function StreamOptionsSection({
                 options={withCurrentValue(
                   settings.h264Bitrate,
                   BITRATE_OPTIONS,
-                  (value) => `${value / 1_000_000} Mbps`,
+                  (value) => `${value / 1_000_000} Mbps`
                 )}
                 disabled={settingsDisabled || !h264Active}
                 onChange={(value) => patchSetting('h264Bitrate', Number(value))}

--- a/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
+++ b/packages/@expo/hub-components/src/dashboard/StreamPanel.tsx
@@ -1,4 +1,4 @@
-import { type ComponentType } from 'react';
+import { type ComponentType, memo } from 'react';
 
 import {
   type AgentInteraction,
@@ -33,7 +33,11 @@ const CONTROLS_GAP = 32;
 
 /** Filesystem-safe screenshot name, e.g. `iPhone-16-2026-06-30T12-34-56.png`. */
 function screenshotFilename(name: string): string {
-  const slug = name.trim().replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'device';
+  const slug =
+    name
+      .trim()
+      .replace(/[^a-zA-Z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'device';
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
   return `${slug}-${stamp}.png`;
 }
@@ -48,7 +52,7 @@ function screenshotFilename(name: string): string {
  * below it, whatever the panel size: the frame viewport reserves their height
  * as padding, and both are anchored to the frame rather than the panel edges.
  */
-export function StreamPanel({
+export const StreamPanel = memo(function StreamPanel({
   device,
   client,
   agentInteraction,
@@ -57,6 +61,7 @@ export function StreamPanel({
   framed = true,
   showDeviceFrame = true,
   deviceFrameAssets,
+  available = true,
 }: {
   device: Device;
   client: DeviceClient;
@@ -74,6 +79,8 @@ export function StreamPanel({
   showDeviceFrame?: boolean;
   /** Consumer-owned frame artwork keyed by the selected device's frame kind. */
   deviceFrameAssets?: DeviceFrameAssets;
+  /** Whether the selected device is present in the host's running-device list. */
+  available?: boolean;
 }) {
   return (
     <section
@@ -116,6 +123,7 @@ export function StreamPanel({
             displayScreen={displayScreen}
             showDeviceFrame={showDeviceFrame}
             deviceFrameAssets={deviceFrameAssets}
+            available={available}
           />
           <div
             style={{
@@ -130,7 +138,11 @@ export function StreamPanel({
               maxWidth: '100cqw',
               transform: 'translateX(-50%)',
             }}>
-            <DeviceTitle key={device.id} device={device} status={client.status} />
+            <DeviceTitle
+              key={device.id}
+              device={device}
+              status={available ? client.status : 'idle'}
+            />
           </div>
           <div
             style={{
@@ -141,6 +153,7 @@ export function StreamPanel({
               transform: 'translateX(-50%)',
             }}>
             <StreamControls
+              disabled={!available}
               appearance={client.appearance}
               onToggleAppearance={() =>
                 client.setAppearance(client.appearance === 'dark' ? 'light' : 'dark')
@@ -158,4 +171,4 @@ export function StreamPanel({
       </div>
     </section>
   );
-}
+});

--- a/packages/expo-device-hub/src/Dashboard.tsx
+++ b/packages/expo-device-hub/src/Dashboard.tsx
@@ -24,7 +24,7 @@ import {
   type Device,
   type DeviceFrameAssets,
 } from '@expo/hub-components';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import pixelDeviceFrame from '../assets/device-frames/google-pixel-10-pro.png';
@@ -41,13 +41,18 @@ import {
   visibleNewDeviceOptions,
 } from './dashboard/deviceVisibility';
 import { useColorScheme } from './dashboard/useColorScheme';
-import { useDeviceLists } from './dashboard/useDevices';
+import { DeviceDiscovery } from './dashboard/DeviceDiscovery';
+import { selectDeviceRoute } from './dashboard/deviceRoute';
+import { useDeviceSessionStore } from './dashboard/deviceSessionStore';
 import {
   FloatingSidebarToggle,
   floatingSidebarToggleInset,
 } from './dashboard/FloatingSidebarToggle';
 import { useArgentInteractions } from './dashboard/useArgentInteraction';
-import { useNewDeviceOptions } from './dashboard/useNewDeviceOptions';
+import {
+  useNewDeviceOptions,
+  type NewDeviceOptionsByPlatform,
+} from './dashboard/useNewDeviceOptions';
 import { SidebarOverlay } from './dashboard/SidebarOverlay';
 import { useSidebarLayout } from './dashboard/useSidebarLayout';
 import {
@@ -55,12 +60,6 @@ import {
   browserStreamModeAvailability,
 } from './dashboard/streamMode';
 import { dashboardPlatformFilter } from './platform-filter';
-
-/** Append `extra` devices not already present in `base` (deduped by id). */
-function mergeById(base: Device[], extra: Device[]): Device[] {
-  const ids = new Set(base.map((device) => device.id));
-  return [...base, ...extra.filter((device) => !ids.has(device.id))];
-}
 
 // Resizable-sidebar bounds. Each column starts at the original fixed width and
 // can be dragged between MIN and MAX — never so wide that the stream, alongside
@@ -116,26 +115,22 @@ function clampSidebarWidth(width: number, otherWidth: number): number {
  * and become toggleable overlays otherwise.
  */
 export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps }) {
+  return (
+    <>
+      <DeviceDiscovery />
+      <DashboardLayout />
+    </>
+  );
+}
+
+const DashboardLayout = memo(function DashboardLayout() {
   const scheme = useColorScheme();
-  const hideBootDevice = dashboardHideBootDevice();
   const platform = dashboardPlatformFilter();
-  const { booted, recent, connectionStatus } = useDeviceLists();
-  // Installed runtimes/system images and models for the new-device forms.
+  const selected = useDeviceSessionStore((state) => state.selectedDevice);
+  const selectedAvailable = useDeviceSessionStore((state) => state.selectedAvailable);
+  const connectionStatus = useDeviceSessionStore((state) => state.connectionStatus);
   const newDeviceOptions = useNewDeviceOptions();
-  const hideUnsupportedDevices = useHideUnsupportedDevices();
-  const selectedId = useDashboardStore((state) => state.selectedDeviceId);
-  const selectDevice = useDashboardStore((state) => state.selectDevice);
-  const reconcileSelectedDevice = useDashboardStore(
-    (state) => state.reconcileSelectedDevice
-  );
-  // Devices started through the picker are retained until host discovery catches up.
-  const added = useDashboardStore((state) => state.addedDevices);
-  const trackAddedDevice = useDashboardStore((state) => state.trackAddedDevice);
-  const dismissDevice = useDashboardStore((state) => state.dismissDevice);
-  const streamModeAvailability = useMemo<StreamModeAvailability>(
-    browserStreamModeAvailability,
-    []
-  );
+  const streamModeAvailability = useMemo<StreamModeAvailability>(browserStreamModeAvailability, []);
   const streamMode = useDashboardStore((state) => state.streamMode);
   const chooseStreamMode = useDashboardStore((state) => state.chooseStreamMode);
   const showDeviceFrame = useDashboardStore((state) => state.showDeviceFrame);
@@ -160,97 +155,6 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
     minStreamWidth: MIN_STREAM_WIDTH,
   });
 
-  // Merge booted devices (from the server) with any the user added, deduped by
-  // id and split back into the two sections by platform.
-  const simulators = useMemo(
-    () =>
-      platform === 'android'
-        ? []
-        : mergeById(
-            booted.simulators,
-            added.filter((device) => device.platform === 'ios')
-          ),
-    [booted.simulators, added, platform]
-  );
-  const emulators = useMemo(
-    () =>
-      platform === 'ios'
-        ? []
-        : mergeById(
-            booted.emulators,
-            added.filter((device) => device.platform === 'android')
-          ),
-    [booted.emulators, added, platform]
-  );
-  // The browser flag affects only shut-down recents and creation choices. Every
-  // running device remains visible in the sidebar, including untested models.
-  const recentSimulators = useMemo(
-    () => visibleDevices(recent.simulators, hideUnsupportedDevices),
-    [recent.simulators, hideUnsupportedDevices]
-  );
-  const recentEmulators = useMemo(
-    () => visibleDevices(recent.emulators, hideUnsupportedDevices),
-    [recent.emulators, hideUnsupportedDevices]
-  );
-  const simulatorOptions = useMemo(
-    () => visibleNewDeviceOptions(newDeviceOptions.ios, hideUnsupportedDevices),
-    [newDeviceOptions.ios, hideUnsupportedDevices]
-  );
-  const emulatorOptions = useMemo(
-    () => visibleNewDeviceOptions(newDeviceOptions.android, hideUnsupportedDevices),
-    [newDeviceOptions.android, hideUnsupportedDevices]
-  );
-
-  // Create/boot the chosen target on the host. The modal awaits this result, so
-  // it stays open during slow Android boots and can show failures in context.
-  async function handleAddDevice(target: AddDeviceTarget): Promise<AddDeviceOutcome> {
-    const result =
-      target.kind === 'new'
-        ? await createDevice(target.device)
-        : target.device.booted
-          ? { id: target.device.id, error: null }
-          : await bootDevice(target.device);
-
-    if (!result.id) {
-      return { ok: false, error: result.error ?? 'The device did not come online.' };
-    }
-
-    const device: Device =
-      target.kind === 'new'
-        ? {
-            id: result.id,
-            name: target.device.name,
-            version: target.device.version,
-            platform: target.device.platform,
-            physical: false,
-            booted: true,
-            supported: target.device.supported,
-            deviceFrame: target.device.deviceFrame,
-            lastUsedAt: Date.now(),
-          }
-        : { ...target.device, id: result.id, booted: true, lastUsedAt: Date.now() };
-
-    const replacedIds =
-      target.kind === 'new'
-        ? [target.device.name, result.id]
-        : [target.device.name, target.device.id, result.id];
-    trackAddedDevice(device, replacedIds);
-    return { ok: true };
-  }
-
-  // Shut down / remove the selected device on the host, then drop it from the
-  // UI. The device leaves the polled booted list within a tick, and the
-  // selection effect re-selects the next device (or falls back to EmptyState).
-  async function handleShutdown(device: Device) {
-    await shutdownDevice(device);
-    dismissDevice(device.id);
-  }
-
-  async function handleRemove(device: Device) {
-    await removeDevice(device);
-    dismissDevice(device.id);
-  }
-
   // Mirror the theme onto the document root so Radix portals (e.g. the dropdown
   // menu), which mount on document.body outside the wrapper below, still pick up
   // the dark `--expo-theme-*` variables.
@@ -260,40 +164,39 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
     return () => root.classList.remove('dark-theme');
   }, [scheme]);
 
-  // Keep a valid selection — default to the first device once the list loads.
-  // Selecting a device streams it (its helper is attached on demand); the
-  // sidebar lists only booted devices, so the default selection streams an
-  // already-running sim and never boots anything.
-  useEffect(() => {
-    const devices = [...simulators, ...emulators];
-    reconcileSelectedDevice(devices.map((device) => device.id));
-  }, [simulators, emulators, reconcileSelectedDevice]);
+  const selectedStreamModeAvailability = useMemo(
+    () =>
+      selected?.platform === 'android'
+        ? androidStreamModeAvailability(
+            streamModeAvailability,
+            typeof window.MediaSource !== 'undefined'
+          )
+        : streamModeAvailability,
+    [selected?.platform, streamModeAvailability]
+  );
+  const handleStreamModeChange = useCallback(
+    (mode: DeviceStreamMode) => {
+      chooseStreamMode(mode, selectedStreamModeAvailability);
+    },
+    [chooseStreamMode, selectedStreamModeAvailability]
+  );
+  const handleShutdown = useCallback(async () => {
+    if (selected) await shutdownDevice(selected);
+  }, [selected]);
+  const handleRemove = useCallback(async () => {
+    if (selected) await removeDevice(selected);
+  }, [selected]);
 
-  const devices = [...simulators, ...emulators];
-  const selected = devices.find((device) => device.id === selectedId) ?? devices[0];
-  const selectedStreamModeAvailability =
-    selected?.platform === 'android'
-      ? androidStreamModeAvailability(
-          streamModeAvailability,
-          typeof window.MediaSource !== 'undefined'
-        )
-      : streamModeAvailability;
-  const handleStreamModeChange = (mode: DeviceStreamMode) => {
-    chooseStreamMode(mode, selectedStreamModeAvailability);
-  };
-
-  // One shared connection to the serve-sim/serve-emu server, wired to the
-  // selected device. Null until the user picks one, so nothing connects (or
-  // boots) on load.
+  // Connect only while discovery confirms the URL-selected device is running.
   const client = useActiveDeviceClient(
-    connectionStatus === 'connected' && selected
+    connectionStatus === 'connected' && selectedAvailable && selected
       ? { platform: selected.platform, device: selected.id, streamMode }
       : null,
     basePath()
   );
   const agentInteractions = useArgentInteractions();
-  const agentInteraction = selected ? agentInteractions[selected.id] ?? null : null;
-  const agentDeviceIds = Object.keys(agentInteractions);
+  const agentInteraction = selected ? (agentInteractions[selected.id] ?? null) : null;
+  const agentDeviceIds = useMemo(() => Object.keys(agentInteractions), [agentInteractions]);
 
   const connectionBlocked = connectionStatus !== 'connected';
 
@@ -322,17 +225,9 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         open={sidebars.leftDocked}
         sidebarOpen={sidebars.leftOpen}
         resizing={resizing}>
-        <Sidebar
-          simulators={simulators}
-          emulators={emulators}
-          recentSimulators={recentSimulators}
-          recentEmulators={recentEmulators}
-          simulatorOptions={simulatorOptions}
-          emulatorOptions={emulatorOptions}
+        <DeviceSidebar
+          newDeviceOptions={newDeviceOptions}
           agentDeviceIds={agentDeviceIds}
-          selectedId={selectedId}
-          onSelect={selectDevice}
-          onAddDevice={hideBootDevice ? undefined : handleAddDevice}
           onToggle={sidebars.closeLeft}
           platform={platform}
           width={sidebarWidth}
@@ -362,6 +257,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
       {selected ? (
         <StreamPanel
           device={selected}
+          available={selectedAvailable}
           client={client}
           agentInteraction={agentInteraction}
           DeviceScreen={DeviceScreen}
@@ -405,6 +301,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         resizing={resizing}>
         <LogSidebar
           device={selected}
+          available={selectedAvailable}
           client={client}
           showDeviceFrame={showDeviceFrame}
           onShowDeviceFrameChange={setShowDeviceFrame}
@@ -413,8 +310,8 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           streamModeAvailability={selectedStreamModeAvailability}
           onStreamModeChange={handleStreamModeChange}
           onHttpCodecChange={setHttpCodec}
-          onShutdown={selected ? () => handleShutdown(selected) : undefined}
-          onRemove={selected ? () => handleRemove(selected) : undefined}
+          onShutdown={selected ? handleShutdown : undefined}
+          onRemove={selected ? handleRemove : undefined}
           onToggle={sidebars.closeRight}
           width={logsWidth}
         />
@@ -426,17 +323,9 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         sidebarOpen={sidebars.leftOpen}
         topmost={sidebars.lastOpened === 'left' || !sidebars.rightOverlay}
         onDismiss={sidebars.closeLeft}>
-        <Sidebar
-          simulators={simulators}
-          emulators={emulators}
-          recentSimulators={recentSimulators}
-          recentEmulators={recentEmulators}
-          simulatorOptions={simulatorOptions}
-          emulatorOptions={emulatorOptions}
+        <DeviceSidebar
+          newDeviceOptions={newDeviceOptions}
           agentDeviceIds={agentDeviceIds}
-          selectedId={selectedId}
-          onSelect={selectDevice}
-          onAddDevice={hideBootDevice ? undefined : handleAddDevice}
           onToggle={sidebars.closeLeft}
           platform={platform}
           width={sidebarWidth}
@@ -451,6 +340,7 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         onDismiss={sidebars.closeRight}>
         <LogSidebar
           device={selected}
+          available={selectedAvailable}
           client={client}
           showDeviceFrame={showDeviceFrame}
           onShowDeviceFrameChange={setShowDeviceFrame}
@@ -459,8 +349,8 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
           streamModeAvailability={selectedStreamModeAvailability}
           onStreamModeChange={handleStreamModeChange}
           onHttpCodecChange={setHttpCodec}
-          onShutdown={selected ? () => handleShutdown(selected) : undefined}
-          onRemove={selected ? () => handleRemove(selected) : undefined}
+          onShutdown={selected ? handleShutdown : undefined}
+          onRemove={selected ? handleRemove : undefined}
           onToggle={sidebars.closeRight}
           width={logsWidth}
         />
@@ -499,4 +389,91 @@ export default function Dashboard(_props: { dom?: import('expo/dom').DOMProps })
         )}
     </div>
   );
+});
+
+/** Only this column subscribes to changes in the other devices. */
+const DeviceSidebar = memo(function DeviceSidebar({
+  newDeviceOptions,
+  agentDeviceIds,
+  onToggle,
+  platform,
+  width,
+}: {
+  newDeviceOptions: NewDeviceOptionsByPlatform;
+  agentDeviceIds: string[];
+  onToggle: () => void;
+  platform?: Device['platform'];
+  width: number;
+}) {
+  const simulators = useDeviceSessionStore((state) => state.simulators);
+  const emulators = useDeviceSessionStore((state) => state.emulators);
+  const recent = useDeviceSessionStore((state) => state.recent);
+  const selectedId = useDeviceSessionStore((state) => state.selectedDevice?.id ?? '');
+  const available = useDeviceSessionStore((state) => state.selectedAvailable);
+  const hideUnsupportedDevices = useHideUnsupportedDevices();
+  const recentSimulators = useMemo(
+    () => visibleDevices(recent.simulators, hideUnsupportedDevices),
+    [recent.simulators, hideUnsupportedDevices]
+  );
+  const recentEmulators = useMemo(
+    () => visibleDevices(recent.emulators, hideUnsupportedDevices),
+    [recent.emulators, hideUnsupportedDevices]
+  );
+  const simulatorOptions = useMemo(
+    () => visibleNewDeviceOptions(newDeviceOptions.ios, hideUnsupportedDevices),
+    [newDeviceOptions.ios, hideUnsupportedDevices]
+  );
+  const emulatorOptions = useMemo(
+    () => visibleNewDeviceOptions(newDeviceOptions.android, hideUnsupportedDevices),
+    [newDeviceOptions.android, hideUnsupportedDevices]
+  );
+
+  return (
+    <Sidebar
+      simulators={simulators}
+      emulators={emulators}
+      recentSimulators={recentSimulators}
+      recentEmulators={recentEmulators}
+      simulatorOptions={simulatorOptions}
+      emulatorOptions={emulatorOptions}
+      agentDeviceIds={agentDeviceIds}
+      selectedId={selectedId}
+      offlineDeviceId={available ? undefined : selectedId}
+      onSelect={selectDeviceRoute}
+      onAddDevice={dashboardHideBootDevice() ? undefined : handleAddDevice}
+      onToggle={onToggle}
+      platform={platform}
+      width={width}
+    />
+  );
+});
+
+async function handleAddDevice(target: AddDeviceTarget): Promise<AddDeviceOutcome> {
+  const result =
+    target.kind === 'new'
+      ? await createDevice(target.device)
+      : target.device.booted
+        ? { id: target.device.id, error: null }
+        : await bootDevice(target.device);
+  if (!result.id) return { ok: false, error: result.error ?? 'The device did not come online.' };
+
+  const device: Device =
+    target.kind === 'new'
+      ? {
+          id: result.id,
+          name: target.device.name,
+          version: target.device.version,
+          platform: target.device.platform,
+          physical: false,
+          booted: true,
+          supported: target.device.supported,
+          deviceFrame: target.device.deviceFrame,
+          lastUsedAt: Date.now(),
+        }
+      : { ...target.device, id: result.id, booted: true, lastUsedAt: Date.now() };
+  // Keep the returned metadata while discovery catches up; availability still
+  // comes from the server, so optimistic devices cannot stay online forever.
+  useDeviceSessionStore.getState().rememberDevice(device);
+  selectDeviceRoute(device.id);
+  return { ok: true };
 }

--- a/packages/expo-device-hub/src/dashboard/DeviceDiscovery.tsx
+++ b/packages/expo-device-hub/src/dashboard/DeviceDiscovery.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+import { dashboardPlatformFilter } from '../platform-filter';
+import { useDeviceRoute } from './deviceRoute';
+import { useDeviceSessionStore } from './deviceSessionStore';
+import { useDeviceLists } from './useDevices';
+
+/** Discovery updates selector subscribers, without rendering the dashboard shell. */
+export function DeviceDiscovery() {
+  const { booted, recent, connectionStatus } = useDeviceLists();
+  const { selectedId, selectDevice } = useDeviceRoute();
+  const platform = dashboardPlatformFilter();
+
+  useEffect(() => {
+    if (!selectedId) {
+      const first =
+        (platform === 'android' ? undefined : booted.simulators[0]) ??
+        (platform === 'ios' ? undefined : booted.emulators[0]);
+      if (first) {
+        selectDevice(first.id, { replace: true });
+        return;
+      }
+    }
+    useDeviceSessionStore.getState().update({ booted, recent, selectedId, platform });
+  }, [booted, recent, selectedId, selectDevice, platform]);
+
+  useEffect(() => {
+    useDeviceSessionStore.getState().setConnectionStatus(connectionStatus);
+  }, [connectionStatus]);
+
+  return null;
+}

--- a/packages/expo-device-hub/src/dashboard/__tests__/dashboardStore.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/dashboardStore.test.ts
@@ -1,64 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { type Device } from '@expo/hub-components';
-
 import { createDashboardStore } from '../dashboardStore';
-
-const iosDevice: Device = {
-  id: 'ios-new',
-  name: 'iPhone 17',
-  version: 'iOS 27',
-  platform: 'ios',
-  booted: true,
-  physical: false,
-  supported: true,
-  deviceFrame: 'ios:iphone-17-pro',
-};
 
 afterEach(() => {
   delete (globalThis as any).window;
 });
 
 describe('dashboard store', () => {
-  test('tracks a replacement device and selects it', () => {
-    const store = createDashboardStore({
-      addedDevices: [
-        { ...iosDevice, id: 'old-id' },
-        { ...iosDevice, id: 'keep-id' },
-      ],
-    });
-
-    store.getState().trackAddedDevice(iosDevice, ['old-id', iosDevice.name]);
-
-    expect(store.getState().addedDevices.map((device) => device.id)).toEqual([
-      'keep-id',
-      'ios-new',
-    ]);
-    expect(store.getState().selectedDeviceId).toBe('ios-new');
-  });
-
-  test('keeps a valid selection and falls back when it disappears', () => {
-    const store = createDashboardStore({ selectedDeviceId: 'second' });
-
-    store.getState().reconcileSelectedDevice(['first', 'second']);
-    expect(store.getState().selectedDeviceId).toBe('second');
-
-    store.getState().reconcileSelectedDevice(['first']);
-    expect(store.getState().selectedDeviceId).toBe('first');
-  });
-
-  test('dismisses an optimistic device without clearing another selection', () => {
-    const store = createDashboardStore({
-      addedDevices: [iosDevice],
-      selectedDeviceId: 'another-device',
-    });
-
-    store.getState().dismissDevice(iosDevice.id);
-
-    expect(store.getState().addedDevices).toEqual([]);
-    expect(store.getState().selectedDeviceId).toBe('another-device');
-  });
-
   test('falls back to MJPEG when the selected stream mode is unavailable', () => {
     const store = createDashboardStore({ streamMode: 'webrtc' });
 

--- a/packages/expo-device-hub/src/dashboard/__tests__/deviceRoute.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/deviceRoute.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  readDeviceRoute,
+  selectDeviceRoute,
+  selectedDeviceRoute,
+  subscribeToDeviceRoute,
+} from '../deviceRoute';
+
+const PLUGIN_MOUNT = '/_expo/plugins/expo-device-hub';
+
+function stubBrowser(
+  path: string,
+  options: { mountPath?: string; dev?: boolean } = { mountPath: '' }
+) {
+  const events = new EventTarget();
+  const entries = [new URL(path, 'http://localhost:8081')];
+  let index = 0;
+  const browser = {
+    __DEV__: options.dev,
+    __EXPO_DEVICE_HUB_BASE_PATH__: options.mountPath,
+    get location() {
+      return entries[index];
+    },
+    history: {
+      state: { preserved: true },
+      get length() {
+        return entries.length;
+      },
+      pushState(_state: unknown, _unused: string, url: string) {
+        entries.splice(index + 1, entries.length, new URL(url, entries[index]));
+        index++;
+      },
+      replaceState(_state: unknown, _unused: string, url: string) {
+        entries[index] = new URL(url, entries[index]);
+      },
+      back() {
+        if (index === 0) return;
+        index--;
+        events.dispatchEvent(new Event('popstate'));
+      },
+      forward() {
+        if (index === entries.length - 1) return;
+        index++;
+        events.dispatchEvent(new Event('popstate'));
+      },
+    },
+    addEventListener: events.addEventListener.bind(events),
+    removeEventListener: events.removeEventListener.bind(events),
+    dispatchEvent: events.dispatchEvent.bind(events),
+  };
+  (globalThis as any).window = browser;
+  return browser;
+}
+
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('device route', () => {
+  test('reads iOS UDIDs and Android serials, including escaped characters', () => {
+    expect(readDeviceRoute('/device/A05B3DB4-425C-40EC-96F1-5F05AD5FB660')).toBe(
+      'A05B3DB4-425C-40EC-96F1-5F05AD5FB660'
+    );
+    expect(readDeviceRoute('/device/emulator-5554')).toBe('emulator-5554');
+    expect(readDeviceRoute('/device/192.168.1.10%3A5555')).toBe('192.168.1.10:5555');
+    expect(readDeviceRoute('/device/serial%2Fwith%20spaces%25/')).toBe('serial/with spaces%');
+  });
+
+  test('matches only device routes beneath the exact mount', () => {
+    expect(readDeviceRoute(`${PLUGIN_MOUNT}/device/ios-id`, `${PLUGIN_MOUNT}/`)).toBe('ios-id');
+    expect(readDeviceRoute('/device/ios-id', PLUGIN_MOUNT)).toBe('');
+    expect(readDeviceRoute('/hub-other/device/ios-id', '/hub')).toBe('');
+    for (const path of ['/', '/index.html', '/device/', '/device/ios-id/extra', '/device/%bad']) {
+      expect(readDeviceRoute(path)).toBe('');
+    }
+  });
+
+  test('initializes from a deep link before devices arrive', () => {
+    stubBrowser(`${PLUGIN_MOUNT}/device/offline-ios-id`, { mountPath: PLUGIN_MOUNT });
+    expect(selectedDeviceRoute()).toBe('offline-ios-id');
+  });
+
+  test('updates selection immediately and follows browser back and forward', () => {
+    const browser = stubBrowser('/?transport=h264#details');
+    const selections: string[] = [];
+    const unsubscribe = subscribeToDeviceRoute(() => selections.push(selectedDeviceRoute()));
+
+    selectDeviceRoute('ios-id', { replace: true });
+    expect(browser.history.length).toBe(1);
+    selectDeviceRoute('192.168.1.10:5555');
+    expect(browser.location.pathname).toBe('/device/192.168.1.10%3A5555');
+    expect(browser.location.search).toBe('?transport=h264');
+    expect(browser.location.hash).toBe('#details');
+    expect(browser.history.length).toBe(2);
+    selectDeviceRoute('192.168.1.10:5555');
+    expect(browser.history.length).toBe(2);
+    browser.history.back();
+    browser.history.forward();
+
+    expect(selections).toEqual(['ios-id', '192.168.1.10:5555', 'ios-id', '192.168.1.10:5555']);
+    unsubscribe();
+    browser.history.back();
+    expect(selections).toHaveLength(4);
+  });
+
+  test('keeps selection and deselection inside the mounted dashboard', () => {
+    const browser = stubBrowser(`${PLUGIN_MOUNT}/`, { mountPath: `${PLUGIN_MOUNT}/` });
+    selectDeviceRoute('emulator-5554');
+    expect(browser.location.pathname).toBe(`${PLUGIN_MOUNT}/device/emulator-5554`);
+    expect(selectedDeviceRoute()).toBe('emulator-5554');
+    selectDeviceRoute('');
+    expect(browser.location.pathname).toBe(`${PLUGIN_MOUNT}/`);
+    expect(selectedDeviceRoute()).toBe('');
+  });
+
+  test('navigates the Metro web app at the root while its API uses the plugin mount', () => {
+    const browser = stubBrowser('/', { dev: true });
+    selectDeviceRoute('ios-id');
+    expect(browser.location.pathname).toBe('/device/ios-id');
+    expect(selectedDeviceRoute()).toBe('ios-id');
+  });
+
+  test('uses an explicit shell mount even when development is enabled', () => {
+    const browser = stubBrowser('/hub/', { dev: true, mountPath: '/hub' });
+    selectDeviceRoute('ios-id');
+    expect(browser.location.pathname).toBe('/hub/device/ios-id');
+  });
+});

--- a/packages/expo-device-hub/src/dashboard/__tests__/deviceSessionStore.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/deviceSessionStore.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test';
+import { type Device } from '@expo/hub-components';
+
+import { createDeviceSessionStore } from '../deviceSessionStore';
+import { reconcileDeviceList, splitDeviceList, type DeviceList } from '../useDevices';
+
+const iphone: Device = {
+  id: 'F20A59AF-5BD8-492F-A613-E2DBA76D4DDD',
+  name: 'iPhone',
+  version: 'iOS 27',
+  platform: 'ios',
+  booted: true,
+  physical: false,
+  supported: true,
+  deviceFrame: 'ios:iphone-17-pro',
+};
+const pixel: Device = {
+  ...iphone,
+  id: 'emulator-5554',
+  name: 'Pixel',
+  version: 'Android 17',
+  platform: 'android',
+  deviceFrame: 'android:pixel-10-pro',
+};
+const empty: DeviceList = { simulators: [], emulators: [] };
+
+describe('device selection from discovery and the URL', () => {
+  test('a late boot response does not mark a discovered device offline', () => {
+    const store = createDeviceSessionStore();
+    store.getState().update({
+      booted: { simulators: [iphone], emulators: [] },
+      recent: empty,
+      selectedId: iphone.id,
+    });
+    store.getState().rememberDevice({ ...iphone, lastUsedAt: Date.now() });
+    expect(store.getState().selectedDevice).toBe(iphone);
+    expect(store.getState().selectedAvailable).toBe(true);
+  });
+
+  test('retains a missing selected device until navigating to another device', () => {
+    const store = createDeviceSessionStore();
+    store.getState().update({
+      booted: { simulators: [iphone], emulators: [pixel] },
+      recent: empty,
+      selectedId: iphone.id,
+    });
+    store.getState().update({
+      booted: { simulators: [], emulators: [pixel] },
+      recent: empty,
+      selectedId: iphone.id,
+    });
+    expect(store.getState().selectedDevice).toBe(iphone);
+    expect(store.getState().selectedAvailable).toBe(false);
+    expect(store.getState().simulators).toEqual([iphone]);
+
+    store.getState().update({
+      booted: { simulators: [], emulators: [pixel] },
+      recent: empty,
+      selectedId: pixel.id,
+    });
+    expect(store.getState().selectedDevice).toBe(pixel);
+    expect(store.getState().selectedAvailable).toBe(true);
+    expect(store.getState().simulators).toEqual([]);
+  });
+
+  test('stays on the requested ID before discovery and reconnects when it returns', () => {
+    const store = createDeviceSessionStore();
+    store.getState().update({
+      booted: { simulators: [iphone], emulators: [] },
+      recent: empty,
+      selectedId: pixel.id,
+    });
+    expect(store.getState().selectedDevice?.id).toBe(pixel.id);
+    expect(store.getState().selectedAvailable).toBe(false);
+    store.getState().update({
+      booted: { simulators: [iphone], emulators: [pixel] },
+      recent: empty,
+      selectedId: pixel.id,
+    });
+    expect(store.getState().selectedDevice).toBe(pixel);
+    expect(store.getState().selectedAvailable).toBe(true);
+    expect(store.getState().emulators).toEqual([pixel]);
+  });
+
+  test('uses known metadata for an offline deep link and for devices that shut down', () => {
+    const store = createDeviceSessionStore();
+    const stopped = { ...iphone, booted: false };
+    store.getState().update({
+      booted: empty,
+      recent: { simulators: [stopped], emulators: [] },
+      selectedId: iphone.id,
+    });
+    expect(store.getState().selectedDevice).toBe(stopped);
+    expect(store.getState().selectedAvailable).toBe(false);
+    expect(store.getState().simulators).toEqual([stopped]);
+  });
+
+  test('a newly created device retains metadata without assuming it stays online', () => {
+    const store = createDeviceSessionStore();
+    store.getState().rememberDevice(pixel);
+    store.getState().update({ booted: empty, recent: empty, selectedId: pixel.id });
+    expect(store.getState().selectedDevice).toBe(pixel);
+    expect(store.getState().selectedAvailable).toBe(false);
+    store.getState().update({
+      booted: { simulators: [], emulators: [pixel] },
+      recent: empty,
+      selectedId: pixel.id,
+    });
+    expect(store.getState().selectedAvailable).toBe(true);
+    store.getState().update({ booted: empty, recent: empty, selectedId: pixel.id });
+    expect(store.getState().selectedAvailable).toBe(false);
+  });
+
+  test('unrelated add, update and remove snapshots leave viewer selector values untouched', () => {
+    const store = createDeviceSessionStore();
+    let snapshot = { simulators: [iphone], emulators: [pixel] };
+    let lists = splitDeviceList(snapshot);
+    store.getState().update({ ...lists, selectedId: iphone.id });
+    let viewerChanges = 0;
+    let iosListChanges = 0;
+    const unsubscribe = store.subscribe((next, previous) => {
+      if (
+        next.selectedDevice !== previous.selectedDevice ||
+        next.selectedAvailable !== previous.selectedAvailable ||
+        next.connectionStatus !== previous.connectionStatus
+      )
+        viewerChanges++;
+      if (next.simulators !== previous.simulators) iosListChanges++;
+    });
+    for (const emulators of [
+      [{ ...pixel, name: 'Renamed Pixel' }],
+      [pixel, { ...pixel, id: 'emulator-5556' }],
+      [],
+    ]) {
+      snapshot = reconcileDeviceList(
+        snapshot,
+        JSON.parse(JSON.stringify({ simulators: [iphone], emulators }))
+      );
+      lists = splitDeviceList(snapshot, lists);
+      store.getState().update({ ...lists, selectedId: iphone.id });
+    }
+    expect(viewerChanges).toBe(0);
+    expect(iosListChanges).toBe(0);
+    expect(store.getState().emulators).toEqual([]);
+    unsubscribe();
+  });
+});

--- a/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
+++ b/packages/expo-device-hub/src/dashboard/__tests__/useDevices.test.ts
@@ -5,6 +5,7 @@ import {
   devicesWebSocketUrl,
   parseDeviceListMessage,
   parseDeviceListSocketMessage,
+  reconcileDeviceList,
   splitDeviceList,
   subscribeToDeviceList,
   type DeviceList,
@@ -45,16 +46,16 @@ describe('device-list WebSocket client helpers', () => {
   test('builds ws and wss URLs under the configured mount', () => {
     (globalThis as any).window = { __EXPO_DEVICE_HUB_BASE_PATH__: '/hub/' };
     expect(devicesWebSocketUrl('http://localhost:3400/dashboard')).toBe(
-      'ws://localhost:3400/hub/api/devices/ws',
+      'ws://localhost:3400/hub/api/devices/ws'
     );
     expect(devicesWebSocketUrl('https://example.com/dashboard')).toBe(
-      'wss://example.com/hub/api/devices/ws',
+      'wss://example.com/hub/api/devices/ws'
     );
   });
 
   test('accepts device-list messages and ignores other payloads', () => {
     expect(
-      parseDeviceListMessage(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: list })),
+      parseDeviceListMessage(JSON.stringify({ type: DEVICE_LIST_MESSAGE_TYPE, devices: list }))
     ).toEqual(list);
     expect(parseDeviceListMessage(JSON.stringify({ type: 'other', devices: list }))).toBeNull();
     expect(parseDeviceListMessage('not json')).toBeNull();
@@ -63,8 +64,8 @@ describe('device-list WebSocket client helpers', () => {
         JSON.stringify({
           type: DEVICE_LIST_MESSAGE_TYPE,
           devices: { ...list, errors: {} },
-        }),
-      ),
+        })
+      )
     ).toBeNull();
   });
 
@@ -90,8 +91,8 @@ describe('device-list WebSocket client helpers', () => {
         JSON.stringify({
           type: DEVICE_LIST_MESSAGE_TYPE,
           devices: { ...list, errors },
-        }),
-      ),
+        })
+      )
     ).toEqual({ ...list, errors });
   });
 
@@ -100,6 +101,90 @@ describe('device-list WebSocket client helpers', () => {
       booted: { simulators: [list.simulators[0]], emulators: [] },
       recent: { simulators: [], emulators: [list.emulators[0]] },
     });
+  });
+
+  test('retains the running lists when only a recent device changes', () => {
+    const previous = splitDeviceList(list);
+    const next = splitDeviceList(
+      {
+        ...list,
+        emulators: [{ ...list.emulators[0], name: 'Renamed Pixel' }],
+      },
+      previous
+    );
+
+    expect(next.booted).toBe(previous.booted);
+    expect(next.recent.simulators).toBe(previous.recent.simulators);
+    expect(next.recent.emulators[0].name).toBe('Renamed Pixel');
+  });
+
+  test('retains every reference for identical JSON snapshots and utility-error changes', () => {
+    const snapshot = {
+      ...structuredClone(list),
+      errors: [{ id: 'discovery-error', message: 'Discovery failed', error: 'Error: unavailable' }],
+    };
+
+    expect(reconcileDeviceList(list, snapshot)).toBe(list);
+    const previous = splitDeviceList(list);
+    expect(splitDeviceList(structuredClone(list), previous)).toBe(previous);
+  });
+
+  test('updates only changed devices while retaining the other platform and siblings', () => {
+    const previous: DeviceList = {
+      ...list,
+      simulators: [...list.simulators, { ...list.simulators[0], id: 'second-ios' }],
+    };
+    const snapshot = structuredClone(previous);
+    snapshot.simulators[1].name = 'Renamed iPhone';
+    snapshot.simulators[1].lastUsedAt = 1_000;
+    const next = reconcileDeviceList(previous, snapshot);
+
+    expect(next.simulators[0]).toBe(previous.simulators[0]);
+    expect(next.simulators[1]).toEqual(snapshot.simulators[1]);
+    expect(next.simulators[1]).not.toBe(previous.simulators[1]);
+    expect(next.emulators).toBe(previous.emulators);
+  });
+
+  test('keeps device identities through additions, removals, and reordered snapshots', () => {
+    const second = { ...list.simulators[0], id: 'second-ios' };
+    const third = { ...list.simulators[0], id: 'third-ios' };
+    const added = reconcileDeviceList(list, {
+      ...structuredClone(list),
+      simulators: [{ ...second }, { ...list.simulators[0] }, { ...third }],
+    });
+    const next = reconcileDeviceList(added, {
+      ...structuredClone(added),
+      simulators: [{ ...added.simulators[2] }, { ...added.simulators[1] }],
+    });
+
+    expect(added.simulators[1]).toBe(list.simulators[0]);
+    expect(next.simulators).toHaveLength(2);
+    expect(next.simulators[0]).toBe(added.simulators[2]);
+    expect(next.simulators[1]).toBe(list.simulators[0]);
+    expect(next.emulators).toBe(list.emulators);
+  });
+
+  test('moves a booted device between sections while preserving the unaffected platform', () => {
+    const previous = splitDeviceList(list);
+    const snapshot = structuredClone(list);
+    snapshot.emulators[0].booted = true;
+    const next = splitDeviceList(reconcileDeviceList(list, snapshot), previous);
+
+    expect(next.booted.simulators).toBe(previous.booted.simulators);
+    expect(next.recent.simulators).toBe(previous.recent.simulators);
+    expect(next.booted.emulators).toEqual(snapshot.emulators);
+    expect(next.recent.emulators).toEqual([]);
+  });
+
+  test('does not retain a removed optional device field', () => {
+    const previous: DeviceList = {
+      ...list,
+      simulators: [{ ...list.simulators[0], lastUsedAt: 1_000 }],
+    };
+    const next = reconcileDeviceList(previous, structuredClone(list));
+
+    expect(next.simulators[0]).not.toBe(previous.simulators[0]);
+    expect(next.simulators[0]).not.toHaveProperty('lastUsedAt');
   });
 });
 

--- a/packages/expo-device-hub/src/dashboard/dashboardStore.ts
+++ b/packages/expo-device-hub/src/dashboard/dashboardStore.ts
@@ -1,5 +1,5 @@
 import { type DeviceStreamMode } from '@expo/hub-client';
-import { type Device, type StreamModeAvailability } from '@expo/hub-components';
+import { type StreamModeAvailability } from '@expo/hub-components';
 import { create } from 'zustand';
 
 import { dashboardHideSidebar } from '../sidebar';
@@ -13,8 +13,6 @@ export type SidebarPreference = 'auto' | 'open' | 'hidden';
 export type SidebarSide = 'left' | 'right';
 
 type DashboardStoreValues = {
-  selectedDeviceId: string;
-  addedDevices: Device[];
   streamMode: DeviceStreamMode;
   sidebarWidths: Record<SidebarSide, number>;
   sidebarPreferences: Record<SidebarSide, SidebarPreference>;
@@ -24,10 +22,6 @@ type DashboardStoreValues = {
 };
 
 export type DashboardStore = DashboardStoreValues & {
-  selectDevice: (id: string) => void;
-  reconcileSelectedDevice: (availableIds: readonly string[]) => void;
-  trackAddedDevice: (device: Device, replacedIds: readonly string[]) => void;
-  dismissDevice: (id: string) => void;
   chooseStreamMode: (mode: DeviceStreamMode, availability: StreamModeAvailability) => void;
   resizeSidebar: (side: SidebarSide, width: number) => void;
   openSidebar: (side: SidebarSide, canDock: boolean) => void;
@@ -71,8 +65,6 @@ function initialHideUnsupportedDevices(): boolean {
 function defaultDashboardStoreValues(): DashboardStoreValues {
   const availability = browserStreamModeAvailability();
   return {
-    selectedDeviceId: '',
-    addedDevices: [],
     streamMode: resolveStreamMode(dashboardTransport(), availability),
     sidebarWidths: { left: DEFAULT_SIDEBAR_WIDTH, right: DEFAULT_SIDEBAR_WIDTH },
     sidebarPreferences: {
@@ -89,26 +81,6 @@ export function createDashboardStore(initialState: Partial<DashboardStoreValues>
   return create<DashboardStore>()((set) => ({
     ...defaultDashboardStoreValues(),
     ...initialState,
-    selectDevice: (selectedDeviceId) => set({ selectedDeviceId }),
-    reconcileSelectedDevice: (availableIds) =>
-      set((state) =>
-        availableIds.includes(state.selectedDeviceId)
-          ? state
-          : { selectedDeviceId: availableIds[0] ?? '' },
-      ),
-    trackAddedDevice: (device, replacedIds) =>
-      set((state) => {
-        const replaced = new Set([...replacedIds, device.id]);
-        return {
-          addedDevices: [...state.addedDevices.filter((item) => !replaced.has(item.id)), device],
-          selectedDeviceId: device.id,
-        };
-      }),
-    dismissDevice: (id) =>
-      set((state) => ({
-        addedDevices: state.addedDevices.filter((item) => item.id !== id),
-        selectedDeviceId: state.selectedDeviceId === id ? '' : state.selectedDeviceId,
-      })),
     chooseStreamMode: (mode, availability) =>
       set({ streamMode: resolveStreamMode(mode, availability) }),
     resizeSidebar: (side, width) =>

--- a/packages/expo-device-hub/src/dashboard/deviceRoute.ts
+++ b/packages/expo-device-hub/src/dashboard/deviceRoute.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react';
+
+import { trimTrailingSlash } from '../utils/trimTrailingSlash';
+import { basePath } from './basePath';
+
+const DEVICE_ROUTE_CHANGE_EVENT = 'expo-device-hub:device-route-change';
+
+/** The web app is at the origin root in Metro, even though its API uses the plugin mount. */
+function browserMountPath(): string {
+  const provided = window.__EXPO_DEVICE_HUB_BASE_PATH__;
+  if (provided != null) return trimTrailingSlash(provided);
+  return window.__DEV__ ? '' : basePath();
+}
+
+/** Read one encoded iOS UDID or Android serial under the dashboard's mount. */
+export function readDeviceRoute(pathname: string, mountPath = ''): string {
+  const prefix = `${trimTrailingSlash(mountPath)}/device/`;
+  if (!pathname.startsWith(prefix)) return '';
+  const encodedId = pathname.slice(prefix.length).replace(/\/$/, '');
+  if (!encodedId || encodedId.includes('/')) return '';
+  try {
+    return decodeURIComponent(encodedId);
+  } catch {
+    return '';
+  }
+}
+
+export function selectedDeviceRoute(): string {
+  if (typeof window === 'undefined') return '';
+  return readDeviceRoute(window.location.pathname, browserMountPath());
+}
+
+export function subscribeToDeviceRoute(onChange: () => void): () => void {
+  window.addEventListener('popstate', onChange);
+  window.addEventListener(DEVICE_ROUTE_CHANGE_EVENT, onChange);
+  return () => {
+    window.removeEventListener('popstate', onChange);
+    window.removeEventListener(DEVICE_ROUTE_CHANGE_EVENT, onChange);
+  };
+}
+
+export function selectDeviceRoute(id: string, options?: { replace?: boolean }): void {
+  const mountPath = browserMountPath();
+  const pathname = id ? `${mountPath}/device/${encodeURIComponent(id)}` : `${mountPath}/`;
+  if (window.location.pathname === pathname) return;
+
+  const url = `${pathname}${window.location.search}${window.location.hash}`;
+  if (options?.replace) {
+    window.history.replaceState(window.history.state, '', url);
+  } else {
+    window.history.pushState(window.history.state, '', url);
+  }
+  window.dispatchEvent(new Event(DEVICE_ROUTE_CHANGE_EVENT));
+}
+
+const serverSelectedDeviceRoute = () => '';
+
+export function useDeviceRoute(): {
+  selectedId: string;
+  selectDevice: typeof selectDeviceRoute;
+} {
+  const selectedId = useSyncExternalStore(
+    subscribeToDeviceRoute,
+    selectedDeviceRoute,
+    serverSelectedDeviceRoute
+  );
+  return { selectedId, selectDevice: selectDeviceRoute };
+}

--- a/packages/expo-device-hub/src/dashboard/deviceSessionStore.ts
+++ b/packages/expo-device-hub/src/dashboard/deviceSessionStore.ts
@@ -1,0 +1,112 @@
+import { type Device, type Platform } from '@expo/hub-components';
+import { create } from 'zustand';
+
+import { type DeviceList, type DeviceListConnectionStatus } from './useDevices';
+
+type DeviceSession = {
+  simulators: Device[];
+  emulators: Device[];
+  recent: DeviceList;
+  selectedDevice?: Device;
+  selectedAvailable: boolean;
+  connectionStatus: DeviceListConnectionStatus;
+};
+
+type SessionUpdate = {
+  booted: DeviceList;
+  recent: DeviceList;
+  selectedId: string;
+  platform?: Platform;
+};
+
+const EMPTY_DEVICES: Device[] = [];
+
+function sameDevices(previous: Device[], next: Device[]): Device[] {
+  return previous.length === next.length &&
+    previous.every((device, index) => device === next[index])
+    ? previous
+    : next;
+}
+
+/** A direct link may arrive before discovery has ever seen this device. */
+function unknownDevice(id: string, platform?: Platform): Device {
+  return {
+    id,
+    name: 'Device',
+    version: id,
+    platform:
+      platform ?? (/^[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}$/i.test(id) ? 'ios' : 'android'),
+    booted: false,
+    physical: false,
+    supported: false,
+    deviceFrame: null,
+  };
+}
+
+/** Retain only the opened missing device; a list refresh must never navigate. */
+export function reconcileDeviceSession(
+  previous: DeviceSession,
+  update: SessionUpdate
+): DeviceSession {
+  const { booted, recent, selectedId, platform } = update;
+  const running = [...booted.simulators, ...booted.emulators];
+  const online = running.find((device) => device.id === selectedId);
+  const known =
+    online ??
+    [...recent.simulators, ...recent.emulators].find((device) => device.id === selectedId);
+  const selectedDevice = selectedId
+    ? (known ??
+      (previous.selectedDevice?.id === selectedId
+        ? previous.selectedDevice
+        : unknownDevice(selectedId, platform)))
+    : undefined;
+  const selectedAvailable = !!online;
+  const withOfflineDevice = (devices: Device[], section: Platform) =>
+    selectedDevice?.platform === section && !selectedAvailable
+      ? [...devices, selectedDevice]
+      : devices;
+  const simulators = sameDevices(
+    previous.simulators,
+    platform === 'android' ? EMPTY_DEVICES : withOfflineDevice(booted.simulators, 'ios')
+  );
+  const emulators = sameDevices(
+    previous.emulators,
+    platform === 'ios' ? EMPTY_DEVICES : withOfflineDevice(booted.emulators, 'android')
+  );
+
+  if (
+    simulators === previous.simulators &&
+    emulators === previous.emulators &&
+    recent === previous.recent &&
+    selectedDevice === previous.selectedDevice &&
+    selectedAvailable === previous.selectedAvailable
+  )
+    return previous;
+  return { ...previous, simulators, emulators, recent, selectedDevice, selectedAvailable };
+}
+
+export function createDeviceSessionStore() {
+  return create<
+    DeviceSession & {
+      update: (update: SessionUpdate) => void;
+      rememberDevice: (device: Device) => void;
+      setConnectionStatus: (status: DeviceListConnectionStatus) => void;
+    }
+  >()((set) => ({
+    simulators: EMPTY_DEVICES,
+    emulators: EMPTY_DEVICES,
+    recent: { simulators: EMPTY_DEVICES, emulators: EMPTY_DEVICES },
+    selectedAvailable: false,
+    connectionStatus: 'connecting',
+    update: (update) => set((state) => reconcileDeviceSession(state, update)),
+    rememberDevice: (selectedDevice) =>
+      set((state) =>
+        state.selectedAvailable && state.selectedDevice?.id === selectedDevice.id
+          ? state
+          : { selectedDevice, selectedAvailable: false }
+      ),
+    setConnectionStatus: (connectionStatus) => set({ connectionStatus }),
+  }));
+}
+
+export const useDeviceSessionStore = createDeviceSessionStore();

--- a/packages/expo-device-hub/src/dashboard/useDevices.ts
+++ b/packages/expo-device-hub/src/dashboard/useDevices.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { type Device } from '@expo/hub-components';
 
@@ -21,6 +21,11 @@ export function devicesWebSocketUrl(locationHref = window.location.href): string
 export type DeviceList = {
   simulators: Device[];
   emulators: Device[];
+};
+
+export type DeviceLists = {
+  booted: DeviceList;
+  recent: DeviceList;
 };
 
 export type DeviceListSnapshot = DeviceList & { errors?: UtilityError[] };
@@ -170,11 +175,11 @@ export function subscribeToDeviceList({
  * host polling once regardless of how many dashboards are open and sends only
  * changed snapshots. Returns the empty list until the first snapshot arrives.
  */
-function useDeviceList(): {
+function useDeviceList(): DeviceLists & {
   devices: DeviceList;
   connectionStatus: DeviceListConnectionStatus;
 } {
-  const [devices, setDevices] = useState<DeviceList>(EMPTY);
+  const [lists, setLists] = useState(() => ({ devices: EMPTY, ...splitDeviceList(EMPTY) }));
   const [connectionStatus, setConnectionStatus] =
     useState<DeviceListConnectionStatus>('connecting');
 
@@ -184,14 +189,18 @@ function useDeviceList(): {
     return subscribeToDeviceList({
       onSnapshot: (snapshot) => {
         activeErrorIds = logUtilityErrors(snapshot.errors, activeErrorIds);
-        const { errors: _errors, ...nextDevices } = snapshot;
-        setDevices(nextDevices);
+        setLists((previous) => {
+          const devices = reconcileDeviceList(previous.devices, snapshot);
+          return devices === previous.devices
+            ? previous
+            : { ...splitDeviceList(devices, previous), devices };
+        });
       },
       onStatus: setConnectionStatus,
     });
   }, []);
 
-  return { devices, connectionStatus };
+  return { ...lists, connectionStatus };
 }
 
 export function parseDeviceListSocketMessage(data: unknown): DeviceListSocketMessage | null {
@@ -231,24 +240,53 @@ export function parseDeviceListMessage(data: unknown): DeviceListSnapshot | null
   return message?.type === DEVICE_LIST_MESSAGE_TYPE ? message.devices : null;
 }
 
-export function splitDeviceList(all: DeviceList): {
-  booted: DeviceList;
-  recent: DeviceList;
-} {
+function sameDevice(previous: Device, next: Device): boolean {
+  if (previous === next) return true;
+  const keys = Object.keys(previous) as (keyof Device)[];
+  return (
+    keys.length === Object.keys(next).length &&
+    keys.every((key) => Object.hasOwn(next, key) && Object.is(previous[key], next[key]))
+  );
+}
+
+function reconcileDevices(previous: Device[], next: Device[]): Device[] {
+  if (previous === next) return previous;
+  const previousById = new Map(previous.map((device) => [device.id, device]));
+  const devices = next.map((device) => {
+    const existing = previousById.get(device.id);
+    return existing && sameDevice(existing, device) ? existing : device;
+  });
+  return previous.length === devices.length &&
+    devices.every((device, index) => device === previous[index])
+    ? previous
+    : devices;
+}
+
+/** Reuse unchanged records and collections despite fresh objects arriving over JSON. */
+export function reconcileDeviceList(previous: DeviceList, next: DeviceList): DeviceList {
+  const simulators = reconcileDevices(previous.simulators, next.simulators);
+  const emulators = reconcileDevices(previous.emulators, next.emulators);
+  return simulators === previous.simulators && emulators === previous.emulators
+    ? previous
+    : { simulators, emulators };
+}
+
+export function splitDeviceList(all: DeviceList, previous?: DeviceLists): DeviceLists {
   const filter = (booted: boolean) => ({
     simulators: all.simulators.filter((device) => device.booted === booted),
     emulators: all.emulators.filter((device) => device.booted === booted),
   });
-  return { booted: filter(true), recent: filter(false) };
+  const booted = reconcileDeviceList(previous?.booted ?? EMPTY, filter(true));
+  const recent = reconcileDeviceList(previous?.recent ?? EMPTY, filter(false));
+  return previous && booted === previous.booted && recent === previous.recent
+    ? previous
+    : { booted, recent };
 }
 
 /** One connection supplying both the running sidebar and recent-device picker. */
-export function useDeviceLists(): {
-  booted: DeviceList;
-  recent: DeviceList;
+export function useDeviceLists(): DeviceLists & {
   connectionStatus: DeviceListConnectionStatus;
 } {
-  const { devices, connectionStatus } = useDeviceList();
-  const lists = useMemo(() => splitDeviceList(devices), [devices]);
-  return { ...lists, connectionStatus };
+  const { booted, recent, connectionStatus } = useDeviceList();
+  return { booted, recent, connectionStatus };
 }

--- a/packages/expo-device-hub/src/dashboard/useSidebarLayout.ts
+++ b/packages/expo-device-hub/src/dashboard/useSidebarLayout.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { type SidebarPreference, useDashboardStore } from './dashboardStore';
 
@@ -32,8 +32,7 @@ export function resolveSidebarLayout({
   const rightFits = containerWidth >= rightWidth + minStreamWidth;
   const rightOpen = rightPreference === 'open' || (rightPreference === 'auto' && rightFits);
   const rightDocked = rightOpen && rightFits;
-  const leftFits =
-    containerWidth >= leftWidth + minStreamWidth + (rightDocked ? rightWidth : 0);
+  const leftFits = containerWidth >= leftWidth + minStreamWidth + (rightDocked ? rightWidth : 0);
   const leftOpen = leftPreference === 'open' || (leftPreference === 'auto' && leftFits);
   const leftDocked = leftOpen && leftFits;
 
@@ -86,16 +85,15 @@ export function useSidebarLayout({
 
   const openLeft = () => {
     const leftFits =
-      containerWidth >=
-      leftWidth + minStreamWidth + (layout.rightDocked ? rightWidth : 0);
+      containerWidth >= leftWidth + minStreamWidth + (layout.rightDocked ? rightWidth : 0);
     openSidebar('left', leftFits);
   };
-  const closeLeft = () => closeSidebar('left');
+  const closeLeft = useCallback(() => closeSidebar('left'), [closeSidebar]);
   const openRight = () => {
     const rightFits = containerWidth >= rightWidth + minStreamWidth;
     openSidebar('right', rightFits);
   };
-  const closeRight = () => closeSidebar('right');
+  const closeRight = useCallback(() => closeSidebar('right'), [closeSidebar]);
 
   return {
     ...layout,

--- a/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
+++ b/packages/expo-device-hub/src/server/__tests__/client-shell.test.ts
@@ -1,6 +1,55 @@
 import { describe, expect, test } from 'bun:test';
 
-import { configureClientShell } from '../client-shell';
+import { configureClientShell, isClientShellRequest } from '../client-shell';
+
+describe('client shell routes', () => {
+  test('serves the dashboard for root and direct iOS or Android device links', () => {
+    for (const path of [
+      '/',
+      '/index.html',
+      '/device/A05B3DB4-425C-40EC-96F1-5F05AD5FB660',
+      '/device/emulator-5554',
+      '/device/192.168.1.10%3A5555/',
+    ]) {
+      expect(isClientShellRequest(new Request(`http://localhost${path}`))).toBe(true);
+    }
+  });
+
+  test('does not intercept API, asset, vendor, or non-GET requests', () => {
+    for (const path of [
+      '/api/devices',
+      '/assets/device.png',
+      '/vendor/serve-sim/device/id',
+      '/device/',
+      '/device/id/extra',
+    ]) {
+      expect(isClientShellRequest(new Request(`http://localhost${path}`))).toBe(false);
+    }
+    expect(
+      isClientShellRequest(new Request('http://localhost/device/ios-id', { method: 'POST' }))
+    ).toBe(false);
+  });
+
+  test('reloads mounted device links with assets resolved under the plugin mount', () => {
+    const mount = '/_expo/plugins/expo-device-hub';
+    const url = new URL(`http://localhost${mount}/device/ios-id`);
+    // The host passes the request to the plugin after stripping its mount.
+    url.pathname = url.pathname.slice(mount.length);
+    expect(isClientShellRequest(new Request(url))).toBe(true);
+    const html = configureClientShell(
+      '<base href="{{mount}}/"><script src="_expo/static/js/web/app.js"></script>',
+      mount,
+      undefined,
+      undefined,
+      false,
+      false
+    );
+    const base = html.match(/<base href="([^"]+)"/)![1];
+    expect(new URL('_expo/static/js/web/app.js', new URL(base, url)).pathname).toBe(
+      `${mount}/_expo/static/js/web/app.js`
+    );
+  });
+});
 
 describe('configureClientShell', () => {
   const shell =

--- a/packages/expo-device-hub/src/server/client-shell.ts
+++ b/packages/expo-device-hub/src/server/client-shell.ts
@@ -1,6 +1,13 @@
 import { type PlatformFilter } from '../platform-filter';
 import { type Transport } from '../transport';
 
+/** Hosts strip the mount prefix before passing requests to the plugin handler. */
+export function isClientShellRequest(request: Request): boolean {
+  if (request.method !== 'GET') return false;
+  const { pathname } = new URL(request.url);
+  return pathname === '/' || pathname === '/index.html' || /^\/device\/[^/]+\/?$/.test(pathname);
+}
+
 /** Fill the runtime values consumed by the exported dashboard shell. */
 export function configureClientShell(
   html: string,

--- a/packages/expo-device-hub/src/server/index.ts
+++ b/packages/expo-device-hub/src/server/index.ts
@@ -21,7 +21,7 @@ import {
   removeHubDevice,
   shutdownHubDevice,
 } from './device-actions';
-import { configureClientShell } from './client-shell';
+import { configureClientShell, isClientShellRequest } from './client-shell';
 import { argentInteractionWebSocketHandler } from './argent-interaction-websocket';
 import { deviceListWebSocketHandler, refreshDeviceList } from './device-list-websocket';
 import { type HubDeviceList, listDevices } from './devices';
@@ -99,7 +99,7 @@ export default async function handler(request: Request): Promise<Response | null
   });
   if (easResponse) return easResponse;
 
-  if (request.method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
+  if (isClientShellRequest(request)) {
     return serveClientIndexHtml();
   }
 


### PR DESCRIPTION
Device selection now follows `/device/{udid}` for iOS and `/device/{serial}` for Android, including direct links and browser history. If the selected device disappears from discovery, its row, frame, and options remain visible with an offline message until the user selects another device.

Discovery snapshots reuse unchanged device objects, and list/viewer subscriptions are separated so unrelated device updates do not rerender the viewer or unchanged rows.

Validation: full Device Hub build; regression tests for URL navigation, snapshot reconciliation, render isolation, and offline frame behavior. The combined branch with the dependent boot/create work passes 296 dashboard, server, and component tests, plus component typecheck and lint.

Follow-up: [#109 — Show device creation and boot progress outside the dialog](https://github.com/expo/expo-device-hub/pull/109). Merge this PR first, then rebase #109 onto main. Both target main because the branches live in a fork and cannot use GitHub stacks here.
